### PR TITLE
Turn everything in the scene into prefabs and add top-down camera

### DIFF
--- a/Assets/Prefabs.meta
+++ b/Assets/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 271072ebd3a5242329e1b6cd4e96568c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Car.prefab
+++ b/Assets/Prefabs/Car.prefab
@@ -1,0 +1,1523 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4759284448920211460
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284448920211463}
+  - component: {fileID: 4759284448920211464}
+  - component: {fileID: 4759284448920211465}
+  m_Layer: 0
+  m_Name: Body
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284448920211463
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284448920211460}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.15, y: 0.05, z: 0.3}
+  m_Children: []
+  m_Father: {fileID: 4759284448989664000}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4759284448920211464
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284448920211460}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4759284448920211465
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284448920211460}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a5aaee4111611af43b5abbff184fe5fa, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!1 &4759284448989664001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284448989664000}
+  - component: {fileID: 4759284448989664002}
+  - component: {fileID: 4759284448989664003}
+  - component: {fileID: 4759284448989664005}
+  m_Layer: 0
+  m_Name: Car
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284448989664000
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284448989664001}
+  m_LocalRotation: {x: -0, y: -0.82514745, z: -0, w: 0.56491745}
+  m_LocalPosition: {x: -2.13, y: 0.1, z: 0.8}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4759284450254289778}
+  - {fileID: 4759284449683412856}
+  - {fileID: 4759284449446690360}
+  - {fileID: 4759284448920211463}
+  - {fileID: 4759284450028473381}
+  - {fileID: 4759284450155138660}
+  - {fileID: 4759284449987079911}
+  - {fileID: 4759284449864841868}
+  - {fileID: 4759284449604946549}
+  - {fileID: 4759284450432389580}
+  - {fileID: 4759284450491433599}
+  - {fileID: 4759284449473770675}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: -111.20701, z: 0}
+--- !u!65 &4759284448989664002
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284448989664001}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.25, y: 0.05, z: 0.35}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &4759284448989664003
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284448989664001}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 80
+  m_CollisionDetection: 0
+--- !u!114 &4759284448989664005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284448989664001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a7ffb5ff4c77846fca7b161ea144b46a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  frontLeftWC: {fileID: 4759284449604946548}
+  frontRightWC: {fileID: 4759284450432389583}
+  rearLeftWC: {fileID: 4759284450491433598}
+  rearRightWC: {fileID: 4759284449473770674}
+  frontLeftT: {fileID: 4759284450028473381}
+  frontRightT: {fileID: 4759284450155138660}
+  rearLeftT: {fileID: 4759284449987079911}
+  rearRightT: {fileID: 4759284449864841868}
+  maxSteerAngle: 30
+  motorForce: 150
+  maxAngleChangePerSecond: 10
+  angle: 0
+  forward: 0
+--- !u!1 &4759284449332738223
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284449332738222}
+  - component: {fileID: 4759284449332738224}
+  - component: {fileID: 4759284449332738225}
+  m_Layer: 0
+  m_Name: Tire
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284449332738222
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449332738223}
+  m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.07000003, y: 0.020000014, z: 0.07000003}
+  m_Children: []
+  m_Father: {fileID: 4759284449864841868}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!33 &4759284449332738224
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449332738223}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4759284449332738225
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449332738223}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: c05de7c865075334786e6a47a543af72, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!1 &4759284449446690356
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284449446690360}
+  - component: {fileID: 4759284449446690361}
+  - component: {fileID: 4759284449446690363}
+  - component: {fileID: 4759284449446690359}
+  m_Layer: 0
+  m_Name: Stream Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284449446690360
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449446690356}
+  m_LocalRotation: {x: 0.08280819, y: 0, z: 0, w: 0.9965655}
+  m_LocalPosition: {x: 0, y: 0.1, z: 0.08}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4759284448989664000}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 9.5, y: 0, z: 0}
+--- !u!20 &4759284449446690361
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449446690356}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 0.2
+    height: 0.2
+  near clip plane: 0.01
+  far clip plane: 20
+  field of view: 48.8
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 1
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &4759284449446690363
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449446690356}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 948f4100a11a5c24981795d21301da5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  volumeTrigger: {fileID: 4759284449446690360}
+  volumeLayer:
+    serializedVersion: 2
+    m_Bits: 256
+  stopNaNPropagation: 1
+  finalBlitToCameraTarget: 1
+  antialiasingMode: 1
+  temporalAntialiasing:
+    jitterSpread: 0.75
+    sharpness: 0.25
+    stationaryBlending: 0.95
+    motionBlending: 0.85
+  subpixelMorphologicalAntialiasing:
+    quality: 2
+  fastApproximateAntialiasing:
+    fastMode: 1
+    keepAlpha: 0
+  fog:
+    enabled: 1
+    excludeSkybox: 1
+  debugLayer:
+    lightMeter:
+      width: 512
+      height: 256
+      showCurves: 1
+    histogram:
+      width: 512
+      height: 256
+      channel: 3
+    waveform:
+      exposure: 0.12
+      height: 256
+    vectorscope:
+      size: 256
+      exposure: 0.12
+    overlaySettings:
+      linearDepth: 0
+      motionColorIntensity: 4
+      motionGridSize: 64
+      colorBlindnessType: 0
+      colorBlindnessStrength: 1
+  m_Resources: {fileID: 11400000, guid: d82512f9c8e5d4a4d938b575d47f88d4, type: 2}
+  m_ShowToolkit: 1
+  m_ShowCustomSorter: 1
+  breakBeforeColorGrading: 0
+  m_BeforeTransparentBundles: []
+  m_BeforeStackBundles: []
+  m_AfterStackBundles: []
+--- !u!114 &4759284449446690359
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449446690356}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8660950fa3cc14a69be99edddcf2d3dc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &4759284449460352180
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284449460352183}
+  - component: {fileID: 4759284449460352185}
+  - component: {fileID: 4759284449460352182}
+  m_Layer: 0
+  m_Name: Tire
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284449460352183
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449460352180}
+  m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.07000003, y: 0.020000014, z: 0.07000003}
+  m_Children: []
+  m_Father: {fileID: 4759284449987079911}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!33 &4759284449460352185
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449460352180}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4759284449460352182
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449460352180}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: c05de7c865075334786e6a47a543af72, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!1 &4759284449473770672
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284449473770675}
+  - component: {fileID: 4759284449473770674}
+  m_Layer: 0
+  m_Name: Wheel RR Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284449473770675
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449473770672}
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0.1, y: -0.024999999, z: -0.14}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4759284448989664000}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!146 &4759284449473770674
+WheelCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449473770672}
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Radius: 0.035
+  m_SuspensionSpring:
+    spring: 35
+    damper: 5
+    targetPosition: 0.9
+  m_SuspensionDistance: 0.01
+  m_ForceAppPointDistance: 0
+  m_Mass: 0.1
+  m_WheelDampingRate: 0.25
+  m_ForwardFriction:
+    m_ExtremumSlip: 0.4
+    m_ExtremumValue: 1
+    m_AsymptoteSlip: 0.8
+    m_AsymptoteValue: 0.5
+    m_Stiffness: 2
+  m_SidewaysFriction:
+    m_ExtremumSlip: 0.2
+    m_ExtremumValue: 1
+    m_AsymptoteSlip: 0.5
+    m_AsymptoteValue: 0.75
+    m_Stiffness: 2
+  m_Enabled: 1
+--- !u!1 &4759284449542084710
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284449542084713}
+  - component: {fileID: 4759284449542084715}
+  - component: {fileID: 4759284449542084712}
+  m_Layer: 5
+  m_Name: Speed
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4759284449542084713
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449542084710}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4759284449780940317}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.99}
+  m_AnchorMax: {x: 0.33, y: 0.99}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 100}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &4759284449542084715
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449542084710}
+  m_CullTransparentMesh: 0
+--- !u!114 &4759284449542084712
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449542084710}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 63fd4656f763f4c1c8d8d300a7726304, type: 2}
+  m_Color: {r: 0, g: 0.7411765, b: 0, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 0
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: S 0
+--- !u!1 &4759284449604946546
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284449604946549}
+  - component: {fileID: 4759284449604946548}
+  m_Layer: 0
+  m_Name: Wheel FL Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284449604946549
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449604946546}
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0.1, y: -0.024999999, z: 0.14}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4759284448989664000}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!146 &4759284449604946548
+WheelCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449604946546}
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Radius: 0.035
+  m_SuspensionSpring:
+    spring: 35
+    damper: 5
+    targetPosition: 0.9
+  m_SuspensionDistance: 0.01
+  m_ForceAppPointDistance: 0
+  m_Mass: 0.1
+  m_WheelDampingRate: 0.25
+  m_ForwardFriction:
+    m_ExtremumSlip: 0.4
+    m_ExtremumValue: 1
+    m_AsymptoteSlip: 0.8
+    m_AsymptoteValue: 0.5
+    m_Stiffness: 2
+  m_SidewaysFriction:
+    m_ExtremumSlip: 0.2
+    m_ExtremumValue: 1
+    m_AsymptoteSlip: 0.5
+    m_AsymptoteValue: 0.75
+    m_Stiffness: 2
+  m_Enabled: 1
+--- !u!1 &4759284449683412857
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284449683412856}
+  - component: {fileID: 4759284449683412858}
+  - component: {fileID: 4759284449683412859}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284449683412856
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449683412857}
+  m_LocalRotation: {x: 0.17364816, y: -0, z: -0.000000007450581, w: 0.98480785}
+  m_LocalPosition: {x: 0, y: 0.20000002, z: -0.4}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4759284448989664000}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 20, y: 0, z: 0}
+--- !u!20 &4759284449683412858
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449683412857}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.1
+  far clip plane: 20
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 1
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &4759284449683412859
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449683412857}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 948f4100a11a5c24981795d21301da5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  volumeTrigger: {fileID: 4759284449683412856}
+  volumeLayer:
+    serializedVersion: 2
+    m_Bits: 256
+  stopNaNPropagation: 1
+  finalBlitToCameraTarget: 1
+  antialiasingMode: 1
+  temporalAntialiasing:
+    jitterSpread: 0.75
+    sharpness: 0.25
+    stationaryBlending: 0.95
+    motionBlending: 0.85
+  subpixelMorphologicalAntialiasing:
+    quality: 2
+  fastApproximateAntialiasing:
+    fastMode: 1
+    keepAlpha: 0
+  fog:
+    enabled: 1
+    excludeSkybox: 1
+  debugLayer:
+    lightMeter:
+      width: 512
+      height: 256
+      showCurves: 1
+    histogram:
+      width: 512
+      height: 256
+      channel: 3
+    waveform:
+      exposure: 0.12
+      height: 256
+    vectorscope:
+      size: 256
+      exposure: 0.12
+    overlaySettings:
+      linearDepth: 0
+      motionColorIntensity: 4
+      motionGridSize: 64
+      colorBlindnessType: 0
+      colorBlindnessStrength: 1
+  m_Resources: {fileID: 11400000, guid: d82512f9c8e5d4a4d938b575d47f88d4, type: 2}
+  m_ShowToolkit: 1
+  m_ShowCustomSorter: 1
+  breakBeforeColorGrading: 0
+  m_BeforeTransparentBundles: []
+  m_BeforeStackBundles: []
+  m_AfterStackBundles: []
+--- !u!1 &4759284449780940314
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284449780940317}
+  - component: {fileID: 4759284449780940318}
+  - component: {fileID: 4759284449780940319}
+  - component: {fileID: 4759284449780940316}
+  - component: {fileID: 4759284449780940257}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4759284449780940317
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449780940314}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 4759284449542084713}
+  - {fileID: 4759284450661744513}
+  - {fileID: 4759284450743708739}
+  m_Father: {fileID: 4759284450254289778}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &4759284449780940318
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449780940314}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 1
+  m_Camera: {fileID: 4759284449446690361}
+  m_PlaneDistance: 0.02
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &4759284449780940319
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449780940314}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1280, y: 800}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!114 &4759284449780940316
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449780940314}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &4759284449780940257
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449780940314}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7053602e5a1f442558dd713eaf44f7a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  car: {fileID: 4759284448989664001}
+  speedText: {fileID: 4759284449542084712}
+  throttleText: {fileID: 4759284450661744512}
+  turnText: {fileID: 4759284450743708738}
+--- !u!1 &4759284449782029949
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284449782029948}
+  - component: {fileID: 4759284449782029950}
+  - component: {fileID: 4759284449782029951}
+  m_Layer: 0
+  m_Name: Tire
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284449782029948
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449782029949}
+  m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.07000003, y: 0.020000007, z: 0.07}
+  m_Children: []
+  m_Father: {fileID: 4759284450155138660}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!33 &4759284449782029950
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449782029949}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4759284449782029951
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449782029949}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: c05de7c865075334786e6a47a543af72, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!1 &4759284449864841869
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284449864841868}
+  m_Layer: 0
+  m_Name: Wheel RR
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284449864841868
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449864841869}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.1, y: -0.024999999, z: -0.14}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4759284449332738222}
+  m_Father: {fileID: 4759284448989664000}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4759284449987079908
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284449987079911}
+  m_Layer: 0
+  m_Name: Wheel RL
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284449987079911
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284449987079908}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.1, y: -0.024999999, z: -0.14}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4759284449460352183}
+  m_Father: {fileID: 4759284448989664000}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4759284450028473378
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284450028473381}
+  m_Layer: 0
+  m_Name: Wheel FL
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284450028473381
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284450028473378}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.1, y: -0.024999999, z: 0.14}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4759284450676356099}
+  m_Father: {fileID: 4759284448989664000}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4759284450155138661
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284450155138660}
+  m_Layer: 0
+  m_Name: Wheel FR
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284450155138660
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284450155138661}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.1, y: -0.024999999, z: 0.14}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4759284449782029948}
+  m_Father: {fileID: 4759284448989664000}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4759284450254289779
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284450254289778}
+  m_Layer: 0
+  m_Name: HUD
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284450254289778
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284450254289779}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4759284449780940317}
+  m_Father: {fileID: 4759284448989664000}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4759284450432389581
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284450432389580}
+  - component: {fileID: 4759284450432389583}
+  m_Layer: 0
+  m_Name: Wheel FR Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284450432389580
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284450432389581}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.1, y: -0.024999999, z: 0.14}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4759284448989664000}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!146 &4759284450432389583
+WheelCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284450432389581}
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Radius: 0.035
+  m_SuspensionSpring:
+    spring: 35
+    damper: 5
+    targetPosition: 0.9
+  m_SuspensionDistance: 0.01
+  m_ForceAppPointDistance: 0
+  m_Mass: 0.1
+  m_WheelDampingRate: 0.25
+  m_ForwardFriction:
+    m_ExtremumSlip: 0.4
+    m_ExtremumValue: 1
+    m_AsymptoteSlip: 0.8
+    m_AsymptoteValue: 0.5
+    m_Stiffness: 2
+  m_SidewaysFriction:
+    m_ExtremumSlip: 0.2
+    m_ExtremumValue: 1
+    m_AsymptoteSlip: 0.5
+    m_AsymptoteValue: 0.75
+    m_Stiffness: 2
+  m_Enabled: 1
+--- !u!1 &4759284450491433596
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284450491433599}
+  - component: {fileID: 4759284450491433598}
+  m_Layer: 0
+  m_Name: Wheel RL Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284450491433599
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284450491433596}
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0.1, y: -0.024999999, z: -0.14}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4759284448989664000}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!146 &4759284450491433598
+WheelCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284450491433596}
+  m_Center: {x: 0, y: 0, z: 0}
+  m_Radius: 0.035
+  m_SuspensionSpring:
+    spring: 35
+    damper: 5
+    targetPosition: 0.9
+  m_SuspensionDistance: 0.01
+  m_ForceAppPointDistance: 0
+  m_Mass: 0.1
+  m_WheelDampingRate: 0.25
+  m_ForwardFriction:
+    m_ExtremumSlip: 0.4
+    m_ExtremumValue: 1
+    m_AsymptoteSlip: 0.8
+    m_AsymptoteValue: 0.5
+    m_Stiffness: 2
+  m_SidewaysFriction:
+    m_ExtremumSlip: 0.2
+    m_ExtremumValue: 1
+    m_AsymptoteSlip: 0.5
+    m_AsymptoteValue: 0.75
+    m_Stiffness: 2
+  m_Enabled: 1
+--- !u!1 &4759284450661744574
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284450661744513}
+  - component: {fileID: 4759284450661744515}
+  - component: {fileID: 4759284450661744512}
+  m_Layer: 5
+  m_Name: Throttle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4759284450661744513
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284450661744574}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4759284449780940317}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.33, y: 0.99}
+  m_AnchorMax: {x: 0.67, y: 0.99}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 100}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &4759284450661744515
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284450661744574}
+  m_CullTransparentMesh: 0
+--- !u!114 &4759284450661744512
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284450661744574}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 63fd4656f763f4c1c8d8d300a7726304, type: 2}
+  m_Color: {r: 0, g: 0.7411765, b: 0, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: F 0
+--- !u!1 &4759284450676356096
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284450676356099}
+  - component: {fileID: 4759284450676356101}
+  - component: {fileID: 4759284450676356098}
+  m_Layer: 0
+  m_Name: Tire
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4759284450676356099
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284450676356096}
+  m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.07000003, y: 0.020000014, z: 0.07000003}
+  m_Children: []
+  m_Father: {fileID: 4759284450028473381}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!33 &4759284450676356101
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284450676356096}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4759284450676356098
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284450676356096}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: c05de7c865075334786e6a47a543af72, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!1 &4759284450743708736
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759284450743708739}
+  - component: {fileID: 4759284450743708741}
+  - component: {fileID: 4759284450743708738}
+  m_Layer: 5
+  m_Name: Turn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4759284450743708739
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284450743708736}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4759284449780940317}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.67, y: 0.99}
+  m_AnchorMax: {x: 1, y: 0.99}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 100}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &4759284450743708741
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284450743708736}
+  m_CullTransparentMesh: 0
+--- !u!114 &4759284450743708738
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4759284450743708736}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 63fd4656f763f4c1c8d8d300a7726304, type: 2}
+  m_Color: {r: 0, g: 0.7411765, b: 0, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: T 0

--- a/Assets/Prefabs/Car.prefab.meta
+++ b/Assets/Prefabs/Car.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bc5ee6cf73cd948b383ef9224f240b33
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Directional Light.prefab
+++ b/Assets/Prefabs/Directional Light.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8662640338840425040
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8662640338840425038}
+  - component: {fileID: 8662640338840425039}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8662640338840425038
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8662640338840425040}
+  m_LocalRotation: {x: 0.7388608, y: 0.5997209, z: -0.2709314, w: 0.14496852}
+  m_LocalPosition: {x: 0.24, y: 3, z: 4.18}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 32.629, y: 195.59999, z: 106.461006}
+--- !u!108 &8662640338840425039
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8662640338840425040}
+  m_Enabled: 1
+  serializedVersion: 9
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.802082
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.02
+    m_NormalBias: 0.1
+    m_NearPlane: 0.1
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 1
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 51

--- a/Assets/Prefabs/Directional Light.prefab.meta
+++ b/Assets/Prefabs/Directional Light.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c53bf4124de6242c988d867025a62152
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/EventSystem.prefab
+++ b/Assets/Prefabs/EventSystem.prefab
@@ -1,0 +1,68 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8269822857894421960
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8269822857894421967}
+  - component: {fileID: 8269822857894421966}
+  - component: {fileID: 8269822857894421961}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8269822857894421967
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8269822857894421960}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8269822857894421966
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8269822857894421960}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -619905303, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!114 &8269822857894421961
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8269822857894421960}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0

--- a/Assets/Prefabs/EventSystem.prefab.meta
+++ b/Assets/Prefabs/EventSystem.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e6d0e87570f414d69bcf566b79758956
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Post-process Volume.prefab
+++ b/Assets/Prefabs/Post-process Volume.prefab
@@ -1,0 +1,50 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1702683005025460132
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1702683005025460129}
+  - component: {fileID: 1702683005025460131}
+  m_Layer: 8
+  m_Name: Post-process Volume
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1702683005025460129
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1702683005025460132}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1702683005025460131
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1702683005025460132}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b9a305e18de0c04dbd257a21cd47087, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sharedProfile: {fileID: 11400000, guid: 680922c45b9bfe14085ea8a49e7d23dd, type: 2}
+  isGlobal: 1
+  blendDistance: 0
+  weight: 1
+  priority: 0

--- a/Assets/Prefabs/Post-process Volume.prefab.meta
+++ b/Assets/Prefabs/Post-process Volume.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 60c63d1905f7546e0bfda04fa769570c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/StationaryCamera.prefab
+++ b/Assets/Prefabs/StationaryCamera.prefab
@@ -1,0 +1,137 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7708220628765859792
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6400925206651555409}
+  - component: {fileID: 1698476123442335882}
+  - component: {fileID: 7708220628765859793}
+  m_Layer: 0
+  m_Name: StationaryCamera 1
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6400925206651555409
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7708220628765859792}
+  m_LocalRotation: {x: 0.6956676, y: -0.12667513, z: 0.12667513, w: 0.6956676}
+  m_LocalPosition: {x: -3.13, y: 9.91, z: 5.28}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 90, y: -20.64, z: 0}
+--- !u!20 &1698476123442335882
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7708220628765859792}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &7708220628765859793
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7708220628765859792}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 948f4100a11a5c24981795d21301da5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  volumeTrigger: {fileID: 0}
+  volumeLayer:
+    serializedVersion: 2
+    m_Bits: 256
+  stopNaNPropagation: 1
+  finalBlitToCameraTarget: 1
+  antialiasingMode: 1
+  temporalAntialiasing:
+    jitterSpread: 0.75
+    sharpness: 0.25
+    stationaryBlending: 0.95
+    motionBlending: 0.85
+  subpixelMorphologicalAntialiasing:
+    quality: 2
+  fastApproximateAntialiasing:
+    fastMode: 1
+    keepAlpha: 0
+  fog:
+    enabled: 1
+    excludeSkybox: 1
+  debugLayer:
+    lightMeter:
+      width: 512
+      height: 256
+      showCurves: 1
+    histogram:
+      width: 512
+      height: 256
+      channel: 3
+    waveform:
+      exposure: 0.12
+      height: 256
+    vectorscope:
+      size: 256
+      exposure: 0.12
+    overlaySettings:
+      linearDepth: 0
+      motionColorIntensity: 4
+      motionGridSize: 64
+      colorBlindnessType: 0
+      colorBlindnessStrength: 1
+  m_Resources: {fileID: 11400000, guid: d82512f9c8e5d4a4d938b575d47f88d4, type: 2}
+  m_ShowToolkit: 1
+  m_ShowCustomSorter: 1
+  breakBeforeColorGrading: 0
+  m_BeforeTransparentBundles: []
+  m_BeforeStackBundles: []
+  m_AfterStackBundles: []

--- a/Assets/Prefabs/StationaryCamera.prefab.meta
+++ b/Assets/Prefabs/StationaryCamera.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a15547f4c5a2f4366b4a48fa06b04603
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Track.prefab
+++ b/Assets/Prefabs/Track.prefab
@@ -1,0 +1,4239 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &178675627461309899
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7019592286938325961}
+  - component: {fileID: 1147668725647646011}
+  - component: {fileID: 3286874207272625532}
+  - component: {fileID: 3196960585452181059}
+  - component: {fileID: 2234488884942058068}
+  m_Layer: 0
+  m_Name: segment 7
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7019592286938325961
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 178675627461309899}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256959887751}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1147668725647646011
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 178675627461309899}
+  m_Mesh: {fileID: 0}
+--- !u!23 &3286874207272625532
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 178675627461309899}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &3196960585452181059
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 178675627461309899}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &2234488884942058068
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 178675627461309899}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &477136618625203206
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4133148766352011973}
+  - component: {fileID: 7613343717269818041}
+  - component: {fileID: 7695362143268498398}
+  - component: {fileID: 6826987405597792691}
+  - component: {fileID: 7861871626331956209}
+  m_Layer: 0
+  m_Name: segment 5
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4133148766352011973
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 477136618625203206}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256959887751}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &7613343717269818041
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 477136618625203206}
+  m_Mesh: {fileID: 0}
+--- !u!23 &7695362143268498398
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 477136618625203206}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &6826987405597792691
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 477136618625203206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &7861871626331956209
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 477136618625203206}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &797203132397594880
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1509823590285534704}
+  - component: {fileID: 6774420398290340508}
+  - component: {fileID: 4358678987496785896}
+  - component: {fileID: 7056613745375593243}
+  - component: {fileID: 1113406785571508307}
+  m_Layer: 0
+  m_Name: segment 3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1509823590285534704
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 797203132397594880}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256959887751}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6774420398290340508
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 797203132397594880}
+  m_Mesh: {fileID: 0}
+--- !u!23 &4358678987496785896
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 797203132397594880}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &7056613745375593243
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 797203132397594880}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &1113406785571508307
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 797203132397594880}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &993393635301327862
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6725681377810944207}
+  - component: {fileID: 8078728387451789292}
+  - component: {fileID: 3749622647807724616}
+  - component: {fileID: 1663443791382659745}
+  - component: {fileID: 6875260830253278821}
+  m_Layer: 0
+  m_Name: segment 10
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6725681377810944207
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 993393635301327862}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256959887751}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8078728387451789292
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 993393635301327862}
+  m_Mesh: {fileID: 0}
+--- !u!23 &3749622647807724616
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 993393635301327862}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &1663443791382659745
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 993393635301327862}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &6875260830253278821
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 993393635301327862}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &997045078541279138
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6619872243134020639}
+  - component: {fileID: 8839251501743093904}
+  - component: {fileID: 4492546538652004566}
+  - component: {fileID: 2155934506952145047}
+  - component: {fileID: 1592775525040503603}
+  m_Layer: 0
+  m_Name: segment 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6619872243134020639
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 997045078541279138}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256279791105}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8839251501743093904
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 997045078541279138}
+  m_Mesh: {fileID: 0}
+--- !u!23 &4492546538652004566
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 997045078541279138}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &2155934506952145047
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 997045078541279138}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &1592775525040503603
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 997045078541279138}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &1150048253323278852
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1772887983614442769}
+  - component: {fileID: 8712080940064437814}
+  - component: {fileID: 1885521237847018738}
+  - component: {fileID: 3047664175296701778}
+  - component: {fileID: 6694546459689352699}
+  m_Layer: 0
+  m_Name: segment 7
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1772887983614442769
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1150048253323278852}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256920081489}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8712080940064437814
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1150048253323278852}
+  m_Mesh: {fileID: 0}
+--- !u!23 &1885521237847018738
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1150048253323278852}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &3047664175296701778
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1150048253323278852}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &6694546459689352699
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1150048253323278852}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &1336621862750360028
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3220476218189577438}
+  - component: {fileID: 3974249534275778220}
+  - component: {fileID: 4369101681729703698}
+  - component: {fileID: 3626029232269778704}
+  - component: {fileID: 2541754902153153784}
+  m_Layer: 0
+  m_Name: segment 8
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3220476218189577438
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336621862750360028}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256959887751}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &3974249534275778220
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336621862750360028}
+  m_Mesh: {fileID: 0}
+--- !u!23 &4369101681729703698
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336621862750360028}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &3626029232269778704
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336621862750360028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &2541754902153153784
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336621862750360028}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &1731503404893030828
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5984108748665289801}
+  - component: {fileID: 138150599418625156}
+  - component: {fileID: 8558381390616404514}
+  - component: {fileID: 523970278340241089}
+  - component: {fileID: 8365841128604327101}
+  m_Layer: 0
+  m_Name: segment 4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5984108748665289801
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1731503404893030828}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256959887751}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &138150599418625156
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1731503404893030828}
+  m_Mesh: {fileID: 0}
+--- !u!23 &8558381390616404514
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1731503404893030828}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &523970278340241089
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1731503404893030828}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &8365841128604327101
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1731503404893030828}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &1761206955314597758
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6589649610351784969}
+  - component: {fileID: 3147445758788518281}
+  - component: {fileID: 2327330554013405618}
+  - component: {fileID: 2792716389297409946}
+  - component: {fileID: 3765886412487075526}
+  m_Layer: 0
+  m_Name: segment 10
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6589649610351784969
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1761206955314597758}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256920081489}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &3147445758788518281
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1761206955314597758}
+  m_Mesh: {fileID: 0}
+--- !u!23 &2327330554013405618
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1761206955314597758}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &2792716389297409946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1761206955314597758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &3765886412487075526
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1761206955314597758}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &1983112072655545877
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3136377323343723734}
+  - component: {fileID: 6891851964805091255}
+  - component: {fileID: 8135038278066990192}
+  - component: {fileID: 1659846264765473923}
+  - component: {fileID: 7644139431957401998}
+  m_Layer: 0
+  m_Name: segment 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3136377323343723734
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1983112072655545877}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256920081489}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6891851964805091255
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1983112072655545877}
+  m_Mesh: {fileID: 0}
+--- !u!23 &8135038278066990192
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1983112072655545877}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &1659846264765473923
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1983112072655545877}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &7644139431957401998
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1983112072655545877}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &2048310367538400206
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1545753705491572219}
+  - component: {fileID: 6553811902379151256}
+  - component: {fileID: 1658793033616356895}
+  - component: {fileID: 8117267695013443573}
+  - component: {fileID: 1911763694175934258}
+  m_Layer: 0
+  m_Name: segment 4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1545753705491572219
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2048310367538400206}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256279791105}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6553811902379151256
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2048310367538400206}
+  m_Mesh: {fileID: 0}
+--- !u!23 &1658793033616356895
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2048310367538400206}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &8117267695013443573
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2048310367538400206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &1911763694175934258
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2048310367538400206}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &2068487412524034886
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8201189608819923189}
+  - component: {fileID: 6929161371589231190}
+  - component: {fileID: 5917386545905990832}
+  - component: {fileID: 1295186701208936682}
+  - component: {fileID: 8023511557899472743}
+  m_Layer: 0
+  m_Name: segment 7
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8201189608819923189
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2068487412524034886}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256279791105}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6929161371589231190
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2068487412524034886}
+  m_Mesh: {fileID: 0}
+--- !u!23 &5917386545905990832
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2068487412524034886}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &1295186701208936682
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2068487412524034886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &8023511557899472743
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2068487412524034886}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &2513733708191381778
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8980633717989184076}
+  - component: {fileID: 5506511592745782056}
+  - component: {fileID: 2092291032382507012}
+  - component: {fileID: 6044670837553765062}
+  - component: {fileID: 2282447443778240258}
+  m_Layer: 0
+  m_Name: segment 3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8980633717989184076
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2513733708191381778}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256920081489}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5506511592745782056
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2513733708191381778}
+  m_Mesh: {fileID: 0}
+--- !u!23 &2092291032382507012
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2513733708191381778}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &6044670837553765062
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2513733708191381778}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &2282447443778240258
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2513733708191381778}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &3185280772703218024
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7116377166307048080}
+  - component: {fileID: 1317884817459096138}
+  - component: {fileID: 4516591720208314178}
+  - component: {fileID: 1512757362486233569}
+  - component: {fileID: 3024566098995238421}
+  m_Layer: 0
+  m_Name: segment 9
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7116377166307048080
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3185280772703218024}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256279791105}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1317884817459096138
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3185280772703218024}
+  m_Mesh: {fileID: 0}
+--- !u!23 &4516591720208314178
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3185280772703218024}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &1512757362486233569
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3185280772703218024}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &3024566098995238421
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3185280772703218024}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &3209094194664412924
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1459416854985247561}
+  - component: {fileID: 6885944863847263525}
+  - component: {fileID: 4847600644021661560}
+  - component: {fileID: 4512971758114388627}
+  - component: {fileID: 5326509325709955112}
+  m_Layer: 0
+  m_Name: segment 6
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1459416854985247561
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3209094194664412924}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256920081489}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6885944863847263525
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3209094194664412924}
+  m_Mesh: {fileID: 0}
+--- !u!23 &4847600644021661560
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3209094194664412924}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &4512971758114388627
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3209094194664412924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &5326509325709955112
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3209094194664412924}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &3396699954532725394
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1420708503164152408}
+  - component: {fileID: 1147760582386782182}
+  - component: {fileID: 86920452700425444}
+  - component: {fileID: 1203195990221882031}
+  - component: {fileID: 9198476181273896357}
+  m_Layer: 0
+  m_Name: segment 5
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1420708503164152408
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3396699954532725394}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256279791105}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1147760582386782182
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3396699954532725394}
+  m_Mesh: {fileID: 0}
+--- !u!23 &86920452700425444
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3396699954532725394}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &1203195990221882031
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3396699954532725394}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &9198476181273896357
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3396699954532725394}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &3673946383006804917
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1707317458170836636}
+  - component: {fileID: 7269681337161398658}
+  - component: {fileID: 8647220492381137971}
+  - component: {fileID: 8250967358155387491}
+  - component: {fileID: 3785824200617683739}
+  m_Layer: 0
+  m_Name: segment 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1707317458170836636
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3673946383006804917}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256920081489}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &7269681337161398658
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3673946383006804917}
+  m_Mesh: {fileID: 0}
+--- !u!23 &8647220492381137971
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3673946383006804917}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &8250967358155387491
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3673946383006804917}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &3785824200617683739
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3673946383006804917}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &3756080373809816411
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8402231609281468127}
+  - component: {fileID: 101338460777817926}
+  - component: {fileID: 3300509888139337225}
+  - component: {fileID: 7289790791400686830}
+  - component: {fileID: 6050064279556275401}
+  m_Layer: 0
+  m_Name: segment 4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8402231609281468127
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3756080373809816411}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256920081489}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &101338460777817926
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3756080373809816411}
+  m_Mesh: {fileID: 0}
+--- !u!23 &3300509888139337225
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3756080373809816411}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &7289790791400686830
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3756080373809816411}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &6050064279556275401
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3756080373809816411}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &3891773255871233217
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3891773255871233222}
+  - component: {fileID: 3891773255871233223}
+  m_Layer: 0
+  m_Name: Left Wall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3891773255871233222
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3891773255871233217}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3891773256920081489}
+  m_Father: {fileID: 3891773256012222674}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3891773255871233223
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3891773255871233217}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d1eb05ecfaa05444b40d40a2ea2268f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shapeVertices:
+  - point: {x: 0.8, y: -0.01}
+    normal: {x: -1, y: 0}
+    uCoord: 0
+  - point: {x: 0.8, y: 0.2}
+    normal: {x: -1, y: 0}
+    uCoord: 0.5
+  - point: {x: 0.81, y: 0.2}
+    normal: {x: 1, y: 0}
+    uCoord: 0.5
+  - point: {x: 0.81, y: -0.01}
+    normal: {x: 1, y: 0}
+    uCoord: 1
+  loopAround: 0
+  material: {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  textureScale: 0.5
+--- !u!1 &3891773256012222687
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3891773256012222674}
+  - component: {fileID: 3891773256012222685}
+  m_Layer: 0
+  m_Name: Track
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3891773256012222674
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3891773256012222687}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3891773257346835857}
+  - {fileID: 3891773256260718634}
+  - {fileID: 3891773255871233222}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3891773256012222685
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3891773256012222687}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a85c5879d519aa4ab2ebbf42591149a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nodes:
+  - position: {x: 4.3995404, y: 0, z: 7.4836774}
+    direction: {x: 5.033156, y: 0, z: 4.722517}
+    up: {x: 0, y: 1, z: 0}
+    scale: {x: 1, y: 1}
+    roll: 0
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - position: {x: 2.2316287, y: 0, z: 2.5614948}
+    direction: {x: 1.0769825, y: 0, z: 1.9719954}
+    up: {x: 0, y: 1, z: 0}
+    scale: {x: 1, y: 1}
+    roll: 0
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - position: {x: -7.150958, y: 0, z: -1.181535}
+    direction: {x: -8.946831, y: 0, z: -1.7925923}
+    up: {x: 0, y: 1, z: 0}
+    scale: {x: 1, y: 1}
+    roll: 0
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - position: {x: -9.656566, y: 0, z: 2.9990437}
+    direction: {x: -9.621862, y: 0, z: 6.0029373}
+    up: {x: 0, y: 1, z: 0}
+    scale: {x: 1, y: 1}
+    roll: 0
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - position: {x: -6.212388, y: 0, z: 8.969346}
+    direction: {x: -4.736134, y: 0, z: 9.367167}
+    up: {x: 0, y: 1, z: 0}
+    scale: {x: 1, y: 1}
+    roll: 0
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - position: {x: -4.375961, y: 0, z: 6.939442}
+    direction: {x: -5.023926, y: 0, z: 5.919211}
+    up: {x: 0, y: 1, z: 0}
+    scale: {x: 1, y: 1}
+    roll: 0
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - position: {x: -6.632031, y: 0, z: 3.4877656}
+    direction: {x: -7.294585, y: 0, z: 2.5051184}
+    up: {x: 0, y: 1, z: 0}
+    scale: {x: 1, y: 1}
+    roll: 0
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - position: {x: -5.125697, y: 0, z: 2.1865432}
+    direction: {x: -3.9142761, y: 0, z: 3.0855324}
+    up: {x: 0, y: 1, z: 0}
+    scale: {x: 1, y: 1}
+    roll: 0
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - position: {x: 0.31468582, y: 0, z: 6.4900513}
+    direction: {x: 1.0833551, y: 0, z: 7.247735}
+    up: {x: 0, y: 1, z: 0}
+    scale: {x: 1, y: 1}
+    roll: 0
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - position: {x: -0.54347414, y: 0, z: 8.170048}
+    direction: {x: -1.5783143, y: 0, z: 7.9782248}
+    up: {x: 0, y: 1, z: 0}
+    scale: {x: 1, y: 1}
+    roll: 0
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - position: {x: -0.95563453, y: 0, z: 10.027262}
+    direction: {x: 0.29973042, y: 0, z: 10.587138}
+    up: {x: 0, y: 1, z: 0}
+    scale: {x: 1, y: 1}
+    roll: 0
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - position: {x: 4.3995404, y: 0, z: 7.4836774}
+    direction: {x: 5.033156, y: 0, z: 4.722517}
+    up: {x: 0, y: 1, z: 0}
+    scale: {x: 1, y: 1}
+    roll: 0
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  curves:
+  - n1:
+      position: {x: 4.3995404, y: 0, z: 7.4836774}
+      direction: {x: 5.033156, y: 0, z: 4.722517}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    n2:
+      position: {x: 2.2316287, y: 0, z: 2.5614948}
+      direction: {x: 1.0769825, y: 0, z: 1.9719954}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - n1:
+      position: {x: 2.2316287, y: 0, z: 2.5614948}
+      direction: {x: 1.0769825, y: 0, z: 1.9719954}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    n2:
+      position: {x: -7.150958, y: 0, z: -1.181535}
+      direction: {x: -8.946831, y: 0, z: -1.7925923}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - n1:
+      position: {x: -7.150958, y: 0, z: -1.181535}
+      direction: {x: -8.946831, y: 0, z: -1.7925923}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    n2:
+      position: {x: -9.656566, y: 0, z: 2.9990437}
+      direction: {x: -9.621862, y: 0, z: 6.0029373}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - n1:
+      position: {x: -9.656566, y: 0, z: 2.9990437}
+      direction: {x: -9.621862, y: 0, z: 6.0029373}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    n2:
+      position: {x: -6.212388, y: 0, z: 8.969346}
+      direction: {x: -4.736134, y: 0, z: 9.367167}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - n1:
+      position: {x: -6.212388, y: 0, z: 8.969346}
+      direction: {x: -4.736134, y: 0, z: 9.367167}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    n2:
+      position: {x: -4.375961, y: 0, z: 6.939442}
+      direction: {x: -5.023926, y: 0, z: 5.919211}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - n1:
+      position: {x: -4.375961, y: 0, z: 6.939442}
+      direction: {x: -5.023926, y: 0, z: 5.919211}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    n2:
+      position: {x: -6.632031, y: 0, z: 3.4877656}
+      direction: {x: -7.294585, y: 0, z: 2.5051184}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - n1:
+      position: {x: -6.632031, y: 0, z: 3.4877656}
+      direction: {x: -7.294585, y: 0, z: 2.5051184}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    n2:
+      position: {x: -5.125697, y: 0, z: 2.1865432}
+      direction: {x: -3.9142761, y: 0, z: 3.0855324}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - n1:
+      position: {x: -5.125697, y: 0, z: 2.1865432}
+      direction: {x: -3.9142761, y: 0, z: 3.0855324}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    n2:
+      position: {x: 0.31468582, y: 0, z: 6.4900513}
+      direction: {x: 1.0833551, y: 0, z: 7.247735}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - n1:
+      position: {x: 0.31468582, y: 0, z: 6.4900513}
+      direction: {x: 1.0833551, y: 0, z: 7.247735}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    n2:
+      position: {x: -0.54347414, y: 0, z: 8.170048}
+      direction: {x: -1.5783143, y: 0, z: 7.9782248}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - n1:
+      position: {x: -0.54347414, y: 0, z: 8.170048}
+      direction: {x: -1.5783143, y: 0, z: 7.9782248}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    n2:
+      position: {x: -0.95563453, y: 0, z: 10.027262}
+      direction: {x: 0.29973042, y: 0, z: 10.587138}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  - n1:
+      position: {x: -0.95563453, y: 0, z: 10.027262}
+      direction: {x: 0.29973042, y: 0, z: 10.587138}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    n2:
+      position: {x: 4.3995404, y: 0, z: 7.4836774}
+      direction: {x: 5.033156, y: 0, z: 4.722517}
+      up: {x: 0, y: 1, z: 0}
+      scale: {x: 1, y: 1}
+      roll: 0
+      Changed:
+        m_PersistentCalls:
+          m_Calls: []
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+    Changed:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+        Culture=neutral, PublicKeyToken=null
+  Length: 58.82646
+  isLoop: 1
+  CurveChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!1 &3891773256260718645
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3891773256260718634}
+  - component: {fileID: 3891773256260718635}
+  m_Layer: 0
+  m_Name: Right Wall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3891773256260718634
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3891773256260718645}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3891773256279791105}
+  m_Father: {fileID: 3891773256012222674}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3891773256260718635
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3891773256260718645}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d1eb05ecfaa05444b40d40a2ea2268f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shapeVertices:
+  - point: {x: -0.81, y: -0.01}
+    normal: {x: -1, y: 0}
+    uCoord: 0
+  - point: {x: -0.81, y: 0.2}
+    normal: {x: -1, y: 0}
+    uCoord: 0.5
+  - point: {x: -0.8, y: 0.2}
+    normal: {x: 1, y: 0}
+    uCoord: 0.5
+  - point: {x: -0.8, y: -0.01}
+    normal: {x: 1, y: 0}
+    uCoord: 1
+  loopAround: 0
+  material: {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  textureScale: 0.5
+--- !u!1 &3891773256279791104
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3891773256279791105}
+  m_Layer: 0
+  m_Name: generated by SplineExtrusion
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3891773256279791105
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3891773256279791104}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7313764255893136211}
+  - {fileID: 6619872243134020639}
+  - {fileID: 5000611467837875742}
+  - {fileID: 5418188380849203384}
+  - {fileID: 1545753705491572219}
+  - {fileID: 1420708503164152408}
+  - {fileID: 4087871996321486483}
+  - {fileID: 8201189608819923189}
+  - {fileID: 2840157498463357519}
+  - {fileID: 7116377166307048080}
+  - {fileID: 3712152143063724719}
+  m_Father: {fileID: 3891773256260718634}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3891773256920081488
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3891773256920081489}
+  m_Layer: 0
+  m_Name: generated by SplineExtrusion
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3891773256920081489
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3891773256920081488}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1707317458170836636}
+  - {fileID: 3136377323343723734}
+  - {fileID: 7538302168506989981}
+  - {fileID: 8980633717989184076}
+  - {fileID: 8402231609281468127}
+  - {fileID: 5220444298975973085}
+  - {fileID: 1459416854985247561}
+  - {fileID: 1772887983614442769}
+  - {fileID: 6723235223340997287}
+  - {fileID: 69236297346537313}
+  - {fileID: 6589649610351784969}
+  m_Father: {fileID: 3891773255871233222}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3891773256959887750
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3891773256959887751}
+  m_Layer: 0
+  m_Name: generated by SplineExtrusion
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3891773256959887751
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3891773256959887750}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7643180074714632932}
+  - {fileID: 4541055234465305357}
+  - {fileID: 5925426655546695411}
+  - {fileID: 1509823590285534704}
+  - {fileID: 5984108748665289801}
+  - {fileID: 4133148766352011973}
+  - {fileID: 1806557319074198583}
+  - {fileID: 7019592286938325961}
+  - {fileID: 3220476218189577438}
+  - {fileID: 2680736551890382434}
+  - {fileID: 6725681377810944207}
+  m_Father: {fileID: 3891773257346835857}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3891773257346835856
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3891773257346835857}
+  - component: {fileID: 3891773257346835862}
+  m_Layer: 0
+  m_Name: Floor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3891773257346835857
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3891773257346835856}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3891773256959887751}
+  m_Father: {fileID: 3891773256012222674}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3891773257346835862
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3891773257346835856}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d1eb05ecfaa05444b40d40a2ea2268f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shapeVertices:
+  - point: {x: -0.81, y: 0}
+    normal: {x: 0, y: 1}
+    uCoord: 0
+  - point: {x: 0, y: 0}
+    normal: {x: 0, y: 1}
+    uCoord: 0.5
+  - point: {x: 0.81, y: 0}
+    normal: {x: 0, y: 1}
+    uCoord: 1
+  loopAround: 0
+  material: {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
+  textureScale: 0.5
+--- !u!1 &3905062992001536217
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 69236297346537313}
+  - component: {fileID: 1620374192948491248}
+  - component: {fileID: 7128421843050377862}
+  - component: {fileID: 569095080823853002}
+  - component: {fileID: 8999466145481894111}
+  m_Layer: 0
+  m_Name: segment 9
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &69236297346537313
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3905062992001536217}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256920081489}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1620374192948491248
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3905062992001536217}
+  m_Mesh: {fileID: 0}
+--- !u!23 &7128421843050377862
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3905062992001536217}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &569095080823853002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3905062992001536217}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &8999466145481894111
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3905062992001536217}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &4146008920867387110
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1806557319074198583}
+  - component: {fileID: 1159999155559391349}
+  - component: {fileID: 1060270844008969818}
+  - component: {fileID: 6319415604237274313}
+  - component: {fileID: 2172131141616597307}
+  m_Layer: 0
+  m_Name: segment 6
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1806557319074198583
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4146008920867387110}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256959887751}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1159999155559391349
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4146008920867387110}
+  m_Mesh: {fileID: 0}
+--- !u!23 &1060270844008969818
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4146008920867387110}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &6319415604237274313
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4146008920867387110}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &2172131141616597307
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4146008920867387110}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &4151954407010847328
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2840157498463357519}
+  - component: {fileID: 4495932151924466462}
+  - component: {fileID: 3749709373034434674}
+  - component: {fileID: 5675942758101261000}
+  - component: {fileID: 5712102614165309066}
+  m_Layer: 0
+  m_Name: segment 8
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2840157498463357519
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4151954407010847328}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256279791105}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &4495932151924466462
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4151954407010847328}
+  m_Mesh: {fileID: 0}
+--- !u!23 &3749709373034434674
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4151954407010847328}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &5675942758101261000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4151954407010847328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &5712102614165309066
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4151954407010847328}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &4622641514137932301
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5925426655546695411}
+  - component: {fileID: 6193557901001714321}
+  - component: {fileID: 1258734105033516388}
+  - component: {fileID: 1659714907298061432}
+  - component: {fileID: 823564075855506725}
+  m_Layer: 0
+  m_Name: segment 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5925426655546695411
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4622641514137932301}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256959887751}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6193557901001714321
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4622641514137932301}
+  m_Mesh: {fileID: 0}
+--- !u!23 &1258734105033516388
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4622641514137932301}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &1659714907298061432
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4622641514137932301}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &823564075855506725
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4622641514137932301}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &4641586256584672519
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4541055234465305357}
+  - component: {fileID: 725300005981539451}
+  - component: {fileID: 3134991517733971882}
+  - component: {fileID: 6971007579624184717}
+  - component: {fileID: 610383685248088616}
+  m_Layer: 0
+  m_Name: segment 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4541055234465305357
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4641586256584672519}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256959887751}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &725300005981539451
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4641586256584672519}
+  m_Mesh: {fileID: 0}
+--- !u!23 &3134991517733971882
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4641586256584672519}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &6971007579624184717
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4641586256584672519}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &610383685248088616
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4641586256584672519}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &4895641187209412361
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2680736551890382434}
+  - component: {fileID: 1341076736484038722}
+  - component: {fileID: 342135329373342543}
+  - component: {fileID: 411224924661569503}
+  - component: {fileID: 2155047867887703775}
+  m_Layer: 0
+  m_Name: segment 9
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2680736551890382434
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4895641187209412361}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256959887751}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1341076736484038722
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4895641187209412361}
+  m_Mesh: {fileID: 0}
+--- !u!23 &342135329373342543
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4895641187209412361}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &411224924661569503
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4895641187209412361}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &2155047867887703775
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4895641187209412361}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &5698132034267582328
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7538302168506989981}
+  - component: {fileID: 2490257402231668751}
+  - component: {fileID: 5818595616021398781}
+  - component: {fileID: 3139705360810318369}
+  - component: {fileID: 2630971147054972944}
+  m_Layer: 0
+  m_Name: segment 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7538302168506989981
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5698132034267582328}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256920081489}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2490257402231668751
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5698132034267582328}
+  m_Mesh: {fileID: 0}
+--- !u!23 &5818595616021398781
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5698132034267582328}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &3139705360810318369
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5698132034267582328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &2630971147054972944
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5698132034267582328}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &6865810709708322872
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6723235223340997287}
+  - component: {fileID: 7018011985409435099}
+  - component: {fileID: 822139246330632161}
+  - component: {fileID: 2537231642892393148}
+  - component: {fileID: 5639671121212161015}
+  m_Layer: 0
+  m_Name: segment 8
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6723235223340997287
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6865810709708322872}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256920081489}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &7018011985409435099
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6865810709708322872}
+  m_Mesh: {fileID: 0}
+--- !u!23 &822139246330632161
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6865810709708322872}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &2537231642892393148
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6865810709708322872}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &5639671121212161015
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6865810709708322872}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &6891255804115930555
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7313764255893136211}
+  - component: {fileID: 8203529996925538436}
+  - component: {fileID: 8307946411353344831}
+  - component: {fileID: 5946234593244407871}
+  - component: {fileID: 330889365549815489}
+  m_Layer: 0
+  m_Name: segment 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7313764255893136211
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6891255804115930555}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256279791105}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &8203529996925538436
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6891255804115930555}
+  m_Mesh: {fileID: 0}
+--- !u!23 &8307946411353344831
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6891255804115930555}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &5946234593244407871
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6891255804115930555}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &330889365549815489
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6891255804115930555}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &7579717634721815514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5418188380849203384}
+  - component: {fileID: 5440205151572703805}
+  - component: {fileID: 5611733965581495523}
+  - component: {fileID: 602179748391972910}
+  - component: {fileID: 2553001960905029883}
+  m_Layer: 0
+  m_Name: segment 3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5418188380849203384
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7579717634721815514}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256279791105}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5440205151572703805
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7579717634721815514}
+  m_Mesh: {fileID: 0}
+--- !u!23 &5611733965581495523
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7579717634721815514}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &602179748391972910
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7579717634721815514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &2553001960905029883
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7579717634721815514}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &7705685274110264106
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5220444298975973085}
+  - component: {fileID: 2308146560734473321}
+  - component: {fileID: 4594357208866346313}
+  - component: {fileID: 8982993819507365840}
+  - component: {fileID: 4888247883264171811}
+  m_Layer: 0
+  m_Name: segment 5
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5220444298975973085
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7705685274110264106}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256920081489}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2308146560734473321
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7705685274110264106}
+  m_Mesh: {fileID: 0}
+--- !u!23 &4594357208866346313
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7705685274110264106}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &8982993819507365840
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7705685274110264106}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &4888247883264171811
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7705685274110264106}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &8029132184423337622
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4087871996321486483}
+  - component: {fileID: 1351314602894731400}
+  - component: {fileID: 2684758523752108370}
+  - component: {fileID: 4002903203182008272}
+  - component: {fileID: 8355555683000472178}
+  m_Layer: 0
+  m_Name: segment 6
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4087871996321486483
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8029132184423337622}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256279791105}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1351314602894731400
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8029132184423337622}
+  m_Mesh: {fileID: 0}
+--- !u!23 &2684758523752108370
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8029132184423337622}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &4002903203182008272
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8029132184423337622}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &8355555683000472178
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8029132184423337622}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &8322435574792873739
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7643180074714632932}
+  - component: {fileID: 5843558909617171145}
+  - component: {fileID: 6744850450183298650}
+  - component: {fileID: 4047452112331820846}
+  - component: {fileID: 8200926219049428831}
+  m_Layer: 0
+  m_Name: segment 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7643180074714632932
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8322435574792873739}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256959887751}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5843558909617171145
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8322435574792873739}
+  m_Mesh: {fileID: 0}
+--- !u!23 &6744850450183298650
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8322435574792873739}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &4047452112331820846
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8322435574792873739}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &8200926219049428831
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8322435574792873739}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &8542314011215744019
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5000611467837875742}
+  - component: {fileID: 3281957005113958647}
+  - component: {fileID: 1840876882304255676}
+  - component: {fileID: 1681469319863510773}
+  - component: {fileID: 9080884017815331388}
+  m_Layer: 0
+  m_Name: segment 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5000611467837875742
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8542314011215744019}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256279791105}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &3281957005113958647
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8542314011215744019}
+  m_Mesh: {fileID: 0}
+--- !u!23 &1840876882304255676
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8542314011215744019}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &1681469319863510773
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8542314011215744019}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &9080884017815331388
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8542314011215744019}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}
+--- !u!1 &9039579351712616840
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3712152143063724719}
+  - component: {fileID: 3053068777966074930}
+  - component: {fileID: 2567981013596144177}
+  - component: {fileID: 1636521177568577759}
+  - component: {fileID: 1806660049038662567}
+  m_Layer: 0
+  m_Name: segment 10
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3712152143063724719
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9039579351712616840}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3891773256279791105}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &3053068777966074930
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9039579351712616840}
+  m_Mesh: {fileID: 0}
+--- !u!23 &2567981013596144177
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9039579351712616840}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &1636521177568577759
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9039579351712616840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &1806660049038662567
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9039579351712616840}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 0}

--- a/Assets/Prefabs/Track.prefab.meta
+++ b/Assets/Prefabs/Track.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f36c1aa58d49149e8be80c3a982875a5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Track.unity
+++ b/Assets/Scenes/Track.unity
@@ -120,2386 +120,7 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!43 &7416093
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 360
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 93
-    localAABB:
-      m_Center: {x: -8.23407, y: 0, z: 6.3705664}
-      m_Extent: {x: 2.2324421, y: 0, z: 3.3808796}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000030003000400010002000100040004000500020004000300060006000700040005000400070007000800050007000600090009000a000700080007000a000a000b0008000a0009000c000c000d000a000b000a000d000d000e000b000d000c000f000f0010000d000e000d001000100011000e0010000f00120012001300100011001000130013001400110013001200150015001600130014001300160016001700140016001500180018001900160017001600190019001a001700190018001b001b001c0019001a0019001c001c001d001a001c001b001e001e001f001c001d001c001f001f0020001d001f001e002100210022001f0020001f002200220023002000220021002400240025002200230022002500250026002300250024002700270028002500260025002800280029002600280027002a002a002b002800290028002b002b002c0029002b002a002d002d002e002b002c002b002e002e002f002c002e002d003000300031002e002f002e003100310032002f0031003000330033003400310032003100340034003500320034003300360036003700340035003400370037003800350037003600390039003a003700380037003a003a003b0038003a0039003c003c003d003a003b003a003d003d003e003b003d003c003f003f0040003d003e003d004000400041003e0040003f00420042004300400041004000430043004400410043004200450045004600430044004300460046004700440046004500480048004900460047004600490049004a004700490048004b004b004c0049004a0049004c004c004d004a004c004b004e004e004f004c004d004c004f004f0050004d004f004e005100510052004f0050004f005200520053005000520051005400540055005200530052005500550056005300550054005700570058005500560055005800580059005600580057005a005a005b005800590058005b005b005c005900
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 93
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 2976
-    _typelessdata: d57627c100000000a4894040000000000000803f0000000000000000eaf82d414b811ac10000000055f03f40000000000000803f000000000000003feaf82d41c18b0dc10000000006573f40000000000000803f000000000000803feaf82d418f4a27c1000000004cd45540000000000000803f0000000000000000555d304183591ac10000000014115340000000000000803f000000000000003f555d304177680dc100000000dc4d5040000000000000803f000000000000803f555d30411de726c10000000042db6a40000000000000803f000000000000000058bc32410a001ac100000000f9fb6540000000000000803f000000000000003f58bc3241f7180dc100000000b01c6140000000000000803f000000000000803f58bc3241064f26c10000000096977f40000000000000803f000000000000000018163541017719c100000000acaa7840000000000000803f000000000000003f18163541fc9e0cc100000000c2bd7140000000000000803f000000000000803f18163541d58425c10000000058018a40000000000000803f0000000000000000a36a374192c018c100000000718b8540000000000000803f000000000000003fa36a37414ffc0bc1000000008a158140000000000000803f000000000000803fa36a3741038b24c1000000001e0b9440000000000000803f0000000000000000edb93941dcde17c100000000209d8e40000000000000803f000000000000003fedb93941b5320bc100000000222f8940000000000000803f000000000000803fedb93941076423c10000000016e69d40000000000000803f0000000000000000d9033c4108d416c10000000040879740000000000000803f000000000000003fd9033c4109440ac1000000006a289140000000000000803f000000000000803fd9033c414a1222c100000000518fa740000000000000803f000000000000000033483e4139a215c100000000a246a040000000000000803f000000000000003f33483e41283209c100000000f3fd9840000000000000803f000000000000803f33483e412b9820c100000000ff03b140000000000000803f0000000000000000b7864041964b14c10000000024d8a840000000000000803f000000000000003fb786404101ff07c10000000049aca040000000000000803f000000000000803fb7864041f7f71ec1000000005641ba40000000000000803f00000000000000000ebf424140d212c1000000009638b140000000000000803f000000000000003f0ebf424189ac06c100000000d62fa840000000000000803f000000000000803f0ebf4241f3331dc100000000ae44c340000000000000803f0000000000000000d5f044415f3811c100000000d564b940000000000000803f000000000000003fd5f04441cb3c05c100000000fc84af40000000000000803f000000000000803fd5f04441514e1bc100000000600bcc40000000000000803f0000000000000000991b474118800fc100000000b759c140000000000000803f000000000000003f991b4741dfb103c1000000000ea8b640000000000000803f000000000000803f991b4741344919c100000000d592d440000000000000803f0000000000000000dd3e49418fab0dc1000000001114c940000000000000803f000000000000003fdd3e4941ea0d02c1000000004d95bd40000000000000803f000000000000803fdd3e4941ae2617c1000000007ed8dc40000000000000803f0000000000000000185a4b41e9bc0bc100000000bc90d040000000000000803f000000000000003f185a4b41245300c100000000fa48c440000000000000803f000000000000803f185a4b41bae814c100000000d6d9e440000000000000803f0000000000000000ba6c4d4149b609c1000000008eccd740000000000000803f000000000000003fba6c4d41b007fdc00000000046bfca40000000000000803f000000000000803fba6c4d41489112c1000000005e94ec40000000000000803f00000000000000002a764f41d79907c10000000060c4de40000000000000803f000000000000003f2a764f41cc44f9c00000000062f4d040000000000000803f000000000000803f2a764f41282210c1000000009c05f440000000000000803f0000000000000000ca755141b66905c1000000000a75e540000000000000803f000000000000003fca7551418862f5c00000000078e4d640000000000000803f000000000000803fca755141149d0dc100000000122bfb40000000000000803f0000000000000000f96a53410b2803c1000000005fdbeb40000000000000803f000000000000003ff96a53410466f1c000000000ac8bdc40000000000000803f000000000000803ff96a5341a8030bc10000000028010141000000000000803f000000000000000012555541fbd600c1000000003af4f140000000000000803f000000000000003f125555419c54edc00000000025e6e140000000000000803f000000000000803f125555415c5708c1000000006b440441000000000000803f00000000000000007233574156f1fcc00000000070bcf740000000000000803f000000000000003f72335741f433e9c00000000009f0e640000000000000803f000000000000803f723357417f9905c100000000145e0741000000000000803f000000000000000077055941801ef8c000000000d930fd40000000000000803f000000000000003f77055941030ae5c00000000089a5eb40000000000000803f000000000000803f770559412ecb02c100000000db4c0a41000000000000803f000000000000000084ca5a41bf39f3c00000000026270141000000000000803f000000000000003f84ca5a4123dde0c000000000e202f040000000000000803f000000000000803f84ca5a4192daffc0000000006c0f0d41000000000000803f000000000000000004825c415a47eec000000000d2880341000000000000803f000000000000003f04825c4122b4dcc0000000006f04f440000000000000803f000000000000803f04825c41d800fac00000000058a40f41000000000000803f00000000000000006b2b5e419b4be9c000000000d8bb0541000000000000803f000000000000003f6b2b5e415e96d8c000000000b0a6f740000000000000803f000000000000803f6b2b5e41b909f4c000000000130a1241000000000000803f000000000000000041c65f41ce4ae4c000000000a7be0741000000000000803f000000000000003f41c65f41e38bd4c00000000075e6fa40000000000000803f000000000000803f41c65f41faf4edc000000000d43e1441000000000000803f00000000000000001e5261413c49dfc000000000a98f0941000000000000803f000000000000003f1e5261417e9dd0c000000000fdc0fd40000000000000803f000000000000803f1e52614179c1e7c0000000007b401641000000000000803f0000000000000000bace62412c4bdac0000000004b2d0b41000000000000803f000000000000003fbace6241dfd4ccc0000000001b1a0041000000000000803f000000000000803fbace62412a6de1c000000000640c1841000000000000803f0000000000000000ec3b6441ec54d5c000000000f7950c41000000000000803f000000000000003fec3b6441ae3cc9c0000000008a1f0141000000000000803f000000000000803fec3b644106f5dac0000000002c9f1941000000000000803f0000000000000000bb996541c36ad0c0000000001ac80d41000000000000803f000000000000003fbb99654180e0c5c00000000008f10141000000000000803f000000000000803fbb9965415e55d4c00000000055f41a41000000000000803f000000000000000067e86641fa90cbc0000000001fc20e41000000000000803f000000000000003f67e8664196ccc2c000000000e98f0241000000000000803f000000000000803f67e866416f8acdc000000000ec051c41000000000000803f000000000000000076286841e2cbc6c00000000071820f41000000000000803f000000000000003f76286841550dc0c000000000f6fe0241000000000000803f000000000000803f76286841
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -8.23407, y: 0, z: 6.3705664}
-    m_Extent: {x: 2.2324421, y: 0, z: 3.3808796}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!1 &24874894
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 24874895}
-  - component: {fileID: 24874899}
-  - component: {fileID: 24874898}
-  - component: {fileID: 24874897}
-  - component: {fileID: 24874896}
-  m_Layer: 0
-  m_Name: segment 5
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &24874895
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 24874894}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 539737851}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &24874896
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 24874894}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 813903962}
---- !u!114 &24874897
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 24874894}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &24874898
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 24874894}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &24874899
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 24874894}
-  m_Mesh: {fileID: 813903962}
---- !u!1 &35796931
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 35796932}
-  m_Layer: 0
-  m_Name: Wheel FL
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &35796932
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 35796931}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.1, y: -0.024999999, z: 0.14}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 759451618}
-  m_Father: {fileID: 1104095457}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &73127173
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 73127174}
-  m_Layer: 0
-  m_Name: Wheel RL
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &73127174
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 73127173}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.1, y: -0.024999999, z: -0.14}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1707151190}
-  m_Father: {fileID: 1104095457}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &94385858
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 94385859}
-  - component: {fileID: 94385863}
-  - component: {fileID: 94385862}
-  - component: {fileID: 94385861}
-  - component: {fileID: 94385860}
-  m_Layer: 0
-  m_Name: segment 10
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &94385859
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 94385858}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1272024235}
-  m_RootOrder: 10
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &94385860
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 94385858}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1000880539}
---- !u!114 &94385861
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 94385858}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &94385862
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 94385858}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &94385863
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 94385858}
-  m_Mesh: {fileID: 1000880539}
---- !u!1 &103254122
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 103254123}
-  - component: {fileID: 103254127}
-  - component: {fileID: 103254126}
-  - component: {fileID: 103254125}
-  - component: {fileID: 103254124}
-  m_Layer: 0
-  m_Name: segment 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &103254123
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 103254122}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1236410749}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &103254124
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 103254122}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 445428743}
---- !u!114 &103254125
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 103254122}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &103254126
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 103254122}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &103254127
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 103254122}
-  m_Mesh: {fileID: 445428743}
---- !u!1 &130995380
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 130995381}
-  - component: {fileID: 130995385}
-  - component: {fileID: 130995384}
-  - component: {fileID: 130995383}
-  - component: {fileID: 130995382}
-  m_Layer: 0
-  m_Name: segment 10
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &130995381
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 130995380}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 539737851}
-  m_RootOrder: 10
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &130995382
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 130995380}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1111941945}
---- !u!114 &130995383
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 130995380}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &130995384
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 130995380}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &130995385
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 130995380}
-  m_Mesh: {fileID: 1111941945}
---- !u!1 &139875387
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 139875388}
-  - component: {fileID: 139875389}
-  m_Layer: 0
-  m_Name: Left Wall
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &139875388
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 139875387}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1272024235}
-  m_Father: {fileID: 809433128}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &139875389
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 139875387}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8d1eb05ecfaa05444b40d40a2ea2268f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  shapeVertices:
-  - point: {x: 0.8, y: -0.01}
-    normal: {x: -1, y: 0}
-    uCoord: 0
-  - point: {x: 0.8, y: 0.2}
-    normal: {x: -1, y: 0}
-    uCoord: 0.5
-  - point: {x: 0.81, y: 0.2}
-    normal: {x: 1, y: 0}
-    uCoord: 0.5
-  - point: {x: 0.81, y: -0.01}
-    normal: {x: 1, y: 0}
-    uCoord: 1
-  loopAround: 0
-  material: {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  textureScale: 0.5
---- !u!1 &146459549
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 146459550}
-  - component: {fileID: 146459554}
-  - component: {fileID: 146459553}
-  - component: {fileID: 146459552}
-  - component: {fileID: 146459551}
-  m_Layer: 0
-  m_Name: segment 6
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &146459550
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 146459549}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1272024235}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &146459551
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 146459549}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1637640996}
---- !u!114 &146459552
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 146459549}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &146459553
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 146459549}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &146459554
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 146459549}
-  m_Mesh: {fileID: 1637640996}
---- !u!1 &150282009
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 150282010}
-  - component: {fileID: 150282014}
-  - component: {fileID: 150282013}
-  - component: {fileID: 150282012}
-  - component: {fileID: 150282011}
-  m_Layer: 0
-  m_Name: segment 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &150282010
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 150282009}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1236410749}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &150282011
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 150282009}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 425473802}
---- !u!114 &150282012
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 150282009}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &150282013
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 150282009}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &150282014
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 150282009}
-  m_Mesh: {fileID: 425473802}
---- !u!1 &157871381
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 157871382}
-  - component: {fileID: 157871386}
-  - component: {fileID: 157871385}
-  - component: {fileID: 157871384}
-  - component: {fileID: 157871383}
-  m_Layer: 0
-  m_Name: segment 8
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &157871382
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 157871381}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 539737851}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &157871383
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 157871381}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 790231893}
---- !u!114 &157871384
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 157871381}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &157871385
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 157871381}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &157871386
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 157871381}
-  m_Mesh: {fileID: 790231893}
---- !u!1 &173503876
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 173503877}
-  m_Layer: 0
-  m_Name: Wheel FR
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &173503877
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 173503876}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.1, y: -0.024999999, z: 0.14}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 278046109}
-  m_Father: {fileID: 1104095457}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!43 &208904281
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 360
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 93
-    localAABB:
-      m_Center: {x: -4.8949666, y: 0, z: 8.176058}
-      m_Extent: {x: 1.5281821, y: 0, z: 1.670877}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000030003000400010002000100040004000500020004000300060006000700040005000400070007000800050007000600090009000a000700080007000a000a000b0008000a0009000c000c000d000a000b000a000d000d000e000b000d000c000f000f0010000d000e000d001000100011000e0010000f00120012001300100011001000130013001400110013001200150015001600130014001300160016001700140016001500180018001900160017001600190019001a001700190018001b001b001c0019001a0019001c001c001d001a001c001b001e001e001f001c001d001c001f001f0020001d001f001e002100210022001f0020001f002200220023002000220021002400240025002200230022002500250026002300250024002700270028002500260025002800280029002600280027002a002a002b002800290028002b002b002c0029002b002a002d002d002e002b002c002b002e002e002f002c002e002d003000300031002e002f002e003100310032002f0031003000330033003400310032003100340034003500320034003300360036003700340035003400370037003800350037003600390039003a003700380037003a003a003b0038003a0039003c003c003d003a003b003a003d003d003e003b003d003c003f003f0040003d003e003d004000400041003e0040003f00420042004300400041004000430043004400410043004200450045004600430044004300460046004700440046004500480048004900460047004600490049004a004700490048004b004b004c0049004a0049004c004c004d004a004c004b004e004e004f004c004d004c004f004f0050004d004f004e005100510052004f0050004f005200520053005000520051005400540055005200530052005500550056005300550054005700570058005500560055005800580059005600580057005a005a005b005800590058005b005b005c005900
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 93
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 2976
-    _typelessdata: 6f8acdc000000000ec051c41000000000000803f000000000000000076286841e2cbc6c00000000071820f41000000000000803f000000000000003f76286841550dc0c000000000f6fe0241000000000000803f000000000000803f762868419d0ec7c00000000030c61c41000000000000803f0000000000000000715b6941ac1fc2c000000000130d1041000000000000803f000000000000003f715b6941bb30bdc000000000f6530341000000000000803f000000000000803f715b6941c99bc0c00000000020471d41000000000000803f00000000000000001b836a41348fbdc00000000067681041000000000000803f000000000000003f1b836a419f82bac000000000ae890341000000000000803f000000000000803f1b836a416f38bac00000000027891d41000000000000803f0000000000000000afa06b419e1cb9c0000000006e961041000000000000803f000000000000003fafa06b41cd00b8c000000000b5a30341000000000000803f000000000000803fafa06b41acebb3c0000000000b8d1d41000000000000803f000000000000000051b56c4117cab4c00000000026991041000000000000803f000000000000003f51b56c4182a8b5c00000000041a50341000000000000803f000000000000803f51b56c41e3bcadc00000000001541d41000000000000803f000000000000000018c26d41c499b0c0000000008b721041000000000000803f000000000000003f18c26d41a576b3c00000000015910341000000000000803f000000000000803f18c26d419ab3a7c000000000badf1c41000000000000803f0000000000000000fdc76e41d58dacc000000000a0241041000000000000803f000000000000003ffdc76e411068b1c00000000086690341000000000000803f000000000000803ffdc76e4111d7a1c00000000050321c41000000000000803f0000000000000000e9c76f416fa8a8c00000000062b10f41000000000000803f000000000000003fe9c76f41cd79afc00000000074300341000000000000803f000000000000803fe9c76f412a2e9cc000000000414e1b41000000000000803f0000000000000000a6c27041bfeba4c000000000d21a0f41000000000000803f000000000000003fa6c2704154a9adc00000000063e70241000000000000803f000000000000803fa6c2704125bf96c0000000004b361a41000000000000803f0000000000000000ebb87141ec59a1c000000000ea620e41000000000000803f000000000000003febb87141b3f4abc000000000898f0241000000000000803f000000000000803febb871419e8f91c00000000065ed1841000000000000803f000000000000000052ab72411ef59dc000000000ad8b0d41000000000000803f000000000000003f52ab72419e5aaac000000000f5290241000000000000803f000000000000803f52ab724188a48cc00000000094761741000000000000803f00000000000000005d9a734185bf9ac0000000001b970c41000000000000803f000000000000003f5d9a734182daa8c000000000a2b70141000000000000803f000000000000803f5d9a7341310288c000000000d8d41541000000000000803f00000000000000007e86744146bb97c00000000031870b41000000000000803f000000000000003f7e8674415b74a7c0000000008a390141000000000000803f000000000000803f7e86744168ac83c000000000190b1441000000000000803f0000000000000000127075418aea94c000000000ec5d0a41000000000000803f000000000000003f12707541ac28a6c000000000bfb00041000000000000803f000000000000803f127075414b4d7fc0000000001f1c1241000000000000803f0000000000000000645776417c4f92c0000000004d1d0941000000000000803f000000000000003f6457764153f8a4c0000000007b1e0041000000000000803f000000000000803f645776415ce877c0000000008c0a1041000000000000803f0000000000000000b43c774147ec8fc00000000054c70741000000000000803f000000000000003fb43c774160e4a3c0000000003808ff40000000000000803f000000000000803fb43c7741773071c000000000d2d80d41000000000000803f00000000000000003c20784112c38dc000000000fd5d0641000000000000803f000000000000003f3c207841e8eda2c00000000050c6fd40000000000000803f000000000000803f3c207841592c6bc0000000004c890b41000000000000803f00000000000000002b02794109d68bc0000000004ae30441000000000000803f000000000000003f2b027941e515a2c000000000907afc40000000000000803f000000000000803f2b0279413ee365c000000000391e0941000000000000803f0000000000000000b5e2794155278ac00000000037590341000000000000803f000000000000003fb5e279410b5da1c0000000006a28fb40000000000000803f000000000000803fb5e27941195d61c000000000de990641000000000000803f00000000000000000fc27a411eb988c000000000c4c10141000000000000803f000000000000003f0fc27a41b0c3a0c00000000053d3f940000000000000803f000000000000803f0fc27a41bea25dc00000000098fe0341000000000000803f000000000000000075a07b41908d87c000000000f11e0041000000000000803f000000000000003f75a07b41c149a0c000000000957ef840000000000000803f000000000000803f75a07b41d6bd5ac000000000f34e0141000000000000803f0000000000000000327e7c41d3a686c00000000078e5fc40000000000000803f000000000000003f327e7c41bbee9fc0000000000a2df740000000000000803f000000000000803f327e7c41c8b858c000000000a41bfd40000000000000803f0000000000000000a05b7d41120786c000000000487ef940000000000000803f000000000000003fa05b7d41c0b19fc000000000ece0f540000000000000803f000000000000803fa05b7d41649e57c000000000157df740000000000000803f00000000000000002e397e4176b085c0000000004e0cf640000000000000803f000000000000003f2e397e41ba919fc000000000879bf440000000000000803f000000000000803f2e397e41657957c00000000002caf140000000000000803f000000000000000063177f4128a585c0000000008c93f240000000000000803f000000000000003f63177f419e8d9fc000000000165df340000000000000803f000000000000803f63177f41bd5358c0000000006a0bec40000000000000803f0000000000000000e4f67f4152e785c000000000fc17ef40000000000000803f000000000000003fe4f67f41c5a49fc0000000008e24f240000000000000803f000000000000803fe4f67f41c8355ac000000000934be640000000000000803f0000000000000000396c80411e7986c0000000009e9deb40000000000000803f000000000000003f396c804158d79fc000000000a9eff040000000000000803f000000000000803f396c804160255dc000000000d695e040000000000000803f000000000000000078de8041b55c87c0000000006f28e840000000000000803f000000000000003f78de8041ba26a0c00000000008bbef40000000000000803f000000000000803f78de8041282561c00000000046f6da40000000000000803f0000000000000000b0528141429488c0000000006dbce440000000000000803f000000000000003fb0528141f095a0c0000000009482ee40000000000000803f000000000000803fb05281410a3466c0000000002d79d540000000000000803f000000000000000073c98141ed218ac000000000955de140000000000000803f000000000000003f73c98141d529a1c000000000fd41ed40000000000000803f000000000000803f73c98141264d6cc000000000702ad040000000000000803f00000000000000005e438241df078cc000000000e90fde40000000000000803f000000000000003f5e4382412be9a1c00000000062f5eb40000000000000803f000000000000803f5e438241
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -4.8949666, y: 0, z: 8.176058}
-    m_Extent: {x: 1.5281821, y: 0, z: 1.670877}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!1 &253818112
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 253818113}
-  - component: {fileID: 253818117}
-  - component: {fileID: 253818116}
-  - component: {fileID: 253818115}
-  - component: {fileID: 253818114}
-  m_Layer: 0
-  m_Name: segment 4
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &253818113
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 253818112}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1272024235}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &253818114
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 253818112}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 834609602}
---- !u!114 &253818115
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 253818112}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &253818116
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 253818112}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &253818117
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 253818112}
-  m_Mesh: {fileID: 834609602}
---- !u!1 &278046108
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 278046109}
-  - component: {fileID: 278046111}
-  - component: {fileID: 278046110}
-  m_Layer: 0
-  m_Name: Tire
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &278046109
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 278046108}
-  m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.07000003, y: 0.020000007, z: 0.07}
-  m_Children: []
-  m_Father: {fileID: 173503877}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
---- !u!23 &278046110
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 278046108}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: c05de7c865075334786e6a47a543af72, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &278046111
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 278046108}
-  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &283461115
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 283461116}
-  - component: {fileID: 283461119}
-  - component: {fileID: 283461118}
-  - component: {fileID: 283461117}
-  - component: {fileID: 283461120}
-  m_Layer: 5
-  m_Name: Canvas
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &283461116
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 283461115}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
-  m_Children:
-  - {fileID: 1629610888}
-  - {fileID: 744834144}
-  - {fileID: 692098978}
-  m_Father: {fileID: 883720339}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
---- !u!114 &283461117
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 283461115}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
---- !u!114 &283461118
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 283461115}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 1
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 1280, y: 800}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
---- !u!223 &283461119
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 283461115}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 1
-  m_Camera: {fileID: 1687258584}
-  m_PlaneDistance: 0.02
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!114 &283461120
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 283461115}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7053602e5a1f442558dd713eaf44f7a0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  car: {fileID: 1104095456}
-  speedText: {fileID: 1629610889}
-  throttleText: {fileID: 744834145}
-  turnText: {fileID: 692098979}
---- !u!1 &380648186
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 380648187}
-  - component: {fileID: 380648191}
-  - component: {fileID: 380648190}
-  - component: {fileID: 380648189}
-  - component: {fileID: 380648188}
-  m_Layer: 0
-  m_Name: segment 9
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &380648187
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 380648186}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1272024235}
-  m_RootOrder: 9
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &380648188
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 380648186}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1740683110}
---- !u!114 &380648189
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 380648186}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &380648190
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 380648186}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &380648191
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 380648186}
-  m_Mesh: {fileID: 1740683110}
---- !u!1 &380988568
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 380988569}
-  - component: {fileID: 380988571}
-  - component: {fileID: 380988570}
-  m_Layer: 0
-  m_Name: Main Camera
-  m_TagString: MainCamera
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &380988569
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 380988568}
-  m_LocalRotation: {x: 0.17364816, y: -0, z: -0.000000007450581, w: 0.98480785}
-  m_LocalPosition: {x: 0, y: 0.20000002, z: -0.4}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1104095457}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 20, y: 0, z: 0}
---- !u!114 &380988570
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 380988568}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 948f4100a11a5c24981795d21301da5c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  volumeTrigger: {fileID: 380988569}
-  volumeLayer:
-    serializedVersion: 2
-    m_Bits: 256
-  stopNaNPropagation: 1
-  finalBlitToCameraTarget: 1
-  antialiasingMode: 1
-  temporalAntialiasing:
-    jitterSpread: 0.75
-    sharpness: 0.25
-    stationaryBlending: 0.95
-    motionBlending: 0.85
-  subpixelMorphologicalAntialiasing:
-    quality: 2
-  fastApproximateAntialiasing:
-    fastMode: 1
-    keepAlpha: 0
-  fog:
-    enabled: 1
-    excludeSkybox: 1
-  debugLayer:
-    lightMeter:
-      width: 512
-      height: 256
-      showCurves: 1
-    histogram:
-      width: 512
-      height: 256
-      channel: 3
-    waveform:
-      exposure: 0.12
-      height: 256
-    vectorscope:
-      size: 256
-      exposure: 0.12
-    overlaySettings:
-      linearDepth: 0
-      motionColorIntensity: 4
-      motionGridSize: 64
-      colorBlindnessType: 0
-      colorBlindnessStrength: 1
-  m_Resources: {fileID: 11400000, guid: d82512f9c8e5d4a4d938b575d47f88d4, type: 2}
-  m_ShowToolkit: 1
-  m_ShowCustomSorter: 1
-  breakBeforeColorGrading: 0
-  m_BeforeTransparentBundles: []
-  m_BeforeStackBundles: []
-  m_AfterStackBundles: []
---- !u!20 &380988571
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 380988568}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
-  near clip plane: 0.1
-  far clip plane: 20
-  field of view: 60
-  orthographic: 0
-  orthographic size: 5
-  m_Depth: -1
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 1
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!43 &390911214
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 540
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 124
-    localAABB:
-      m_Center: {x: -6.177451, y: 0.095, z: 5.654354}
-      m_Extent: {x: 1.1261795, y: 0.105000004, z: 1.7193499}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 124
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 3968
-    _typelessdata: 04a4a1c00ad723bc76c9eb407619583f00000000863f09bf000000005e43824104a4a1c0cdcc4c3e76c9eb407619583f00000000863f09bf0000003f5e4382412be9a1c0cdcc4c3e62f5eb40761958bf00000000863f093f0000003f5e4382412be9a1c00ad723bc62f5eb40761958bf00000000863f093f0000803f5e438241c3baa3c00ad723bc8f80e84058f1573f00000000997e09bf00000000dec08241c3baa3c0cdcc4c3e8f80e84058f1573f00000000997e09bf0000003fdec08241ddffa3c0cdcc4c3e8face84058f157bf00000000997e093f0000003fdec08241ddffa3c00ad723bc8face84058f157bf00000000997e093f0000803fdec08241f8e0a5c00ad723bc7c21e540bccb573f000000009bb909bf00000000af418341f8e0a5c0cdcc4c3e7c21e540bccb573f000000009bb909bf0000003faf4183410626a6c0cdcc4c3e8e4de540bccb57bf000000009bb9093f0000003faf4183410626a6c00ad723bc8e4de540bccb57bf000000009bb9093f0000803faf4183418315a8c00ad723bce5ade1404ca8573f000000000cf109bf0000000093c583418315a8c0cdcc4c3ee5ade1404ca8573f000000000cf109bf0000003f93c58341865aa8c0cdcc4c3e09dae1404ca857bf000000000cf1093f0000003f93c58341865aa8c00ad723bc09dae1404ca857bf000000000cf1093f0000803f93c583415657aac00ad723bc8227de40ac86573f0000000091250abf000000004c4c84415657aac0cdcc4c3e8227de40ac86573f0000000091250abf0000003f4c4c84414e9caac0cdcc4c3eb853de40ac8657bf0000000091250a3f0000003f4c4c84414e9caac00ad723bcb853de40ac8657bf0000000091250a3f0000803f4c4c844155a5acc00ad723bcf48fda40a666573f000000007d570abf000000009bd5844155a5acc0cdcc4c3ef48fda40a666573f000000007d570abf0000003f9bd5844142eaacc0cdcc4c3e39bcda40a66657bf000000007d570a3f0000003f9bd5844142eaacc00ad723bc39bcda40a66657bf000000007d570a3f0000803f9bd584416efeaec00ad723bcf1e8d640e647573f000000004f870abf00000000436185416efeaec0cdcc4c3ef1e8d640e647573f000000004f870abf0000003f436185415143afc0cdcc4c3e4515d740e64757bf000000004f870a3f0000003f436185415143afc00ad723bc4515d740e64757bf000000004f870a3f0000803f436185418b61b1c00ad723bc1834d3404c2a573f0000000044b50abf0000000006ef85418b61b1c0cdcc4c3e1834d3404c2a573f0000000044b50abf0000003f06ef854165a6b1c0cdcc4c3e7b60d3404c2a57bf0000000044b50a3f0000003f06ef854165a6b1c00ad723bc7b60d3404c2a57bf0000000044b50a3f0000803f06ef85419dcdb3c00ad723bc1e73cf40900d573f00000000cee10abf00000000a47e86419dcdb3c0cdcc4c3e1e73cf40900d573f00000000cee10abf0000003fa47e86416e12b4c0cdcc4c3e909fcf40900d57bf00000000cee10a3f0000003fa47e86416e12b4c00ad723bc909fcf40900d57bf00000000cee10a3f0000803fa47e86418a41b6c00ad723bca3a7cb4092f1563f00000000200d0bbf00000000e10f87418a41b6c0cdcc4c3ea3a7cb4092f1563f00000000200d0bbf0000003fe10f87415286b6c0cdcc4c3e22d4cb4092f156bf00000000200d0b3f0000003fe10f87415286b6c00ad723bc22d4cb4092f156bf00000000200d0b3f0000803fe10f874144bcb8c00ad723bc4fd3c74026d6563f000000007a370bbf000000007fa2874144bcb8c0cdcc4c3e4fd3c74026d6563f000000007a370bbf0000003f7fa287410301b9c0cdcc4c3edbffc74026d656bf000000007a370b3f0000003f7fa287410301b9c00ad723bcdbffc74026d656bf000000007a370b3f0000803f7fa28741b93cbbc00ad723bccef7c34026bb563f000000001e610bbf000000003e368841b93cbbc0cdcc4c3ecef7c34026bb563f000000001e610bbf0000003f3e3688417081bbc0cdcc4c3e6824c44026bb56bf000000001e610b3f0000003f3e3688417081bbc00ad723bc6824c44026bb56bf000000001e610b3f0000803f3e368841d5c1bdc00ad723bcc016c0406ca0563f000000003e8a0bbf00000000e1ca8841d5c1bdc0cdcc4c3ec016c0406ca0563f000000003e8a0bbf0000003fe1ca88418306bec0cdcc4c3e6843c0406ca056bf000000003e8a0b3f0000003fe1ca88418306bec00ad723bc6843c0406ca056bf000000003e8a0b3f0000803fe1ca8841864ac0c00ad723bccf31bc40d885563f0000000016b30bbf000000002a608941864ac0c0cdcc4c3ecf31bc40d885563f0000000016b30bbf0000003f2a6089412c8fc0c0cdcc4c3e835ebc40d88556bf0000000016b30b3f0000003f2a6089412c8fc0c00ad723bc835ebc40d88556bf0000000016b30b3f0000803f2a608941bad5c2c00ad723bc9f4ab8404a6b563f00000000d4db0bbf00000000dbf58941bad5c2c0cdcc4c3e9f4ab8404a6b563f00000000d4db0bbf0000003fdbf58941571ac3c0cdcc4c3e6077b8404a6b56bf00000000d4db0b3f0000003fdbf58941571ac3c00ad723bc6077b8404a6b56bf00000000d4db0b3f0000803fdbf589416262c5c00ad723bcda62b440a650563f00000000a4040cbf00000000b58b8a416262c5c0cdcc4c3eda62b440a650563f00000000a4040cbf0000003fb58b8a41f7a6c5c0cdcc4c3ea88fb440a65056bf00000000a4040c3f0000003fb58b8a41f7a6c5c00ad723bca88fb440a65056bf00000000a4040c3f0000803fb58b8a416aefc7c00ad723bc217cb040c235563f00000000c72d0cbf000000007b218b416aefc7c0cdcc4c3e217cb040c235563f00000000c72d0cbf0000003f7b218b41f633c8c0cdcc4c3efca8b040c23556bf00000000c72d0c3f0000003f7b218b41f633c8c00ad723bcfca8b040c23556bf00000000c72d0c3f0000803f7b218b41bd7bcac00ad723bc1e98ac407e1a563f0000000069570cbf00000000eeb68b41bd7bcac0cdcc4c3e1e98ac407e1a563f0000000069570cbf0000003feeb68b4140c0cac0cdcc4c3e06c5ac407e1a56bf0000000069570c3f0000003feeb68b4140c0cac00ad723bc06c5ac407e1a56bf0000000069570c3f0000803feeb68b414e06cdc00ad723bc75b8a840b0fe553f00000000c4810cbf00000000d04b8c414e06cdc0cdcc4c3e75b8a840b0fe553f00000000c4810cbf0000003fd04b8c41c84acdc0cdcc4c3e6be5a840b0fe55bf00000000c4810c3f0000003fd04b8c41c84acdc00ad723bc6be5a840b0fe55bf00000000c4810c3f0000803fd04b8c41068ecfc00ad723bccddea4403ee2553f000000000dad0cbf00000000e4df8c41068ecfc0cdcc4c3ecddea4403ee2553f000000000dad0cbf0000003fe4df8c4177d2cfc0cdcc4c3ed10ba5403ee255bf000000000dad0c3f0000003fe4df8c4177d2cfc00ad723bcd10ba5403ee255bf000000000dad0c3f0000803fe4df8c41d611d2c00ad723bcce0ca14000c5553f000000007bd90cbf00000000eb728d41d611d2c0cdcc4c3ece0ca14000c5553f000000007bd90cbf0000003feb728d413e56d2c0cdcc4c3ee039a14000c555bf000000007bd90c3f0000003feb728d413e56d2c00ad723bce039a14000c555bf000000007bd90c3f0000803feb728d41ac90d4c00ad723bc1f449d40c8a6553f000000004e070dbf00000000a6048e41ac90d4c0cdcc4c3e1f449d40c8a6553f000000004e070dbf0000003fa6048e410bd5d4c0cdcc4c3e40719d40c8a655bf000000004e070d3f0000003fa6048e410bd5d4c00ad723bc40719d40c8a655bf000000004e070d3f0000803fa6048e417109d7c00ad723bc668699406087553f00000000d6360dbf00000000d8948e417109d7c0cdcc4c3e668699406087553f00000000d6360dbf0000003fd8948e41c64dd7c0cdcc4c3e97b39940608755bf00000000d6360d3f0000003fd8948e41c64dd7c00ad723bc97b39940608755bf00000000d6360d3f0000803fd8948e41137bd9c00ad723bc4ed595409866553f000000005f680dbf0000000044238f41137bd9c0cdcc4c3e4ed595409866553f000000005f680dbf0000003f44238f415dbfd9c0cdcc4c3e8f029640986655bf000000005f680d3f0000003f44238f415dbfd9c00ad723bc8f029640986655bf000000005f680d3f0000803f44238f417de4dbc00ad723bc823292403644553f000000002f9c0dbf00000000a9af8f417de4dbc0cdcc4c3e823292403644553f000000002f9c0dbf0000003fa9af8f41bc28dcc0cdcc4c3ed35f9240364455bf000000002f9c0d3f0000003fa9af8f41bc28dcc00ad723bcd35f9240364455bf000000002f9c0d3f0000803fa9af8f419c44dec00ad723bca89f8e40fc1f553f00000000b4d20dbf00000000cc3990419c44dec0cdcc4c3ea89f8e40fc1f553f00000000b4d20dbf0000003fcc399041cf88dec0cdcc4c3e0acd8e40fc1f55bf00000000b4d20d3f0000003fcc399041cf88dec00ad723bc0acd8e40fc1f55bf00000000b4d20d3f0000803fcc399041559ae0c00ad723bc6f1e8b408ef9543f00000000600c0ebf000000006cc19041559ae0c0cdcc4c3e6f1e8b408ef9543f00000000600c0ebf0000003f6cc190417cdee0c0cdcc4c3ee44b8b408ef954bf00000000600c0e3f0000003f6cc190417cdee0c00ad723bce44b8b408ef954bf00000000600c0e3f0000803f6cc1904194e4e2c00ad723bc85b08740a0d0543f00000000ab490ebf000000004d46914194e4e2c0cdcc4c3e85b08740a0d0543f00000000ab490ebf0000003f4d469141ae28e3c0cdcc4c3e0dde8740a0d054bf00000000ab490e3f0000003f4d469141ae28e3c00ad723bc0dde8740a0d054bf00000000ab490e3f0000803f4d4691414122e5c00ad723bc99578440caa4543f00000000288b0ebf0000000030c891414122e5c0cdcc4c3e99578440caa4543f00000000288b0ebf0000003f30c891414d66e5c0cdcc4c3e36858440caa454bf00000000288b0e3f0000003f30c891414d66e5c00ad723bc36858440caa454bf00000000288b0e3f0000803f30c891413c52e7c00ad723bc5e1581408075543f0000000099d10ebf00000000d84692413c52e7c0cdcc4c3e5e1581408075543f0000000099d10ebf0000003fd84692413996e7c0cdcc4c3e12438140807554bf0000000099d10e3f0000003fd84692413996e7c00ad723bc12438140807554bf0000000099d10e3f0000803fd84692416b73e9c00ad723bc1cd77b403642543f00000000c91d0fbf0000000005c292416b73e9c0cdcc4c3e1cd77b403642543f00000000c91d0fbf0000003f05c2924157b7e9c0cdcc4c3eb4327c40364254bf00000000c91d0f3f0000003f05c2924157b7e9c00ad723bcb4327c40364254bf00000000c91d0f3f0000803f05c29241
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -6.177451, y: 0.095, z: 5.654354}
-    m_Extent: {x: 1.1261795, y: 0.105000004, z: 1.7193499}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!43 &425473802
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 360
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 93
-    localAABB:
-      m_Center: {x: -8.678727, y: 0, z: 0.4487927}
-      m_Extent: {x: 1.7886868, y: 0, z: 2.5596082}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000030003000400010002000100040004000500020004000300060006000700040005000400070007000800050007000600090009000a000700080007000a000a000b0008000a0009000c000c000d000a000b000a000d000d000e000b000d000c000f000f0010000d000e000d001000100011000e0010000f00120012001300100011001000130013001400110013001200150015001600130014001300160016001700140016001500180018001900160017001600190019001a001700190018001b001b001c0019001a0019001c001c001d001a001c001b001e001e001f001c001d001c001f001f0020001d001f001e002100210022001f0020001f002200220023002000220021002400240025002200230022002500250026002300250024002700270028002500260025002800280029002600280027002a002a002b002800290028002b002b002c0029002b002a002d002d002e002b002c002b002e002e002f002c002e002d003000300031002e002f002e003100310032002f0031003000330033003400310032003100340034003500320034003300360036003700340035003400370037003800350037003600390039003a003700380037003a003a003b0038003a0039003c003c003d003a003b003a003d003d003e003b003d003c003f003f0040003d003e003d004000400041003e0040003f00420042004300400041004000430043004400410043004200450045004600430044004300460046004700440046004500480048004900460047004600490049004a004700490048004b004b004c0049004a0049004c004c004d004a004c004b004e004e004f004c004d004c004f004f0050004d004f004e005100510052004f0050004f005200520053005000520051005400540055005200530052005500550056005300550054005700570058005500560055005800580059005600580057005a005a005b005800590058005b005b005c005900
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 93
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 2976
-    _typelessdata: 367bdcc000000000e463f9bf000000800000803f00000000000000005ad1fe40a6d4e4c0000000008a3c97bf000000800000803f000000000000003f5ad1fe40162eedc000000000be54d4be000000800000803f000000000000803f5ad1fe40b0e4e3c000000000792a01c0000000800000803f000000000000000062e100413177eac000000000440a9ebf000000800000803f000000000000003f62e10041b209f1c0000000005afee6be000000800000803f000000000000803f62e100411250ebc000000000db7104c0000000800000803f00000000000000002b440241d3e0efc00000000098d4a2bf000000800000803f000000000000003f2b4402419471f4c000000000e815f3be000000800000803f000000000000803f2b4402417ebef2c0000000008a7306c0000000800000803f00000000000000007f9303410312f5c0000000001ca4a5bf000000800000803f000000000000003f7f9303418865f7c0000000008c84f9be000000800000803f000000000000803f7f930341712cfac0000000009a1707c0000000000000803f00000000000000001dd20441480bfac0000000007381a6bf000000000000803f000000000000003f1dd204411feaf9c000000000cc4efbbe000000000000803f000000000000803f1dd2044108c800c100000000184606c0000000000000803f00000000000000000603064116cdfec0000000003075a5bf000000000000803f000000000000003f060306411c0afcc000000000be78f9be000000000000803f000000000000803f060306415a6c04c10000000082ec03c0000000000000803f00000000000000007e290741fcab01c100000000fb87a2bf000000000000803f000000000000003f7e2907413cd7fdc000000000ccdbf4be000000000000803f000000000000803f7e290741e6f707c100000000c80300c0000000000000803f0000000000000000ec48084131d603c10000000067c29dbf000000000000803f000000000000003fec480841f868ffc000000000fcf4edbe000000000000803f000000000000803fec480841125e0bc100000000012af5bf000000000000803f0000000000000000cf6409416fe505c100000000162d97bf000000000000803f000000000000003fcf640941cc6c00c100000000acc0e4be000000000000803f000000000000803fcf6409410b930ec1000000000f74e7bf000000000000803f000000000000000093800a41f0d907c100000000a3d08ebf000000000000803f000000000000003f93800a41d52001c100000000dcb4d8be000000000000803f000000000000803f93800a41e08d11c100000000ed32d7bf000000000000803f00000000000000007c9f0b41f7b309c100000000aab584bf000000000000803f000000000000003f7c9f0b410eda01c1000000009ce1c8be000000000000803f000000000000803f7c9f0b41914914c1000000002cbfc4bf000000000000803f000000000000000086c40c41c3730bc10000000099c971bf000000000000803f000000000000003f86c40c41f59d02c100000000b429b4be000000000000803f000000000000803f86c40c4113c516c1000000002a6eb0bf000000000000803f000000000000000055f20d4193190dc10000000041cd56bf000000000000803f000000000000003f55f20d41136e03c1000000005e7c99be000000000000803f000000000000803f55f20d416e0219c1000000002a889abf000000000000803f00000000000000002b2b0f41a5a50ec1000000008a8738bf000000000000803f000000000000003f2b2b0f41dc4804c10000000002fb6fbe000000000000803f000000000000803f2b2b0f4196051bc100000000124483bf000000000000803f0000000000000000ee7010413a1810c100000000ae0917bf000000000000803f000000000000003fee701041de2a05c100000000de2c1ebe000000000000803f000000000000803fee70104154d31cc100000000d68f55bf000000000000803f000000000000000028c51141937111c100000000d1c9e4be000000000000803f000000000000003f28c51141d20f06c100000000a89f73bd000000000000803f000000000000803f28c5114183701ec100000000ca5722bf000000000000803f000000000000000010291341ecb112c100000000dc5495be000000000000803f000000000000003f1029134155f306c100000000e82e503d000000000000803f000000000000803f10291341a5e11fc10000000023f8d9be000000000000803f00000000000000009b9d144186d913c100000000c05bffbd000000000000803f000000000000003f9b9d144167d107c1000000008694343e000000000000803f000000000000803f9b9d1441ae2a21c1000000002e2d56be000000000000803f00000000000000007f231641a2e814c100000000f06b5c3d000000000000803f000000000000003f7f23164196a608c1000000009331a23e000000000000803f000000000000803f7f231641f14e22c10000000060047d3c000000000000803f000000000000000042bb17417ddf15c100000000fc6b793e000000000000803f000000000000003f42bb1741097009c100000000d983f13e000000000000803f000000000000803f42bb1741355123c10000000066ff7d3e000000000000803f00000000000000003f65194157be16c1000000001280e33e000000000000803f000000000000003f3f651941792b0ac1000000003800243f000000000000803f000000000000803f3f651941c33324c1000000008a2ffa3e000000000000803f0000000000000000af211b41728517c100000000ace4273f000000000000803f000000000000003faf211b4121d70ac10000000093b1523f000000000000803f000000000000803faf211b4176f824c100000000b0bb3c3f000000000000803f0000000000000000aef01c410a3518c100000000a6b7603f000000000000803f000000000000003faef01c419e710bc100000000ce59823f000000000000803f000000000000803faef01c41d5a025c100000000e16a7e3f000000000000803f00000000000000003ed21e415ecd18c100000000e2138e3f000000000000803f000000000000003f3ed21e41e7f90bc10000000054f29c3f000000000000803f000000000000803f3ed21e41282e26c100000000bc11a13f000000000000803f000000000000000052c62041b24e19c100000000e611ad3f000000000000803f000000000000003f52c620413c6f0cc1000000001012b93f000000000000803f000000000000803f52c6204178a126c10000000012f1c33f000000000000803f0000000000000000c6cc224142b919c100000000424dcd3f000000000000803f000000000000003fc6cc22410cd10cc10000000072a9d63f000000000000803f000000000000803fc6cc2241a8fb26c10000000025d1e73f000000000000803f00000000000000006de524414d0d1ac10000000059bdee3f000000000000803f000000000000003f6de52441f21e0dc1000000008da9f53f000000000000803f000000000000803f6de524417b3d27c10000000076570640000000000000803f00000000000000000d102741154b1ac100000000c7ac0840000000000000803f000000000000003f0d102741af580dc10000000018020b40000000000000803f000000000000803f0d102741946727c10000000066431940000000000000803f0000000000000000614c2941d7721ac100000000a38c1a40000000000000803f000000000000003f614c29411a7e0dc100000000e0d51b40000000000000803f000000000000803f614c2941877a27c10000000042aa2c40000000000000803f00000000000000001c9a2b41d4841ac100000000f1f92c40000000000000803f000000000000003f1c9a2b41218f0dc100000000a0492d40000000000000803f000000000000803f1c9a2b41d57627c100000000a4894040000000000000803f0000000000000000eaf82d414b811ac10000000055f03f40000000000000803f000000000000003feaf82d41c18b0dc10000000006573f40000000000000803f000000000000803feaf82d41
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -8.678727, y: 0, z: 0.4487927}
-    m_Extent: {x: 1.7886868, y: 0, z: 2.5596082}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!43 &445428743
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 360
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 93
-    localAABB:
-      m_Center: {x: 3.6061394, y: 0, z: 4.7524605}
-      m_Extent: {x: 1.7428272, y: 0, z: 2.9123828}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000030003000400010002000100040004000500020004000300060006000700040005000400070007000800050007000600090009000a000700080007000a000a000b0008000a0009000c000c000d000a000b000a000d000d000e000b000d000c000f000f0010000d000e000d001000100011000e0010000f00120012001300100011001000130013001400110013001200150015001600130014001300160016001700140016001500180018001900160017001600190019001a001700190018001b001b001c0019001a0019001c001c001d001a001c001b001e001e001f001c001d001c001f001f0020001d001f001e002100210022001f0020001f002200220023002000220021002400240025002200230022002500250026002300250024002700270028002500260025002800280029002600280027002a002a002b002800290028002b002b002c0029002b002a002d002d002e002b002c002b002e002e002f002c002e002d003000300031002e002f002e003100310032002f0031003000330033003400310032003100340034003500320034003300360036003700340035003400370037003800350037003600390039003a003700380037003a003a003b0038003a0039003c003c003d003a003b003a003d003d003e003b003d003c003f003f0040003d003e003d004000400041003e0040003f00420042004300400041004000430043004400410043004200450045004600430044004300460046004700440046004500480048004900460047004600490049004a004700490048004b004b004c0049004a0049004c004c004d004a004c004b004e004e004f004c004d004c004f004f0050004d004f004e005100510052004f0050004f005200520053005000520051005400540055005200530052005500550056005300550054005700570058005500560055005800580059005600580057005a005a005b005800590058005b005b005c005900
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 93
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 2976
-    _typelessdata: 750ca640000000006546f540000000000000803f00000000000000000000000009c98c4000000000497aef40000000000000803f000000000000003f000000003a0b6740000000002daee940000000000000803f000000000000803f000000006c14a84000000000b660eb40000000000000803f00000000000000001e400e3ea8928e4000000000c2c4e640000000000000803f000000000000003f1e400e3ec8216a4000000000ce28e240000000000000803f000000000000803f1e400e3ed597a94000000000c2afe140000000000000803f00000000000000006a998b3ecbe48f4000000000d64fde40000000000000803f000000000000003f6a998b3e82636c4000000000eaefda40000000000000803f000000000000803f6a998b3e2d9aaa4000000000a534d840000000000000803f0000000000000000289ecd3e77c49040000000001e1bd640000000000000803f000000000000003f289ecd3e81dd6d40000000009701d440000000000000803f000000000000803f289ecd3e2c1fab4000000000e0f0ce40000000000000803f00000000000000005caf063fbf369140000000004026ce40000000000000803f000000000000003f5caf063fa49c6e4000000000a05bcd40000000000000803f000000000000803f5caf063fbc2aab400000000034e6c540000000000000803f00000000000000002a85253fa940914000000000d370c640000000000000803f000000000000003f2a85253f2dad6e400000000072fbc640000000000000803f000000000000803f2a85253f24c1aa4000000000b116bd40000000000000803f0000000000000000de66433f48e79040000000007dfabe40000000000000803f000000000000003fde66433fd81a6e400000000049dec040000000000000803f000000000000803fde66433fffe6a940000000008584b440000000000000803f0000000000000000dd69603fa12f904000000000d8c2b740000000000000803f000000000000003fdd69603f86f06c40000000002b01bb40000000000000803f000000000000803fdd69603f55a1a84000000000fc31ac40000000000000803f000000000000000005a27c3fc61e8f400000000089c9b040000000000000803f000000000000003f05a27c3f6e386b40000000001661b540000000000000803f000000000000803f05a27c3f92f5a640000000005421a440000000000000803f0000000000000000ed108c3fbfb98d40000000002c0eaa40000000000000803f000000000000003fed108c3fd9fb68400000000004fbaf40000000000000803f000000000000803fed108c3f84e9a44000000000a8549c40000000000000803f0000000000000000197d993f9a058c40000000005e90a340000000000000803f000000000000003f197d993f604366400000000014ccaa40000000000000803f000000000000803f197d993f5583a24000000000e6cd9440000000000000803f0000000000000000009da63f65078a4000000000c44f9d40000000000000803f000000000000003f009da63feb16634000000000a2d1a540000000000000803f000000000000803f009da63f6dc99f4000000000a48e8d40000000000000803f00000000000000004577b33f2ac4874000000000f94b9740000000000000803f000000000000003f4577b33fce7d5f40000000004e09a140000000000000803f000000000000803f4577b33f6cc29c400000000025988640000000000000803f00000000000000008c11c03ff5408540000000009d849140000000000000803f000000000000003f8c11c03ffc7e5b400000000015719c40000000000000803f000000000000803f8c11c03f10759940000000009bd67f40000000000000803f00000000000000008670cc3fd2828240000000004ef98b40000000000000803f000000000000003f8670cc3f28215740000000004f079840000000000000803f000000000000803f8670cc3f21e895400000000044117340000000000000803f0000000000000000e197d83f9e1d7f4000000000aea98640000000000000803f000000000000003fe197d83ffa6a524000000000baca9340000000000000803f000000000000803fe197d83f5b2292400000000093e06640000000000000803f0000000000000000628ae43fecd37840000000005c958140000000000000803f000000000000003f628ae43f23634d40000000006eba8f40000000000000803f000000000000803f628ae43f662a8e400000000029445b40000000000000803f0000000000000000df49f03fab32724000000000ea777940000000000000803f000000000000003fdf49f03f8a10484000000000d5d58b40000000000000803f000000000000803fdf49f03fc2068a40000000001b3b5040000000000000803f000000000000000047d7fb3ff1436b4000000000343a7040000000000000803f000000000000003f47d7fb3f5e7a424000000000a71c8840000000000000803f000000000000803f47d7fb3fc2bd854000000000fdc34540000000000000803f000000000000000059990340d511644000000000d2706740000000000000803f000000000000003f5999034025a83c4000000000d48e8440000000000000803f000000000000803f59990340895581400000000005dd3b40000000000000803f0000000000000000b42d094071a65c4000000000051b5f40000000000000803f000000000000003fb42d0940d0a1364000000000832c8140000000000000803f000000000000803fb42d094000a87940000000001a843240000000000000803f0000000000000000f8a70e40df0b5540000000000c385740000000000000803f000000000000003ff8a70e40be6f304000000000feeb7b40000000000000803f000000000000803ff8a70e40ae7d704000000000eab62940000000000000803f000000000000000012071440344c4d400000000022c74f40000000000000803f000000000000003f12071440ba1a2a40000000005ad77540000000000000803f000000000000803f12071440123767400000000001732140000000000000803f00000000000000009c491940887145400000000087c74840000000000000803f000000000000003f9c491940feab2340000000000d1c7040000000000000803f000000000000803f9c491940aede5d4000000000d6b51940000000000000803f0000000000000000df6d1e40f8853d40000000007c384240000000000000803f000000000000003fdf6d1e40422d1d400000000022bb6a40000000000000803f000000000000803fdf6d1e40887e544000000000cd7c1240000000000000803f0000000000000000e771234099933540000000003c193c40000000000000803f000000000000003fe7712340aaa8164000000000abb56540000000000000803f000000000000803fe771234038204b400000000053c50b40000000000000803f00000000000000007c53284083a42d400000000008693640000000000000803f000000000000003f7c532840ce28104000000000bd0c6140000000000000803f000000000000803f7c532840cfcc414000000000ce8c0540000000000000803f000000000000000030102d40d1c22540000000001c273140000000000000803f000000000000003f30102d40d3b80940000000006ac15c40000000000000803f000000000000803f30102d40cc8c3840000000006fa1ff3f000000000000803f000000000000000062a5314099f81d4000000000ba522c40000000000000803f000000000000003f62a531406664034000000000bcd45840000000000000803f000000000000803f62a5314004682f4000000000101df53f000000800000803f000000000000000046103640f44f1640000000001ceb2740000000800000803f000000000000003f46103640c76ffa3f00000000b0475540000000800000803f000000000000803f461036408165264000000000a887eb3f000000800000803f0000000000000000e34d3a4001d30e400000000088ef2340000000800000803f000000000000003fe34d3a400381ee3f000000003c1b5240000000800000803f000000000000803fe34d3a40
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 3.6061394, y: 0, z: 4.7524605}
-    m_Extent: {x: 1.7428272, y: 0, z: 2.9123828}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!1 &459612991
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 459612992}
-  - component: {fileID: 459612996}
-  - component: {fileID: 459612995}
-  - component: {fileID: 459612994}
-  - component: {fileID: 459612993}
-  m_Layer: 0
-  m_Name: segment 7
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &459612992
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 459612991}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1236410749}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &459612993
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 459612991}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1446604457}
---- !u!114 &459612994
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 459612991}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &459612995
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 459612991}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &459612996
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 459612991}
-  m_Mesh: {fileID: 1446604457}
---- !u!1 &501547372
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 501547373}
-  m_Layer: 0
-  m_Name: Wheel RR
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &501547373
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 501547372}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.1, y: -0.024999999, z: -0.14}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 2103067471}
-  m_Father: {fileID: 1104095457}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!43 &525209673
+--- !u!43 &7534102
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2662,213 +283,170 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1 &539737850
-GameObject:
+--- !u!43 &14025792
+Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 539737851}
-  m_Layer: 0
-  m_Name: generated by SplineExtrusion
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &539737851
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 539737850}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 957949371}
-  - {fileID: 2146937495}
-  - {fileID: 1647536395}
-  - {fileID: 1297241110}
-  - {fileID: 723254066}
-  - {fileID: 24874895}
-  - {fileID: 1240106739}
-  - {fileID: 1291100384}
-  - {fileID: 157871382}
-  - {fileID: 1532668706}
-  - {fileID: 130995381}
-  m_Father: {fileID: 588167376}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &581401478
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 581401479}
-  - component: {fileID: 581401483}
-  - component: {fileID: 581401482}
-  - component: {fileID: 581401481}
-  - component: {fileID: 581401480}
-  m_Layer: 0
-  m_Name: segment 4
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &581401479
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 581401478}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1236410749}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &581401480
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 581401478}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 208904281}
---- !u!114 &581401481
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 581401478}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &581401482
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 581401478}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &581401483
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 581401478}
-  m_Mesh: {fileID: 208904281}
---- !u!1 &588167375
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 588167376}
-  - component: {fileID: 588167377}
-  m_Layer: 0
-  m_Name: Right Wall
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &588167376
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 588167375}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 539737851}
-  m_Father: {fileID: 809433128}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &588167377
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 588167375}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8d1eb05ecfaa05444b40d40a2ea2268f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  shapeVertices:
-  - point: {x: -0.81, y: -0.01}
-    normal: {x: -1, y: 0}
-    uCoord: 0
-  - point: {x: -0.81, y: 0.2}
-    normal: {x: -1, y: 0}
-    uCoord: 0.5
-  - point: {x: -0.8, y: 0.2}
-    normal: {x: 1, y: 0}
-    uCoord: 0.5
-  - point: {x: -0.8, y: -0.01}
-    normal: {x: 1, y: 0}
-    uCoord: 1
-  loopAround: 0
-  material: {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  textureScale: 0.5
---- !u!43 &595044863
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 540
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 124
+    localAABB:
+      m_Center: {x: -6.177451, y: 0.095, z: 5.654354}
+      m_Extent: {x: 1.1261795, y: 0.105000004, z: 1.7193499}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 124
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 3968
+    _typelessdata: 04a4a1c00ad723bc76c9eb407619583f00000000863f09bf000000005e43824104a4a1c0cdcc4c3e76c9eb407619583f00000000863f09bf0000003f5e4382412be9a1c0cdcc4c3e62f5eb40761958bf00000000863f093f0000003f5e4382412be9a1c00ad723bc62f5eb40761958bf00000000863f093f0000803f5e438241c3baa3c00ad723bc8f80e84058f1573f00000000997e09bf00000000dec08241c3baa3c0cdcc4c3e8f80e84058f1573f00000000997e09bf0000003fdec08241ddffa3c0cdcc4c3e8face84058f157bf00000000997e093f0000003fdec08241ddffa3c00ad723bc8face84058f157bf00000000997e093f0000803fdec08241f8e0a5c00ad723bc7c21e540bccb573f000000009bb909bf00000000af418341f8e0a5c0cdcc4c3e7c21e540bccb573f000000009bb909bf0000003faf4183410626a6c0cdcc4c3e8e4de540bccb57bf000000009bb9093f0000003faf4183410626a6c00ad723bc8e4de540bccb57bf000000009bb9093f0000803faf4183418315a8c00ad723bce5ade1404ca8573f000000000cf109bf0000000093c583418315a8c0cdcc4c3ee5ade1404ca8573f000000000cf109bf0000003f93c58341865aa8c0cdcc4c3e09dae1404ca857bf000000000cf1093f0000003f93c58341865aa8c00ad723bc09dae1404ca857bf000000000cf1093f0000803f93c583415657aac00ad723bc8227de40ac86573f0000000091250abf000000004c4c84415657aac0cdcc4c3e8227de40ac86573f0000000091250abf0000003f4c4c84414e9caac0cdcc4c3eb853de40ac8657bf0000000091250a3f0000003f4c4c84414e9caac00ad723bcb853de40ac8657bf0000000091250a3f0000803f4c4c844155a5acc00ad723bcf48fda40a666573f000000007d570abf000000009bd5844155a5acc0cdcc4c3ef48fda40a666573f000000007d570abf0000003f9bd5844142eaacc0cdcc4c3e39bcda40a66657bf000000007d570a3f0000003f9bd5844142eaacc00ad723bc39bcda40a66657bf000000007d570a3f0000803f9bd584416efeaec00ad723bcf1e8d640e647573f000000004f870abf00000000436185416efeaec0cdcc4c3ef1e8d640e647573f000000004f870abf0000003f436185415143afc0cdcc4c3e4515d740e64757bf000000004f870a3f0000003f436185415143afc00ad723bc4515d740e64757bf000000004f870a3f0000803f436185418b61b1c00ad723bc1834d3404c2a573f0000000044b50abf0000000006ef85418b61b1c0cdcc4c3e1834d3404c2a573f0000000044b50abf0000003f06ef854165a6b1c0cdcc4c3e7b60d3404c2a57bf0000000044b50a3f0000003f06ef854165a6b1c00ad723bc7b60d3404c2a57bf0000000044b50a3f0000803f06ef85419dcdb3c00ad723bc1e73cf40900d573f00000000cee10abf00000000a47e86419dcdb3c0cdcc4c3e1e73cf40900d573f00000000cee10abf0000003fa47e86416e12b4c0cdcc4c3e909fcf40900d57bf00000000cee10a3f0000003fa47e86416e12b4c00ad723bc909fcf40900d57bf00000000cee10a3f0000803fa47e86418a41b6c00ad723bca3a7cb4092f1563f00000000200d0bbf00000000e10f87418a41b6c0cdcc4c3ea3a7cb4092f1563f00000000200d0bbf0000003fe10f87415286b6c0cdcc4c3e22d4cb4092f156bf00000000200d0b3f0000003fe10f87415286b6c00ad723bc22d4cb4092f156bf00000000200d0b3f0000803fe10f874144bcb8c00ad723bc4fd3c74026d6563f000000007a370bbf000000007fa2874144bcb8c0cdcc4c3e4fd3c74026d6563f000000007a370bbf0000003f7fa287410301b9c0cdcc4c3edbffc74026d656bf000000007a370b3f0000003f7fa287410301b9c00ad723bcdbffc74026d656bf000000007a370b3f0000803f7fa28741b93cbbc00ad723bccef7c34026bb563f000000001e610bbf000000003e368841b93cbbc0cdcc4c3ecef7c34026bb563f000000001e610bbf0000003f3e3688417081bbc0cdcc4c3e6824c44026bb56bf000000001e610b3f0000003f3e3688417081bbc00ad723bc6824c44026bb56bf000000001e610b3f0000803f3e368841d5c1bdc00ad723bcc016c0406ca0563f000000003e8a0bbf00000000e1ca8841d5c1bdc0cdcc4c3ec016c0406ca0563f000000003e8a0bbf0000003fe1ca88418306bec0cdcc4c3e6843c0406ca056bf000000003e8a0b3f0000003fe1ca88418306bec00ad723bc6843c0406ca056bf000000003e8a0b3f0000803fe1ca8841864ac0c00ad723bccf31bc40d885563f0000000016b30bbf000000002a608941864ac0c0cdcc4c3ecf31bc40d885563f0000000016b30bbf0000003f2a6089412c8fc0c0cdcc4c3e835ebc40d88556bf0000000016b30b3f0000003f2a6089412c8fc0c00ad723bc835ebc40d88556bf0000000016b30b3f0000803f2a608941bad5c2c00ad723bc9f4ab8404a6b563f00000000d4db0bbf00000000dbf58941bad5c2c0cdcc4c3e9f4ab8404a6b563f00000000d4db0bbf0000003fdbf58941571ac3c0cdcc4c3e6077b8404a6b56bf00000000d4db0b3f0000003fdbf58941571ac3c00ad723bc6077b8404a6b56bf00000000d4db0b3f0000803fdbf589416262c5c00ad723bcda62b440a650563f00000000a4040cbf00000000b58b8a416262c5c0cdcc4c3eda62b440a650563f00000000a4040cbf0000003fb58b8a41f7a6c5c0cdcc4c3ea88fb440a65056bf00000000a4040c3f0000003fb58b8a41f7a6c5c00ad723bca88fb440a65056bf00000000a4040c3f0000803fb58b8a416aefc7c00ad723bc217cb040c235563f00000000c72d0cbf000000007b218b416aefc7c0cdcc4c3e217cb040c235563f00000000c72d0cbf0000003f7b218b41f633c8c0cdcc4c3efca8b040c23556bf00000000c72d0c3f0000003f7b218b41f633c8c00ad723bcfca8b040c23556bf00000000c72d0c3f0000803f7b218b41bd7bcac00ad723bc1e98ac407e1a563f0000000069570cbf00000000eeb68b41bd7bcac0cdcc4c3e1e98ac407e1a563f0000000069570cbf0000003feeb68b4140c0cac0cdcc4c3e06c5ac407e1a56bf0000000069570c3f0000003feeb68b4140c0cac00ad723bc06c5ac407e1a56bf0000000069570c3f0000803feeb68b414e06cdc00ad723bc75b8a840b0fe553f00000000c4810cbf00000000d04b8c414e06cdc0cdcc4c3e75b8a840b0fe553f00000000c4810cbf0000003fd04b8c41c84acdc0cdcc4c3e6be5a840b0fe55bf00000000c4810c3f0000003fd04b8c41c84acdc00ad723bc6be5a840b0fe55bf00000000c4810c3f0000803fd04b8c41068ecfc00ad723bccddea4403ee2553f000000000dad0cbf00000000e4df8c41068ecfc0cdcc4c3ecddea4403ee2553f000000000dad0cbf0000003fe4df8c4177d2cfc0cdcc4c3ed10ba5403ee255bf000000000dad0c3f0000003fe4df8c4177d2cfc00ad723bcd10ba5403ee255bf000000000dad0c3f0000803fe4df8c41d611d2c00ad723bcce0ca14000c5553f000000007bd90cbf00000000eb728d41d611d2c0cdcc4c3ece0ca14000c5553f000000007bd90cbf0000003feb728d413e56d2c0cdcc4c3ee039a14000c555bf000000007bd90c3f0000003feb728d413e56d2c00ad723bce039a14000c555bf000000007bd90c3f0000803feb728d41ac90d4c00ad723bc1f449d40c8a6553f000000004e070dbf00000000a6048e41ac90d4c0cdcc4c3e1f449d40c8a6553f000000004e070dbf0000003fa6048e410bd5d4c0cdcc4c3e40719d40c8a655bf000000004e070d3f0000003fa6048e410bd5d4c00ad723bc40719d40c8a655bf000000004e070d3f0000803fa6048e417109d7c00ad723bc668699406087553f00000000d6360dbf00000000d8948e417109d7c0cdcc4c3e668699406087553f00000000d6360dbf0000003fd8948e41c64dd7c0cdcc4c3e97b39940608755bf00000000d6360d3f0000003fd8948e41c64dd7c00ad723bc97b39940608755bf00000000d6360d3f0000803fd8948e41137bd9c00ad723bc4ed595409866553f000000005f680dbf0000000044238f41137bd9c0cdcc4c3e4ed595409866553f000000005f680dbf0000003f44238f415dbfd9c0cdcc4c3e8f029640986655bf000000005f680d3f0000003f44238f415dbfd9c00ad723bc8f029640986655bf000000005f680d3f0000803f44238f417de4dbc00ad723bc823292403644553f000000002f9c0dbf00000000a9af8f417de4dbc0cdcc4c3e823292403644553f000000002f9c0dbf0000003fa9af8f41bc28dcc0cdcc4c3ed35f9240364455bf000000002f9c0d3f0000003fa9af8f41bc28dcc00ad723bcd35f9240364455bf000000002f9c0d3f0000803fa9af8f419c44dec00ad723bca89f8e40fc1f553f00000000b4d20dbf00000000cc3990419c44dec0cdcc4c3ea89f8e40fc1f553f00000000b4d20dbf0000003fcc399041cf88dec0cdcc4c3e0acd8e40fc1f55bf00000000b4d20d3f0000003fcc399041cf88dec00ad723bc0acd8e40fc1f55bf00000000b4d20d3f0000803fcc399041559ae0c00ad723bc6f1e8b408ef9543f00000000600c0ebf000000006cc19041559ae0c0cdcc4c3e6f1e8b408ef9543f00000000600c0ebf0000003f6cc190417cdee0c0cdcc4c3ee44b8b408ef954bf00000000600c0e3f0000003f6cc190417cdee0c00ad723bce44b8b408ef954bf00000000600c0e3f0000803f6cc1904194e4e2c00ad723bc85b08740a0d0543f00000000ab490ebf000000004d46914194e4e2c0cdcc4c3e85b08740a0d0543f00000000ab490ebf0000003f4d469141ae28e3c0cdcc4c3e0dde8740a0d054bf00000000ab490e3f0000003f4d469141ae28e3c00ad723bc0dde8740a0d054bf00000000ab490e3f0000803f4d4691414122e5c00ad723bc99578440caa4543f00000000288b0ebf0000000030c891414122e5c0cdcc4c3e99578440caa4543f00000000288b0ebf0000003f30c891414d66e5c0cdcc4c3e36858440caa454bf00000000288b0e3f0000003f30c891414d66e5c00ad723bc36858440caa454bf00000000288b0e3f0000803f30c891413c52e7c00ad723bc5e1581408075543f0000000099d10ebf00000000d84692413c52e7c0cdcc4c3e5e1581408075543f0000000099d10ebf0000003fd84692413996e7c0cdcc4c3e12438140807554bf0000000099d10e3f0000003fd84692413996e7c00ad723bc12438140807554bf0000000099d10e3f0000803fd84692416b73e9c00ad723bc1cd77b403642543f00000000c91d0fbf0000000005c292416b73e9c0cdcc4c3e1cd77b403642543f00000000c91d0fbf0000003f05c2924157b7e9c0cdcc4c3eb4327c40364254bf00000000c91d0f3f0000003f05c2924157b7e9c00ad723bcb4327c40364254bf00000000c91d0f3f0000803f05c29241
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -6.177451, y: 0.095, z: 5.654354}
+    m_Extent: {x: 1.1261795, y: 0.105000004, z: 1.7193499}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &17559291
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3031,2116 +609,7 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!43 &612005129
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 540
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 124
-    localAABB:
-      m_Center: {x: 3.9721823, y: 0.095, z: 4.7524605}
-      m_Extent: {x: 1.3767842, y: 0.105000004, z: 2.9123828}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 124
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 3968
-    _typelessdata: 750ca6400ad723bc6546f540c683793f000000006907653e0000000000000000750ca640cdcc4c3e6546f540c683793f000000006907653e0000003f000000009dbca540cdcc4c3e1234f540c68379bf00000000690765be0000003f000000009dbca5400ad723bc1234f540c68379bf00000000690765be0000803f000000006c14a8400ad723bcb660eb4082eb7b3f000000007417363e000000001e400e3e6c14a840cdcc4c3eb660eb4082eb7b3f000000007417363e0000003f1e400e3ecfc3a740cdcc4c3e2552eb4082eb7bbf00000000741736be0000003f1e400e3ecfc3a7400ad723bc2552eb4082eb7bbf00000000741736be0000803f1e400e3ed597a9400ad723bcc2afe1402cd27d3f000000004552053e000000006a998b3ed597a940cdcc4c3ec2afe1402cd27d3f000000004552053e0000003f6a998b3e9c46a940cdcc4c3e18a5e1402cd27dbf00000000455205be0000003f6a998b3e9c46a9400ad723bc18a5e1402cd27dbf00000000455205be0000803f6a998b3e2d9aaa400ad723bca534d8409e287f3f000000003ae7a53d00000000289ecd3e2d9aaa40cdcc4c3ea534d8409e287f3f000000003ae7a53d0000003f289ecd3e8748aa40cdcc4c3e022ed8409e287fbf000000003ae7a5bd0000003f289ecd3e8748aa400ad723bc022ed8409e287fbf000000003ae7a5bd0000803f289ecd3e2c1fab400ad723bce0f0ce4070e17f3f000000009927fa3c000000005caf063f2c1fab40cdcc4c3ee0f0ce4070e17f3f000000009927fa3c0000003f5caf063f4acdaa40cdcc4c3e60eece4070e17fbf000000009927fabc0000003f5caf063f4acdaa400ad723bc60eece4070e17fbf000000009927fabc0000803f5caf063fbc2aab400ad723bc34e6c540b4f17f3f00000000ff22abbc000000002a85253fbc2aab40cdcc4c3e34e6c540b4f17f3f00000000ff22abbc0000003f2a85253fd5d8aa40cdcc4c3eeae7c540b4f17fbf00000000ff22ab3c0000003f2a85253fd5d8aa400ad723bceae7c540b4f17fbf00000000ff22ab3c0000803f2a85253f24c1aa400ad723bcb116bd4096517f3f00000000e05195bd00000000de66433f24c1aa40cdcc4c3eb116bd4096517f3f00000000e05195bd0000003fde66433f716faa40cdcc4c3eaa1cbd4096517fbf00000000e051953d0000003fde66433f716faa400ad723bcaa1cbd4096517fbf00000000e051953d0000803fde66433fffe6a9400ad723bc8584b440e6fc7d3f00000000002300be00000000dd69603fffe6a940cdcc4c3e8584b440e6fc7d3f00000000002300be0000003fdd69603fb895a940cdcc4c3ec58eb440e6fc7dbf000000000023003e0000003fdd69603fb895a9400ad723bcc58eb440e6fc7dbf000000000023003e0000803fdd69603f55a1a8400ad723bcfc31ac405af37b3f00000000836935be0000000005a27c3f55a1a840cdcc4c3efc31ac405af37b3f00000000836935be0000003f05a27c3fb550a840cdcc4c3e7f40ac405af37bbf000000008369353e0000003f05a27c3fb550a8400ad723bc7f40ac405af37bbf000000008369353e0000803f05a27c3f92f5a6400ad723bc5421a440b838793f00000000c2146abe00000000ed108c3f92f5a640cdcc4c3e5421a440b838793f00000000c2146abe0000003fed108c3fd1a5a640cdcc4c3e0e34a440b83879bf00000000c2146a3e0000003fed108c3fd1a5a6400ad723bc0e34a440b83879bf00000000c2146a3e0000803fed108c3f84e9a4400ad723bca8549c407cd4753f0000000000e18ebe00000000197d993f84e9a440cdcc4c3ea8549c407cd4753f0000000000e18ebe0000003f197d993fda9aa440cdcc4c3e846b9c407cd475bf0000000000e18e3e0000003f197d993fda9aa4400ad723bc846b9c407cd475bf0000000000e18e3e0000803f197d993f5583a2400ad723bce6cd94408ad1713f000000009e0ba8be00000000009da63f5583a240cdcc4c3ee6cd94408ad1713f000000009e0ba8be0000003f009da63ff335a240cdcc4c3ec9e894408ad171bf000000009e0ba83e0000003f009da63ff335a2400ad723bcc9e894408ad171bf000000009e0ba83e0000803f009da63f6dc99f400ad723bca48e8d40763d6d3f000000000b63c0be000000004577b33f6dc99f40cdcc4c3ea48e8d40763d6d3f000000000b63c0be0000003f4577b33f837d9f40cdcc4c3e6cad8d40763d6dbf000000000b63c03e0000003f4577b33f837d9f400ad723bc6cad8d40763d6dbf000000000b63c03e0000803f4577b33f6cc29c400ad723bc25988640c227683f00000000dfc6d7be000000008c11c03f6cc29c40cdcc4c3e25988640c227683f00000000dfc6d7be0000003f8c11c03f22789c40cdcc4c3eabba8640c22768bf00000000dfc6d73e0000003f8c11c03f22789c400ad723bcabba8640c22768bf00000000dfc6d73e0000803f8c11c03f107599400ad723bc9bd67f4034a1623f00000000111eeebe000000008670cc3f10759940cdcc4c3e9bd67f4034a1623f00000000111eeebe0000003f8670cc3f8a2c9940cdcc4c3e6711804034a162bf00000000111eee3e0000003f8670cc3f8a2c99400ad723bc6711804034a162bf00000000111eee3e0000803f8670cc3f21e895400ad723bc44117340dcba5c3f0000000086ab01bf00000000e197d83f21e89540cdcc4c3e44117340dcba5c3f0000000086ab01bf0000003fe197d83f7fa19540cdcc4c3e41647340dcba5cbf0000000086ab013f0000003fe197d83f7fa195400ad723bc41647340dcba5cbf0000000086ab013f0000803fe197d83f5b2292400ad723bc93e066407685563f00000000adb30bbf00000000628ae43f5b229240cdcc4c3e93e066407685563f00000000adb30bbf0000003f628ae43fb5dd9140cdcc4c3efc396740768556bf00000000adb30b3f0000003f628ae43fb5dd91400ad723bcfc396740768556bf00000000adb30b3f0000803f628ae43f662a8e400ad723bc29445b40d410503f000000007f2515bf00000000df49f03f662a8e40cdcc4c3e29445b40d410503f000000007f2515bf0000003fdf49f03fd1e78d40cdcc4c3e9da35b40d41050bf000000007f25153f0000003fdf49f03fd1e78d400ad723bc9da35b40d41050bf000000007f25153f0000803fdf49f03fc2068a400ad723bc1b3b5040566b493f00000000df011ebf0000000047d7fb3fc2068a40cdcc4c3e1b3b5040566b493f00000000df011ebf0000003f47d7fb3f4ec68940cdcc4c3e3ba05040566b49bf00000000df011e3f0000003f47d7fb3f4ec689400ad723bc3ba05040566b49bf00000000df011e3f0000803f47d7fb3fc2bd85400ad723bcfdc345409ea1423f00000000034c26bf0000000059990340c2bd8540cdcc4c3efdc345409ea1423f00000000034c26bf0000003f599903407a7f8540cdcc4c3e6b2e46409ea142bf00000000034c263f0000003f599903407a7f85400ad723bc6b2e46409ea142bf00000000034c263f0000803f59990340895581400ad723bc05dd3b405ebe3b3f0000000017092ebf00000000b42d094089558140cdcc4c3e05dd3b405ebe3b3f0000000017092ebf0000003fb42d094075198140cdcc4c3e674c3c405ebe3bbf0000000017092e3f0000003fb42d0940751981400ad723bc674c3c405ebe3bbf0000000017092e3f0000803fb42d094000a879400ad723bc1a8432401cca343f00000000b93f35bf00000000f8a70e4000a87940cdcc4c3e1a8432401cca343f00000000b93f35bf0000003ff8a70e404b347940cdcc4c3e1af832401cca34bf00000000b93f353f0000003ff8a70e404b3479400ad723bc1af832401cca34bf00000000b93f353f0000803ff8a70e40ae7d70400ad723bceab6294040cb2d3f0000000099f73bbf0000000012071440ae7d7040cdcc4c3eeab6294040cb2d3f0000000099f73bbf0000003f12071440740e7040cdcc4c3e362f2a4040cb2dbf0000000099f73b3f0000003f12071440740e70400ad723bc362f2a4040cb2dbf0000000099f73b3f0000803f12071440123767400ad723bc0173214004c6263f000000001b3942bf000000009c49194012376740cdcc4c3e0173214004c6263f000000001b3942bf0000003f9c49194056cc6640cdcc4c3e4eef214004c626bf000000001b39423f0000003f9c49194056cc66400ad723bc4eef214004c626bf000000001b39423f0000803f9c491940aede5d400ad723bcd6b5194064bc1f3f00000000170d48bf00000000df6d1e40aede5d40cdcc4c3ed6b5194064bc1f3f00000000170d48bf0000003fdf6d1e4072785d40cdcc4c3ede351a4064bc1fbf00000000170d483f0000003fdf6d1e4072785d400ad723bcde351a4064bc1fbf00000000170d483f0000803fdf6d1e40887e54400ad723bccd7c12401aae183f000000009b7c4dbf00000000e7712340887e5440cdcc4c3ecd7c12401aae183f000000009b7c4dbf0000003fe7712340d11c5440cdcc4c3e500013401aae18bf000000009b7c4d3f0000003fe7712340d11c54400ad723bc500013401aae18bf000000009b7c4d3f0000803fe771234038204b400ad723bc53c50b40a098113f00000000b89052bf000000007c53284038204b40cdcc4c3e53c50b40a098113f00000000b89052bf0000003f7c53284009c34a40cdcc4c3e164c0c40a09811bf00000000b890523f0000003f7c53284009c34a400ad723bc164c0c40a09811bf00000000b890523f0000803f7c532840cfcc41400ad723bcce8c0540de760a3f000000007b5257bf0000000030102d40cfcc4140cdcc4c3ece8c0540de760a3f000000007b5257bf0000003f30102d4031744140cdcc4c3e9d160640de760abf000000007b52573f0000003f30102d40317441400ad723bc9d160640de760abf000000007b52573f0000803f30102d40cc8c38400ad723bc6fa1ff3ffa40033f00000000b7ca5bbf0000000062a53140cc8c3840cdcc4c3e6fa1ff3ffa40033f00000000b7ca5bbf0000003f62a53140cb383840cdcc4c3e625d0040fa4003bf00000000b7ca5b3f0000003f62a53140cb3838400ad723bc625d0040fa4003bf00000000b7ca5b3f0000803f62a5314004682f400ad723bc101df53f8cd7f73e00000000110260bf000000004610364004682f40cdcc4c3e101df53f8cd7f73e00000000110260bf0000003f46103640b5182f40cdcc4c3eca3bf63f8cd7f7be000000001102603f0000003f46103640b5182f400ad723bcca3bf63f8cd7f7be000000001102603f0000803f46103640816526400ad723bca887eb3ffccfe83e00000000e60064bf00000000e34d3a4081652640cdcc4c3ea887eb3ffccfe83e00000000e60064bf0000003fe34d3a40011b2640cdcc4c3e80abec3ffccfe8be00000000e600643f0000003fe34d3a40011b26400ad723bc80abec3ffccfe8be00000000e600643f0000803fe34d3a40
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 3.9721823, y: 0.095, z: 4.7524605}
-    m_Extent: {x: 1.3767842, y: 0.105000004, z: 2.9123828}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!1 &642513309
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 642513310}
-  - component: {fileID: 642513311}
-  m_Layer: 0
-  m_Name: Wheel RL Collider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &642513310
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 642513309}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0.1, y: -0.024999999, z: -0.14}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1104095457}
-  m_RootOrder: 10
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!146 &642513311
-WheelCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 642513309}
-  m_Center: {x: 0, y: 0, z: 0}
-  m_Radius: 0.035
-  m_SuspensionSpring:
-    spring: 35
-    damper: 5
-    targetPosition: 0.9
-  m_SuspensionDistance: 0.01
-  m_ForceAppPointDistance: 0
-  m_Mass: 0.1
-  m_WheelDampingRate: 0.25
-  m_ForwardFriction:
-    m_ExtremumSlip: 0.4
-    m_ExtremumValue: 1
-    m_AsymptoteSlip: 0.8
-    m_AsymptoteValue: 0.5
-    m_Stiffness: 2
-  m_SidewaysFriction:
-    m_ExtremumSlip: 0.2
-    m_ExtremumValue: 1
-    m_AsymptoteSlip: 0.5
-    m_AsymptoteValue: 0.75
-    m_Stiffness: 2
-  m_Enabled: 1
---- !u!1 &653260035
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 653260038}
-  - component: {fileID: 653260036}
-  m_Layer: 8
-  m_Name: Post-process Volume
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &653260036
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 653260035}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8b9a305e18de0c04dbd257a21cd47087, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  sharedProfile: {fileID: 11400000, guid: 680922c45b9bfe14085ea8a49e7d23dd, type: 2}
-  isGlobal: 1
-  blendDistance: 0
-  weight: 1
-  priority: 0
---- !u!4 &653260038
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 653260035}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!43 &663229291
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 540
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 124
-    localAABB:
-      m_Center: {x: -2.7720082, y: 0.095, z: 1.4293681}
-      m_Extent: {x: 4.6398673, y: 0.105000004, z: 1.8535441}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 124
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 3968
-    _typelessdata: 0316ef3f0ad723bc50895140fccfe83e00000000e60064bf00000000e34d3a400316ef3fcdcc4c3e50895140fccfe83e00000000e60064bf0000003fe34d3a400381ee3fcdcc4c3e3c1b5240fccfe8be00000000e600643f0000003fe34d3a400381ee3f0ad723bc3c1b5240fccfe8be00000000e600643f0000803fe34d3a409f79e03f0ad723bc57f14d402cf2dc3e00000000c5ef66bf000000006f093f409f79e03fcdcc4c3e57f14d402cf2dc3e00000000c5ef66bf0000003f6f093f4037ecdf3fcdcc4c3e24854e402cf2dcbe00000000c5ef663f0000003f6f093f4037ecdf3f0ad723bc24854e402cf2dcbe00000000c5ef663f0000803f6f093f4016bfcc3f0ad723bca1544940b88fd53e00000000bbaa68bf00000000a7e3444016bfcc3fcdcc4c3ea1544940b88fd53e00000000bbaa68bf0000003fa7e344406836cc3fcdcc4c3e89e94940b88fd5be00000000bbaa683f0000003fa7e344406836cc3f0ad723bc89e94940b88fd5be00000000bbaa683f0000803fa7e34440ed9cb43f0ad723bcdce04340dc80d03e00000000a1cf69bf000000009ac94b40ed9cb43fcdcc4c3edce04340dc80d03e00000000a1cf69bf0000003f9ac94b407c17b43fcdcc4c3e80764440dc80d0be00000000a1cf693f0000003f9ac94b407c17b43f0ad723bc80764440dc80d0be00000000a1cf693f0000803f9ac94b40ea8c983f0ad723bc69b13d40d8cdcc3e0000000083a06abf000000001fa85340ea8c983fcdcc4c3e69b13d40d8cdcc3e0000000083a06abf0000003f1fa85340d709983fcdcc4c3e92473e40d8cdccbe0000000083a06a3f0000003f1fa85340d709983f0ad723bc92473e40d8cdccbe0000000083a06a3f0000803f1fa853407be1713f0ad723bce5da3640f0f6c93e00000000d63d6bbf00000000fd6b5c407be1713fcdcc4c3ee5da3640f0f6c93e00000000d63d6bbf0000003ffd6b5c40f8de703fcdcc4c3e73713740f0f6c9be00000000d63d6b3f0000003ffd6b5c40f8de703f0ad723bc73713740f0f6c9be00000000d63d6b3f0000803ffd6b5c40563e2c3f0ad723bc066f2f4088b3c73e000000005fb96bbf00000000e7016640563e2c3fcdcc4c3e066f2f4088b3c73e000000005fb96bbf0000003fe7016640b83e2b3fcdcc4c3ee305304088b3c7be000000005fb96b3f0000003fe7016640b83e2b3f0ad723bce305304088b3c7be000000005fb96b3f0000803fe7016640aba4c13e0ad723bc087e274074d7c53e00000000a71d6cbf000000008f567040aba4c13ecdcc4c3e087e274074d7c53e00000000a71d6cbf0000003f8f56704032aabf3ecdcc4c3e2515284074d7c5be00000000a71d6c3f0000003f8f56704032aabf3e0ad723bc2515284074d7c5be00000000a71d6c3f0000803f8f5670407ccb813d0ad723bc6b171f40ec45c43e000000005e716cbf000000009c567b407ccb813dcdcc4c3e6b171f40ec45c43e000000005e716cbf0000003f9c567b4050e3733dcdcc4c3ebeae1f40ec45c4be000000005e716c3f0000003f9c567b4050e3733d0ad723bcbeae1f40ec45c4be000000005e716c3f0000803f9c567b4084e889be0ad723bc334a164098ebc23e00000000f6b86cbf000000005b77834084e889becdcc4c3e334a164098ebc23e00000000f6b86cbf0000003f5b77834084db8bbecdcc4c3eb3e1164098ebc2be00000000f6b86c3f0000003f5b77834084db8bbe0ad723bcb3e1164098ebc2be00000000f6b86c3f0000803f5b778340e3201ebf0ad723bc22250d40b0bac13e0000000080f76cbf00000000c2858940e3201ebfcdcc4c3e22250d40b0bac13e0000000080f76cbf0000003fc2858940dc181fbfcdcc4c3ecabc0d40b0bac1be0000000080f76c3f0000003fc2858940dc181fbf0ad723bccabc0d40b0bac1be0000000080f76c3f0000803fc285894004b87abf0ad723bcd1b6034038a9c03e00000000342f6dbf00000000d2cc8f4004b87abfcdcc4c3ed1b6034038a9c03e00000000342f6dbf0000003fd2cc8f409fae7bbfcdcc4c3e9e4e044038a9c0be00000000342f6d3f0000003fd2cc8f409fae7bbf0ad723bc9e4e044038a9c0be00000000342f6d3f0000803fd2cc8f402813adbf0ad723bc701bf43f98afbf3e00000000c0616dbf00000000e04296402813adbfcdcc4c3e701bf43f98afbf3e00000000c0616dbf0000003fe0429640d68dadbfcdcc4c3e4a4bf53f98afbfbe00000000c0616d3f0000003fe0429640d68dadbf0ad723bc4a4bf53f98afbfbe00000000c0616d3f0000803fe042964076ecddbf0ad723bc7a70e03fc4c7be3e000000006c906dbf000000003bde9c4076ecddbfcdcc4c3e7a70e03fc4c7be3e000000006c906dbf0000003f3bde9c409066debfcdcc4c3e90a0e13fc4c7bebe000000006c906d3f0000003f3bde9c409066debf0ad723bc90a0e13fc4c7bebe000000006c906d3f0000803f3bde9c4062cf07c00ad723bc7389cc3fe4ecbd3e0000000040bc6dbf000000003495a34062cf07c0cdcc4c3e7389cc3fe4ecbd3e0000000040bc6dbf0000003f3495a340280c08c0cdcc4c3ec0b9cd3fe4ecbdbe0000000040bc6d3f0000003f3495a340280c08c00ad723bcc0b9cd3fe4ecbdbe0000000040bc6d3f0000803f3495a34089f020c00ad723bc0083b83fd01abd3e0000000018e66dbf000000001a5eaa4089f020c0cdcc4c3e0083b83fd01abd3e0000000018e66dbf0000003f1a5eaa400c2d21c0cdcc4c3e83b3b93fd01abdbe0000000018e66d3f0000003f1a5eaa400c2d21c00ad723bc83b3b93fd01abdbe0000000018e66d3f0000803f1a5eaa403a353ac00ad723bcb579a43fec4dbc3e00000000ba0e6ebf00000000402fb1403a353ac0cdcc4c3eb579a43fec4dbc3e00000000ba0e6ebf0000003f402fb1407c713ac0cdcc4c3e6caaa53fec4dbcbe00000000ba0e6e3f0000003f402fb1407c713ac00ad723bc6caaa53fec4dbcbe00000000ba0e6e3f0000803f402fb140027953c00ad723bc1e8a903fb882bb3e00000000d0366ebf00000000f4feb740027953c0cdcc4c3e1e8a903fb882bb3e00000000d0366ebf0000003ff4feb74002b553c0cdcc4c3e08bb913fb882bbbe00000000d0366e3f0000003ff4feb74002b553c00ad723bc08bb913fb882bbbe00000000d0366e3f0000803ff4feb74074976cc00ad723bc9ba1793fc0b5ba3e000000000b5f6ebf0000000088c3be4074976cc0cdcc4c3e9ba1793fc0b5ba3e000000000b5f6ebf0000003f88c3be4034d36cc0cdcc4c3ed6037c3fc0b5babe000000000b5f6e3f0000003f88c3be4034d36cc00ad723bcd6037c3fc0b5babe000000000b5f6e3f0000803f88c3be400db682c00ad723bca5d4523f84e3b93e000000001a886ebf000000004c73c5400db682c0cdcc4c3ea5d4523f84e3b93e000000001a886ebf0000003f4c73c540cbd382c0cdcc4c3e4937553f84e3b9be000000001a886e3f0000003f4c73c540cbd382c00ad723bc4937553f84e3b9be000000001a886e3f0000803f4c73c5403de98ec00ad723bc86e62c3f1008b93e00000000bdb26ebf000000008e04cc403de98ec0cdcc4c3e86e62c3f1008b93e00000000bdb26ebf0000003f8e04cc40d8068fc0cdcc4c3e96492f3f1008b9be00000000bdb26e3f0000003f8e04cc40d8068fc00ad723bc96492f3f1008b9be00000000bdb26e3f0000803f8e04cc4003d39ac00ad723bc7e10083fe81eb83e00000000d0df6ebf00000000a06dd24003d39ac0cdcc4c3e7e10083fe81eb83e00000000d0df6ebf0000003fa06dd24078f09ac0cdcc4c3e03740a3fe81eb8be00000000d0df6e3f0000003fa06dd24078f09ac00ad723bc03740a3fe81eb8be00000000d0df6e3f0000803fa06dd2400c61a6c00ad723bcd417c93e6c22b73e000000004f106fbf00000000d4a4d8400c61a6c0cdcc4c3ed417c93e6c22b73e000000004f106fbf0000003fd4a4d840597ea6c0cdcc4c3ed6dfcd3e6c22b7be000000004f106f3f0000003fd4a4d840597ea6c00ad723bcd6dfcd3e6c22b7be000000004f106f3f0000803fd4a4d840ef80b1c00ad723bcce24853e8c0bb63e0000000088456fbf0000000076a0de40ef80b1c0cdcc4c3ece24853e8c0bb63e0000000088456fbf0000003f76a0de40109eb1c0cdcc4c3ee0ed893e8c0bb6be0000000088456f3f0000003f76a0de40109eb1c00ad723bce0ed893e8c0bb6be0000000088456f3f0000803f76a0de402e20bcc00ad723bc6077093e00d1b43e0000000020816fbf00000000de56e4402e20bcc0cdcc4c3e6077093e00d1b43e0000000020816fbf0000003fde56e4401c3dbcc0cdcc4c3ee80b133e00d1b4be0000000020816f3f0000003fde56e4401c3dbcc00ad723bce80b133e00d1b4be0000000020816f3f0000803fde56e440152cc6c00ad723bc8013853c0066b33e0000000057c56fbf0000000058bee940152cc6c0cdcc4c3e8013853c0066b33e0000000057c56fbf0000003f58bee940c948c6c0cdcc4c3e80cdd13c0066b3be0000000057c56f3f0000003f58bee940c948c6c00ad723bc80cdd13c0066b3be0000000057c56f3f0000803f58bee940af91cfc00ad723bcd891bebd34b8b13e000000004e1570bf0000000038cdee40af91cfc0cdcc4c3ed891bebd34b8b13e000000004e1570bf0000003f38cdee401faecfc0cdcc4c3ef05cabbd34b8b1be000000004e15703f0000003f38cdee401faecfc00ad723bcf05cabbd34b8b1be000000004e15703f0000803f38cdee408e3dd8c00ad723bc885945be10acaf3e00000000aa7570bf00000000d279f3408e3dd8c0cdcc4c3e885945be10acaf3e00000000aa7570bf0000003fd279f340aa59d8c0cdcc4c3e3cbb3bbe10acafbe00000000aa75703f0000003fd279f340aa59d8c00ad723bc3cbb3bbe10acafbe00000000aa75703f0000803fd279f3407e1be0c00ad723bc2e4b90be4416ad3e0000000088ed70bf000000007abaf7407e1be0c0cdcc4c3e2e4b90be4416ad3e0000000088ed70bf0000003f7abaf7403037e0c0cdcc4c3ea2798bbe4416adbe0000000088ed703f0000003f7abaf7403037e0c00ad723bca2798bbe4416adbe0000000088ed703f0000803f7abaf740c915e7c00ad723bcfefbb7bebcada93e00000000838871bf000000008a85fb40c915e7c0cdcc4c3efefbb7bebcada93e00000000838871bf0000003f8a85fb40ef30e7c0cdcc4c3e5827b3bebcada9be000000008388713f0000003f8a85fb40ef30e7c00ad723bc5827b3bebcada9be000000008388713f0000803f8a85fb40b213edc00ad723bc9a2dd9bef4eca43e00000000d95a72bf000000005ad1fe40b213edc0cdcc4c3e9a2dd9bef4eca43e00000000d95a72bf0000003f5ad1fe40162eedc0cdcc4c3ebe54d4bef4eca4be00000000d95a723f0000003f5ad1fe40162eedc00ad723bcbe54d4bef4eca4be00000000d95a723f0000803f5ad1fe40
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -2.7720082, y: 0.095, z: 1.4293681}
-    m_Extent: {x: 4.6398673, y: 0.105000004, z: 1.8535441}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!43 &680000683
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 540
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 124
-    localAABB:
-      m_Center: {x: -1.428297, y: 0.095, z: 9.055265}
-      m_Extent: {x: 1.0324535, y: 0.105000004, z: 1.71176}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 124
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 3968
-    _typelessdata: fdabcabe0ad723bca7f4eb4068a23a3e000000004cb67bbf000000004335c541fdabcabecdcc4c3ea7f4eb4068a23a3e000000004cb67bbf0000003f4335c541e19acbbecdcc4c3e3445ec4068a23abe000000004cb67b3f0000003f4335c541e19acbbe0ad723bc3445ec4068a23abe000000004cb67b3f0000803f4335c5412f4a14bf0ad723bcbe2beb4090a5a73d000000000f247fbf00000000bc9ec5412f4a14bfcdcc4c3ebe2beb4090a5a73d000000000f247fbf0000003fbc9ec541d47f14bfcdcc4c3e637deb4090a5a7bd000000000f247f3f0000003fbc9ec541d47f14bf0ad723bc637deb4090a5a7bd000000000f247f3f0000803fbc9ec541480843bf0ad723bcfefdea40e001aebc0000000038f17fbf000000003d04c641480843bfcdcc4c3efefdea40e001aebc0000000038f17fbf0000003f3d04c6415dfa42bfcdcc4c3ee54feb40e001ae3c0000000038f17f3f0000003f3d04c6415dfa42bf0ad723bce54feb40e001ae3c0000000038f17f3f0000803f3d04c641c50871bf0ad723bcc669eb40a0c8ffbd00000000dbfe7dbf000000008866c641c50871bfcdcc4c3ec669eb40a0c8ffbd00000000dbfe7dbf0000003f8866c641ebb670bfcdcc4c3e0dbbeb40a0c8ff3d00000000dbfe7d3f0000003f8866c641ebb670bf0ad723bc0dbbeb40a0c8ff3d00000000dbfe7d3f0000803f8866c641cae28ebf0ad723bce569ec40306e68be000000006e5179bf000000004dc6c641cae28ebfcdcc4c3ee569ec40306e68be000000006e5179bf0000003f4dc6c6416a988ebfcdcc4c3eadb9ec40306e683e000000006e51793f0000003f4dc6c6416a988ebf0ad723bcadb9ec40306e683e000000006e51793f0000803f4dc6c6413262a4bf0ad723bcf7f5ed406cb6a6be000000008d0c72bf000000002424c7413262a4bfcdcc4c3ef7f5ed406cb6a6be000000008d0c72bf0000003f2424c7417ff7a3bfcdcc4c3e6c43ee406cb6a63e000000008d0c723f0000003f2424c7417ff7a3bf0ad723bc6c43ee406cb6a63e000000008d0c723f0000803f2424c7417acfb8bf0ad723bc6c03f04004a9d6be00000000fb6968bf000000008c80c7417acfb8bfcdcc4c3e6c03f04004a9d6be00000000fb6968bf0000003f8c80c7411846b8bfcdcc4c3ecc4df04004a9d63e00000000fb69683f0000003f8c80c7411846b8bf0ad723bccc4df04004a9d63e00000000fb69683f0000803f8c80c741c402ccbf0ad723bc7886f240bcbf01bf00000000faae5cbf00000000eedbc741c402ccbfcdcc4c3e7886f240bcbf01bf00000000faae5cbf0000003feedbc741b05ccbbfcdcc4c3e17cdf240bcbf013f00000000faae5c3f0000003feedbc741b05ccbbf0ad723bc17cdf240bcbf013f00000000faae5c3f0000803feedbc74159dfddbf0ad723bc4873f540b07016bf00000000d9214fbf000000009d36c84159dfddbfcdcc4c3e4873f540b07016bf00000000d9214fbf0000003f9d36c841c91eddbfcdcc4c3e90b5f540b070163f00000000d9214f3f0000003f9d36c841c91eddbf0ad723bc90b5f540b070163f00000000d9214f3f0000803f9d36c8418451eebf0ad723bc9cbef840775129bf000000003a0240bf00000000d590c8418451eebfcdcc4c3e9cbef840775129bf000000003a0240bf0000003fd590c841ca78edbfcdcc4c3e0efcf8407751293f000000003a02403f0000003fd590c841ca78edbf0ad723bc0efcf8407751293f000000003a02403f0000803fd590c841004cfdbf0ad723bc725efc40fb5b3abf0000000059842fbf00000000c2eac841004cfdbfcdcc4c3e725efc40fb5b3abf0000000059842fbf0000003fc2eac841765dfcbfcdcc4c3e9c96fc40fb5b3a3f0000000059842f3f0000003fc2eac841765dfcbf0ad723bc9c96fc40fb5b3a3f0000000059842f3f0000803fc2eac841966205c00ad723bc0d2500412f9349bf00000000ffce1dbf000000008444c941966205c0cdcc4c3e0d2500412f9349bf00000000ffce1dbf0000003f8444c94194e104c0cdcc4c3e4d3e00412f93493f00000000ffce1d3f0000003f8444c94194e104c00ad723bc4d3e00412f93493f00000000ffce1d3f0000803f8444c941355a0bc00ad723bc1a3d024180fc56bf0000000035fc0abf000000002d9ec941355a0bc0cdcc4c3e1a3d024180fc56bf0000000035fc0abf0000003f2d9ec9419ed00ac0cdcc4c3e5753024180fc563f0000000035fc0a3f0000003f2d9ec9419ed00ac00ad723bc5753024180fc563f0000000035fc0a3f0000803f2d9ec941068810c00ad723bc37740441c29a62bf000000009736eebe00000000cbf7c941068810c0cdcc4c3e37740441c29a62bf000000009736eebe0000003fcbf7c941fff60fc0cdcc4c3e45870441c29a623f000000009736ee3e0000003fcbf7c941fff60fc00ad723bc45870441c29a623f000000009736ee3e0000803fcbf7c941d9e514c00ad723bc9bc70641246a6cbf00000000b868c4be000000006951ca41d9e514c0cdcc4c3e9bc70641246a6cbf00000000b868c4be0000003f6951ca418b4e14c0cdcc4c3e51d70641246a6c3f00000000b868c43e0000003f6951ca418b4e14c00ad723bc51d70641246a6c3f00000000b868c43e0000803f6951ca41a06b18c00ad723bca6340941915d74bf00000000fa9898be0000000014abca41a06b18c0cdcc4c3ea6340941915d74bf00000000fa9898be0000003f14abca413bcf17c0cdcc4c3edb400941915d743f00000000fa98983e0000003f14abca413bcf17c00ad723bcdb400941915d743f00000000fa98983e0000803f14abca412a0f1bc00ad723bc99b80b416e5d7abf0000000017ab55be00000000de04cb412a0f1bc0cdcc4c3e99b80b416e5d7abf0000000017ab55be0000003fde04cb41ef6e1ac0cdcc4c3e25c10b416e5d7a3f0000000017ab553e0000003fde04cb41ef6e1ac00ad723bc25c10b416e5d7a3f0000000017ab553e0000803fde04cb4138c41cc00ad723bc57500e41f0477ebf00000000caefecbd00000000e35ecb4138c41cc0cdcc4c3e57500e41f0477ebf00000000caefecbd0000003fe35ecb417a211cc0cdcc4c3e14550e41f0477e3f00000000caefec3d0000003fe35ecb417a211cc00ad723bc14550e41f0477e3f00000000caefec3d0000803fe35ecb41f07c1dc00ad723bc11f8104174f37fbf00000000c547a0bc000000004cb9cb41f07c1dc0cdcc4c3e11f8104174f37fbf00000000c547a0bc0000003f4cb9cb4121d91cc0cdcc4c3edef8104174f37f3f00000000c547a03c0000003f4cb9cb4121d91cc00ad723bcdef8104174f37f3f00000000c547a03c0000803f4cb9cb41d82a1dc00ad723bc07ab13412a337fbf00000000ffcba13d000000005314cc41d82a1dc0cdcc4c3e07ab13412a337fbf00000000ffcba13d0000003f5314cc4184871cc0cdcc4c3ecba713412a337f3f00000000ffcba1bd0000003f5314cc4184871cc00ad723bccba713412a337f3f00000000ffcba1bd0000803f5314cc413ac01bc00ad723bc556316411ede7bbf00000000ef3e373e000000004470cc413ac01bc0cdcc4c3e556316411ede7bbf00000000ef3e373e0000003f4470cc41081f1bc0cdcc4c3e015c16411ede7b3f00000000ef3e37be0000003f4470cc41081f1bc00ad723bc015c16411ede7b3f00000000ef3e37be0000803f4470cc41023219c00ad723bce41919414cd875bf00000000c4c68e3e0000000085cdcc41023219c0cdcc4c3ee41919414cd875bf00000000c4c68e3e0000003f85cdcc41aa9418c0cdcc4c3e780e19414cd8753f00000000c4c68ebe0000003f85cdcc41aa9418c00ad723bc780e19414cd8753f00000000c4c68ebe0000803f85cdcc41ae7915c00ad723bc96c61b414c1c6dbf000000003b06c13e00000000912ccd41ae7915c0cdcc4c3e96c61b414c1c6dbf000000003b06c13e0000003f912ccd41eee114c0cdcc4c3e25b71b414c1c6d3f000000003b06c1be0000003f912ccd41eee114c00ad723bc25b71b414c1c6d3f000000003b06c1be0000803f912ccd41f69610c00ad723bcb2601e416fc361bf00000000fd62f13e00000000fc8dcd41f69610c0cdcc4c3eb2601e416fc361bf00000000fd62f13e0000003ffc8dcd41790610c0cdcc4c3e624d1e416fc3613f00000000fd62f1be0000003ffc8dcd41790610c00ad723bc624d1e416fc3613f00000000fd62f1be0000803ffc8dcd419d900ac00ad723bc80df2041cb0954bf000000004e710f3f0000000070f2cd419d900ac0cdcc4c3e80df2041cb0954bf000000004e710f3f0000003f70f2cd41e9080ac0cdcc4c3e8dc82041cb09543f000000004e710fbf0000003f70f2cd41e9080ac00ad723bc8dc82041cb09543f000000004e710fbf0000803f70f2cd41167403c00ad723bcff3a23418a4c44bf000000003553243f00000000af5ace41167403c0cdcc4c3eff3a23418a4c44bf000000003553243f0000003faf5ace4174f602c0cdcc4c3eb42023418a4c443f00000000355324bf0000003faf5ace4174f602c00ad723bcb42023418a4c443f00000000355324bf0000803faf5ace41cca7f6bf0ad723bc816c2541d40133bf000000006902373f0000000089c7ce41cca7f6bfcdcc4c3e816c2541d40133bf000000006902373f0000003f89c7ce41aac2f5bfcdcc4c3e394f2541d401333f00000000690237bf0000003f89c7ce41aac2f5bf0ad723bc394f2541d401333f00000000690237bf0000803f89c7ce415f8ae4bf0ad723bc176f2741c2ac20bf000000003a4c473f00000000dc39cf415f8ae4bfcdcc4c3e176f2741c2ac20bf000000003a4c473f0000003fdc39cf41b6bce3bfcdcc4c3e344f2741c2ac203f000000003a4c47bf0000003fdc39cf41b6bce3bf0ad723bc344f2741c2ac203f000000003a4c47bf0000803fdc39cf41f9b9d0bf0ad723bca03f2941eccf0dbf00000000d321553f0000000093b2cf41f9b9d0bfcdcc4c3ea03f2941eccf0dbf00000000d321553f0000003f93b2cf417404d0bfcdcc4c3e861d2941eccf0d3f00000000d32155bf0000003f93b2cf417404d0bf0ad723bc861d2941eccf0d3f00000000d32155bf0000803f93b2cf41d25bbbbf0ad723bc98dc2a41eac3f5be000000004b94603f000000009a32d041d25bbbbfcdcc4c3e98dc2a41eac3f5be000000004b94603f0000003f9a32d04188bebabfcdcc4c3ea9b82a41eac3f53e000000004b9460bf0000003f9a32d04188bebabf0ad723bca9b82a41eac3f53e000000004b9460bf0000803f9a32d041368da4bf0ad723bcbc452c418a8bd0be000000003dcd693f00000000e1bad041368da4bfcdcc4c3ebc452c418a8bd0be000000003dcd693f0000003fe1bad041be07a4bfcdcc4c3e53202c418a8bd03e000000003dcd69bf0000003fe1bad041be07a4bf0ad723bc53202c418a8bd03e000000003dcd69bf0000803fe1bad041
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -1.428297, y: 0.095, z: 9.055265}
-    m_Extent: {x: 1.0324535, y: 0.105000004, z: 1.71176}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!1 &692098977
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 692098978}
-  - component: {fileID: 692098980}
-  - component: {fileID: 692098979}
-  m_Layer: 5
-  m_Name: Turn
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &692098978
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 692098977}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 283461116}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.67, y: 0.99}
-  m_AnchorMax: {x: 1, y: 0.99}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 100}
-  m_Pivot: {x: 0, y: 1}
---- !u!114 &692098979
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 692098977}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 2100000, guid: 63fd4656f763f4c1c8d8d300a7726304, type: 2}
-  m_Color: {r: 0, g: 0.7411765, b: 0, a: 1}
-  m_RaycastTarget: 0
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 30
-    m_FontStyle: 1
-    m_BestFit: 0
-    m_MinSize: 0
-    m_MaxSize: 40
-    m_Alignment: 0
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: T 0
---- !u!222 &692098980
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 692098977}
-  m_CullTransparentMesh: 0
---- !u!1 &716379423
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 716379424}
-  - component: {fileID: 716379428}
-  - component: {fileID: 716379427}
-  - component: {fileID: 716379426}
-  - component: {fileID: 716379425}
-  m_Layer: 0
-  m_Name: segment 5
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &716379424
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 716379423}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1236410749}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &716379425
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 716379423}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1011930731}
---- !u!114 &716379426
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 716379423}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &716379427
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 716379423}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &716379428
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 716379423}
-  m_Mesh: {fileID: 1011930731}
---- !u!1 &723254065
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 723254066}
-  - component: {fileID: 723254070}
-  - component: {fileID: 723254069}
-  - component: {fileID: 723254068}
-  - component: {fileID: 723254067}
-  m_Layer: 0
-  m_Name: segment 4
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &723254066
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 723254065}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 539737851}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &723254067
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 723254065}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1203178056}
---- !u!114 &723254068
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 723254065}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &723254069
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 723254065}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &723254070
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 723254065}
-  m_Mesh: {fileID: 1203178056}
---- !u!1 &744834143
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 744834144}
-  - component: {fileID: 744834146}
-  - component: {fileID: 744834145}
-  m_Layer: 5
-  m_Name: Throttle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &744834144
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 744834143}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 283461116}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.33, y: 0.99}
-  m_AnchorMax: {x: 0.67, y: 0.99}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 100}
-  m_Pivot: {x: 0, y: 1}
---- !u!114 &744834145
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 744834143}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 2100000, guid: 63fd4656f763f4c1c8d8d300a7726304, type: 2}
-  m_Color: {r: 0, g: 0.7411765, b: 0, a: 1}
-  m_RaycastTarget: 0
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 30
-    m_FontStyle: 1
-    m_BestFit: 0
-    m_MinSize: 0
-    m_MaxSize: 40
-    m_Alignment: 0
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: F 0
---- !u!222 &744834146
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 744834143}
-  m_CullTransparentMesh: 0
---- !u!1 &759451617
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 759451618}
-  - component: {fileID: 759451620}
-  - component: {fileID: 759451619}
-  m_Layer: 0
-  m_Name: Tire
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &759451618
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 759451617}
-  m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.07000003, y: 0.020000014, z: 0.07000003}
-  m_Children: []
-  m_Father: {fileID: 35796932}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
---- !u!23 &759451619
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 759451617}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: c05de7c865075334786e6a47a543af72, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &759451620
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 759451617}
-  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
---- !u!43 &790231893
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 540
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 124
-    localAABB:
-      m_Center: {x: -0.26652777, y: 0.095, z: 7.2257757}
-      m_Extent: {x: 0.13113822, y: 0.105000004, z: 0.16598248}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 124
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 3968
-    _typelessdata: 980382be0ad723bc2b24e2403ab633bf000000004651363f0000000090c8ba41980382becdcc4c3e2b24e2403ab633bf000000004651363f0000003f90c8ba41f0d67cbecdcc4c3ed4e9e1403ab6333f00000000465136bf0000003f90c8ba41f0d67cbe0ad723bcd4e9e1403ab6333f00000000465136bf0000803f90c8ba41d42265be0ad723bc662ae3405c0c41bf00000000ca21283f00000000b034bb41d42265becdcc4c3e662ae3405c0c41bf00000000ca21283f0000003fb034bb41046a5dbecdcc4c3e99f4e2405c0c413f00000000ca2128bf0000003fb034bb41046a5dbe0ad723bc99f4e2405c0c413f00000000ca2128bf0000803fb034bb4126004dbe0ad723bcf019e440eeaa4dbf00000000ad6f183f00000000669cbb4126004dbecdcc4c3ef019e440eeaa4dbf00000000ad6f183f0000003f669cbb411ec644becdcc4c3e28e9e340eeaa4d3f00000000ad6f18bf0000003f669cbb411ec644be0ad723bc28e9e340eeaa4d3f00000000ad6f18bf0000803f669cbb4104a13abe0ad723bc63f1e440fa5359bf00000000514b073f000000002c00bc4104a13abecdcc4c3e63f1e440fa5359bf00000000514b073f0000003f2c00bc4194ef31becdcc4c3e18c6e440fa53593f00000000514b07bf0000003f2c00bc4194ef31be0ad723bc18c6e440fa53593f00000000514b07bf0000803f2c00bc414c0c2dbe0ad723bca1b0e54024cb63bf0000000018a2e93e000000007860bc414c0c2dbecdcc4c3ea1b0e54024cb63bf0000000018a2e93e0000003f7860bc41b4ef23becdcc4c3e3f8be54024cb633f0000000018a2e9be0000003f7860bc41b4ef23be0ad723bc3f8be54024cb633f0000000018a2e9be0000803f7860bc41305823be0ad723bc9858e640bad86cbf00000000f150c23e00000000b8bdbc41305823becdcc4c3e9858e640bad86cbf00000000f150c23e0000003fb8bdbc41e4de19becdcc4c3e8139e640bad86c3f00000000f150c2be0000003fb8bdbc41e4de19be0ad723bc8139e640bad86c3f00000000f150c2be0000803fb8bdbc4180b31cbe0ad723bc41ebe640b64c74bf00000000cc04993e000000005918bd4180b31cbecdcc4c3e41ebe640b64c74bf00000000cc04993e0000003f5918bd41e0ed12becdcc4c3ec6d2e640b64c743f00000000cc0499be0000003f5918bd41e0ed12be0ad723bcc6d2e640b64c743f00000000cc0499be0000803f5918bd41706c18be0ad723bc2c6be740af007abf00000000e2595c3e00000000b970bd41706c18becdcc4c3e2c6be740af007abf00000000e2595c3e0000003fb970bd41686c0ebecdcc4c3e8b59e740af007a3f00000000e2595cbe0000003fb970bd41686c0ebe0ad723bc8b59e740af007a3f00000000e2595cbe0000803fb970bd4114f415be0ad723bc58dbe74011d97dbf00000000857f043e0000000034c7bd4114f415becdcc4c3e58dbe74011d97dbf00000000857f043e0000003f34c7bd41accc0bbecdcc4c3ebfd0e74011d97d3f00000000857f04be0000003f34c7bd41accc0bbe0ad723bcbfd0e74011d97d3f00000000857f04be0000803f34c7bd41a4de14be0ad723bcc73ee84015c57fbf00000000bba52d3d000000001b1cbe41a4de14becdcc4c3ec73ee84015c57fbf00000000bba52d3d0000003f1b1cbe4190a30abecdcc4c3e4e3be84015c57f3f00000000bba52dbd0000003f1b1cbe4190a30abe0ad723bc4e3be84015c57f3f00000000bba52dbd0000803f1b1cbe4150e014be0ad723bc4498e840d1bd7fbf00000000260938bd00000000b96fbe4150e014becdcc4c3e4498e840d1bd7fbf00000000260938bd0000003fb96fbe4184a50abecdcc4c3ef29be840d1bd7f3f000000002609383d0000003fb96fbe4184a50abe0ad723bcf29be840d1bd7f3f000000002609383d0000803fb96fbe41c0c715be0ad723bc37eae84094c47dbf00000000c6ed06be0000000051c2be41c0c715becdcc4c3e37eae84094c47dbf00000000c6ed06be0000003f51c2be412ca10bbecdcc4c3e03f5e84094c47d3f00000000c6ed063e0000003f51c2be412ca10bbe0ad723bc03f5e84094c47d3f00000000c6ed063e0000803f51c2be41f47717be0ad723bc7836e940e3e079bf0000000007985ebe000000001d14bf41f47717becdcc4c3e7836e940e3e079bf0000000007985ebe0000003f1d14bf4130790dbecdcc4c3e4748e940e3e0793f0000000007985e3e0000003f1d14bf4130790dbe0ad723bc4748e940e3e0793f0000000007985e3e0000803f1d14bf4184e119be0ad723bc5a7ee940821e74bf00000000a42a9abe000000005465bf4184e119becdcc4c3e5a7ee940821e74bf00000000a42a9abe0000003f5465bf41bc1d10becdcc4c3e0597e940821e743f00000000a42a9a3e0000003f5465bf41bc1d10be0ad723bc0597e940821e743f00000000a42a9a3e0000803f5465bf417cfd1cbe0ad723bcb4c2e940c88b6cbf0000000070c6c3be0000000027b6bf417cfd1cbecdcc4c3eb4c2e940c88b6cbf0000000070c6c3be0000003f27b6bf41448713becdcc4c3e07e2e940c88b6c3f0000000070c6c33e0000003f27b6bf41448713be0ad723bc07e2e940c88b6c3f0000000070c6c33e0000803f27b6bf416cc920be0ad723bcfc03ea407b3863bf00000000a6daebbe00000000c506c0416cc920becdcc4c3efc03ea407b3863bf00000000a6daebbe0000003fc506c041b0b217becdcc4c3eb829ea407b38633f00000000a6daeb3e0000003fc506c041b0b217be0ad723bcb829ea407b38633f00000000a6daeb3e0000803fc506c041104625be0ad723bc6542ea404e3558bf000000009e1309bf000000005757c041104625becdcc4c3e6542ea404e3558bf000000009e1309bf0000003f5757c04118a01cbecdcc4c3e436eea404e35583f000000009e13093f0000003f5757c04118a01cbe0ad723bc436eea404e35583f000000009e13093f0000803f5757c0416a772abe0ad723bc0c7eea4004944bbf000000003a371bbf000000000aa8c0416a772abecdcc4c3e0c7eea4004944bbf000000003a371bbf0000003f0aa8c041c65222becdcc4c3eb7afea4004944b3f000000003a371b3f0000003f0aa8c041c65222be0ad723bcb7afea4004944b3f000000003a371b3f0000803f0aa8c041406730be0ad723bc07b7ea401c683dbf0000000059392cbf000000000bf9c041406730becdcc4c3e07b7ea401c683dbf0000000059392cbf0000003f0bf9c041b8d328becdcc4c3e24eeea401c683d3f0000000059392c3f0000003f0bf9c041b8d328be0ad723bc24eeea401c683d3f0000000059392c3f0000803f0bf9c041be2837be0ad723bc7dedea4006c82dbf0000000095fa3bbf00000000874ac141be2837becdcc4c3e7dedea4006c82dbf0000000095fa3bbf0000003f874ac1413a3530becdcc4c3ea429eb4006c82d3f0000000095fa3b3f0000003f874ac1413a3530be0ad723bca429eb4006c82d3f0000000095fa3b3f0000803f874ac1414cdd3ebe0ad723bca721eb4092ce1cbf00000000e85a4abf00000000b19cc1414cdd3ebecdcc4c3ea721eb4092ce1cbf00000000e85a4abf0000003fb19cc141989738becdcc4c3e6862eb4092ce1c3f00000000e85a4a3f0000003fb19cc141989738be0ad723bc6862eb4092ce1c3f00000000e85a4a3f0000803fb19cc141dab847be0ad723bcba53eb40489c0abf00000000663a57bf00000000c1efc141dab847becdcc4c3eba53eb40489c0abf00000000663a57bf0000003fc1efc1417c2d42becdcc4c3e9998eb40489c0a3f00000000663a573f0000003fc1efc1417c2d42be0ad723bc9998eb40489c0a3f00000000663a573f0000803fc1efc141620652be0ad723bcc683eb4092b1eebe00000000667a62bf00000000f643c241620652becdcc4c3ec683eb4092b1eebe00000000667a62bf0000003ff643c24146404dbecdcc4c3e3fcceb4092b1ee3e00000000667a623f0000003ff643c24146404dbe0ad723bc3fcceb4092b1ee3e00000000667a623f0000803ff643c241a5295ebe0ad723bc8ab1eb40c666c6be0000000094ff6bbf000000009299c241a5295ebecdcc4c3e8ab1eb40c666c6be0000000094ff6bbf0000003f9299c241d5315abecdcc4c3e0ffdeb40c666c63e0000000094ff6b3f0000003f9299c241d5315abe0ad723bc0ffdeb40c666c63e0000000094ff6b3f0000803f9299c241f39d6cbe0ad723bc36dceb4046c59cbe0000000048b473bf00000000e5f0c241f39d6cbecdcc4c3e36dceb4046c59cbe0000000048b473bf0000003fe5f0c241497b69becdcc4c3e322aec4046c59c3e0000000048b4733f0000003fe5f0c241497b69be0ad723bc322aec4046c59c3e0000000048b4733f0000803fe5f0c24151f47dbe0ad723bc2102ec403c8f64be00000000aa8a79bf00000000414ac34151f47dbecdcc4c3e2102ec403c8f64be00000000aa8a79bf0000003f414ac34134ab7bbecdcc4c3efc51ec403c8f643e00000000aa8a793f0000003f414ac34134ab7bbe0ad723bcfc51ec403c8f643e00000000aa8a793f0000803f414ac341726589be0ad723bcb020ec40d4e00ebe00000000ec7e7dbf0000000004a6c341726589becdcc4c3eb020ec40d4e00ebe00000000ec7e7dbf0000003f04a6c34190ae88becdcc4c3ece71ec40d4e00e3e00000000ec7e7d3f0000003f04a6c34190ae88be0ad723bcce71ec40d4e00e3e00000000ec7e7d3f0000803f04a6c341a9e295be0ad723bc1534ec40802d66bd0000000070987fbf000000009004c441a9e295becdcc4c3e1534ec40802d66bd0000000070987fbf0000003f9004c441019995becdcc4c3ee085ec40802d663d0000000070987f3f0000003f9004c441019995be0ad723bce085ec40802d663d0000000070987f3f0000803f9004c4416ac0a4be0ad723bc6437ec404068d33c000000002dea7fbf000000005366c4416ac0a4becdcc4c3e6437ec404068d33c000000002dea7fbf0000003f5366c4413de2a4becdcc4c3e4989ec404068d3bc000000002dea7f3f0000003f5366c4413de2a4be0ad723bc4989ec404068d3bc000000002dea7f3f0000803f5366c4419845b6be0ad723bc9124ec40a02ed83d00000000dc917ebf00000000bccbc4419845b6becdcc4c3e9124ec40a02ed83d00000000dc917ebf0000003fbccbc441f4cfb6becdcc4c3e0876ec40a02ed8bd00000000dc917e3f0000003fbccbc441f4cfb6be0ad723bc0876ec40a02ed8bd00000000dc917e3f0000803fbccbc441fdabcabe0ad723bca7f4eb4068a23a3e000000004cb67bbf000000004335c541fdabcabecdcc4c3ea7f4eb4068a23a3e000000004cb67bbf0000003f4335c541e19acbbecdcc4c3e3445ec4068a23abe000000004cb67b3f0000003f4335c541e19acbbe0ad723bc3445ec4068a23abe000000004cb67b3f0000803f4335c541
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -0.26652777, y: 0.095, z: 7.2257757}
-    m_Extent: {x: 0.13113822, y: 0.105000004, z: 0.16598248}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!1 &809433125
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 809433128}
-  - component: {fileID: 809433127}
-  m_Layer: 0
-  m_Name: Track
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &809433127
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 809433125}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1a85c5879d519aa4ab2ebbf42591149a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  nodes:
-  - position: {x: 4.3995404, y: 0, z: 7.4836774}
-    direction: {x: 5.033156, y: 0, z: 4.722517}
-    up: {x: 0, y: 1, z: 0}
-    scale: {x: 1, y: 1}
-    roll: 0
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - position: {x: 2.2316287, y: 0, z: 2.5614948}
-    direction: {x: 1.0769825, y: 0, z: 1.9719954}
-    up: {x: 0, y: 1, z: 0}
-    scale: {x: 1, y: 1}
-    roll: 0
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - position: {x: -7.150958, y: 0, z: -1.181535}
-    direction: {x: -8.946831, y: 0, z: -1.7925923}
-    up: {x: 0, y: 1, z: 0}
-    scale: {x: 1, y: 1}
-    roll: 0
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - position: {x: -9.656566, y: 0, z: 2.9990437}
-    direction: {x: -9.621862, y: 0, z: 6.0029373}
-    up: {x: 0, y: 1, z: 0}
-    scale: {x: 1, y: 1}
-    roll: 0
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - position: {x: -6.212388, y: 0, z: 8.969346}
-    direction: {x: -4.736134, y: 0, z: 9.367167}
-    up: {x: 0, y: 1, z: 0}
-    scale: {x: 1, y: 1}
-    roll: 0
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - position: {x: -4.375961, y: 0, z: 6.939442}
-    direction: {x: -5.023926, y: 0, z: 5.919211}
-    up: {x: 0, y: 1, z: 0}
-    scale: {x: 1, y: 1}
-    roll: 0
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - position: {x: -6.632031, y: 0, z: 3.4877656}
-    direction: {x: -7.294585, y: 0, z: 2.5051184}
-    up: {x: 0, y: 1, z: 0}
-    scale: {x: 1, y: 1}
-    roll: 0
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - position: {x: -5.125697, y: 0, z: 2.1865432}
-    direction: {x: -3.9142761, y: 0, z: 3.0855324}
-    up: {x: 0, y: 1, z: 0}
-    scale: {x: 1, y: 1}
-    roll: 0
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - position: {x: 0.31468582, y: 0, z: 6.4900513}
-    direction: {x: 1.0833551, y: 0, z: 7.247735}
-    up: {x: 0, y: 1, z: 0}
-    scale: {x: 1, y: 1}
-    roll: 0
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - position: {x: -0.54347414, y: 0, z: 8.170048}
-    direction: {x: -1.5783143, y: 0, z: 7.9782248}
-    up: {x: 0, y: 1, z: 0}
-    scale: {x: 1, y: 1}
-    roll: 0
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - position: {x: -0.95563453, y: 0, z: 10.027262}
-    direction: {x: 0.29973042, y: 0, z: 10.587138}
-    up: {x: 0, y: 1, z: 0}
-    scale: {x: 1, y: 1}
-    roll: 0
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - position: {x: 4.3995404, y: 0, z: 7.4836774}
-    direction: {x: 5.033156, y: 0, z: 4.722517}
-    up: {x: 0, y: 1, z: 0}
-    scale: {x: 1, y: 1}
-    roll: 0
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  curves:
-  - n1:
-      position: {x: 4.3995404, y: 0, z: 7.4836774}
-      direction: {x: 5.033156, y: 0, z: 4.722517}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    n2:
-      position: {x: 2.2316287, y: 0, z: 2.5614948}
-      direction: {x: 1.0769825, y: 0, z: 1.9719954}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - n1:
-      position: {x: 2.2316287, y: 0, z: 2.5614948}
-      direction: {x: 1.0769825, y: 0, z: 1.9719954}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    n2:
-      position: {x: -7.150958, y: 0, z: -1.181535}
-      direction: {x: -8.946831, y: 0, z: -1.7925923}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - n1:
-      position: {x: -7.150958, y: 0, z: -1.181535}
-      direction: {x: -8.946831, y: 0, z: -1.7925923}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    n2:
-      position: {x: -9.656566, y: 0, z: 2.9990437}
-      direction: {x: -9.621862, y: 0, z: 6.0029373}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - n1:
-      position: {x: -9.656566, y: 0, z: 2.9990437}
-      direction: {x: -9.621862, y: 0, z: 6.0029373}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    n2:
-      position: {x: -6.212388, y: 0, z: 8.969346}
-      direction: {x: -4.736134, y: 0, z: 9.367167}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - n1:
-      position: {x: -6.212388, y: 0, z: 8.969346}
-      direction: {x: -4.736134, y: 0, z: 9.367167}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    n2:
-      position: {x: -4.375961, y: 0, z: 6.939442}
-      direction: {x: -5.023926, y: 0, z: 5.919211}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - n1:
-      position: {x: -4.375961, y: 0, z: 6.939442}
-      direction: {x: -5.023926, y: 0, z: 5.919211}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    n2:
-      position: {x: -6.632031, y: 0, z: 3.4877656}
-      direction: {x: -7.294585, y: 0, z: 2.5051184}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - n1:
-      position: {x: -6.632031, y: 0, z: 3.4877656}
-      direction: {x: -7.294585, y: 0, z: 2.5051184}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    n2:
-      position: {x: -5.125697, y: 0, z: 2.1865432}
-      direction: {x: -3.9142761, y: 0, z: 3.0855324}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - n1:
-      position: {x: -5.125697, y: 0, z: 2.1865432}
-      direction: {x: -3.9142761, y: 0, z: 3.0855324}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    n2:
-      position: {x: 0.31468582, y: 0, z: 6.4900513}
-      direction: {x: 1.0833551, y: 0, z: 7.247735}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - n1:
-      position: {x: 0.31468582, y: 0, z: 6.4900513}
-      direction: {x: 1.0833551, y: 0, z: 7.247735}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    n2:
-      position: {x: -0.54347414, y: 0, z: 8.170048}
-      direction: {x: -1.5783143, y: 0, z: 7.9782248}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - n1:
-      position: {x: -0.54347414, y: 0, z: 8.170048}
-      direction: {x: -1.5783143, y: 0, z: 7.9782248}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    n2:
-      position: {x: -0.95563453, y: 0, z: 10.027262}
-      direction: {x: 0.29973042, y: 0, z: 10.587138}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  - n1:
-      position: {x: -0.95563453, y: 0, z: 10.027262}
-      direction: {x: 0.29973042, y: 0, z: 10.587138}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    n2:
-      position: {x: 4.3995404, y: 0, z: 7.4836774}
-      direction: {x: 5.033156, y: 0, z: 4.722517}
-      up: {x: 0, y: 1, z: 0}
-      scale: {x: 1, y: 1}
-      roll: 0
-      Changed:
-        m_PersistentCalls:
-          m_Calls: []
-        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-          Culture=neutral, PublicKeyToken=null
-    Changed:
-      m_PersistentCalls:
-        m_Calls: []
-      m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-        Culture=neutral, PublicKeyToken=null
-  Length: 58.82646
-  isLoop: 1
-  CurveChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
---- !u!4 &809433128
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 809433125}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1614957931}
-  - {fileID: 588167376}
-  - {fileID: 139875388}
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!43 &813903962
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 540
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 124
-    localAABB:
-      m_Center: {x: -4.830466, y: 0.095, z: 4.7727394}
-      m_Extent: {x: 1.138257, y: 0.105000004, z: 1.7378027}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 124
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 3968
-    _typelessdata: 264d6cc00ad723bc702ad0407619583f00000000863f09bf000000005e438241264d6cc0cdcc4c3e702ad0407619583f00000000863f09bf0000003f5e43824173d76cc0cdcc4c3e5c56d040761958bf00000000863f093f0000003f5e43824173d76cc00ad723bc5c56d040761958bf00000000863f093f0000803f5e438241c98a70c00ad723bcd7d4cc4058f1573f00000000997e09bf00000000dec08241c98a70c0cdcc4c3ed7d4cc4058f1573f00000000997e09bf0000003fdec08241fd1471c0cdcc4c3ed700cd4058f157bf00000000997e093f0000003fdec08241fd1471c00ad723bcd700cd4058f157bf00000000997e093f0000803fdec0824155e674c00ad723bce469c940bccb573f000000009bb909bf00000000af41834155e674c0cdcc4c3ee469c940bccb573f000000009bb909bf0000003faf418341717075c0cdcc4c3ef695c940bccb57bf000000009bb9093f0000003faf418341717075c00ad723bcf695c940bccb57bf000000009bb9093f0000803faf418341b05d79c00ad723bc25ebc5404ca8573f000000000cf109bf0000000093c58341b05d79c0cdcc4c3e25ebc5404ca8573f000000000cf109bf0000003f93c58341b5e779c0cdcc4c3e4917c6404ca857bf000000000cf1093f0000003f93c58341b5e779c00ad723bc4917c6404ca857bf000000000cf1093f0000803f93c58341ddee7dc00ad723bc305ac240ac86573f0000000091250abf000000004c4c8441ddee7dc0cdcc4c3e305ac240ac86573f0000000091250abf0000003f4c4c8441cd787ec0cdcc4c3e6686c240ac8657bf0000000091250a3f0000003f4c4c8441cd787ec00ad723bc6686c240ac8657bf0000000091250a3f0000803f4c4c8441e04b81c00ad723bc97b8be40a666573f000000007d570abf000000009bd58441e04b81c0cdcc4c3e97b8be40a666573f000000007d570abf0000003f9bd58441cd9081c0cdcc4c3edce4be40a66657bf000000007d570a3f0000003f9bd58441cd9081c00ad723bcdce4be40a66657bf000000007d570a3f0000803f9bd5844129ab83c00ad723bcf307bb40e647573f000000004f870abf000000004361854129ab83c0cdcc4c3ef307bb40e647573f000000004f870abf0000003f436185410cf083c0cdcc4c3e4734bb40e64757bf000000004f870a3f0000003f436185410cf083c00ad723bc4734bb40e64757bf000000004f870a3f0000803f436185413b1486c00ad723bcdb49b7404c2a573f0000000044b50abf0000000006ef85413b1486c0cdcc4c3edb49b7404c2a573f0000000044b50abf0000003f06ef8541155986c0cdcc4c3e3e76b7404c2a57bf0000000044b50a3f0000003f06ef8541155986c00ad723bc3e76b7404c2a57bf0000000044b50a3f0000803f06ef8541168688c00ad723bcea7fb340900d573f00000000cee10abf00000000a47e8641168688c0cdcc4c3eea7fb340900d573f00000000cee10abf0000003fa47e8641e7ca88c0cdcc4c3e5cacb340900d57bf00000000cee10a3f0000003fa47e8641e7ca88c00ad723bc5cacb340900d57bf00000000cee10a3f0000803fa47e8641a4ff8ac00ad723bcb8abaf4092f1563f00000000200d0bbf00000000e10f8741a4ff8ac0cdcc4c3eb8abaf4092f1563f00000000200d0bbf0000003fe10f87416c448bc0cdcc4c3e37d8af4092f156bf00000000200d0b3f0000003fe10f87416c448bc00ad723bc37d8af4092f156bf00000000200d0b3f0000803fe10f8741e37f8dc00ad723bcddceab4026d6563f000000007a370bbf000000007fa28741e37f8dc0cdcc4c3eddceab4026d6563f000000007a370bbf0000003f7fa28741a2c48dc0cdcc4c3e69fbab4026d656bf000000007a370b3f0000003f7fa28741a2c48dc00ad723bc69fbab4026d656bf000000007a370b3f0000803f7fa28741c80590c00ad723bcfaeaa74026bb563f000000001e610bbf000000003e368841c80590c0cdcc4c3efaeaa74026bb563f000000001e610bbf0000003f3e3688417f4a90c0cdcc4c3e9417a84026bb56bf000000001e610b3f0000003f3e3688417f4a90c00ad723bc9417a84026bb56bf000000001e610b3f0000803f3e368841459092c00ad723bca601a4406ca0563f000000003e8a0bbf00000000e1ca8841459092c0cdcc4c3ea601a4406ca0563f000000003e8a0bbf0000003fe1ca8841f3d492c0cdcc4c3e4e2ea4406ca056bf000000003e8a0b3f0000003fe1ca8841f3d492c00ad723bc4e2ea4406ca056bf000000003e8a0b3f0000803fe1ca88414e1e95c00ad723bc7d14a040d885563f0000000016b30bbf000000002a6089414e1e95c0cdcc4c3e7d14a040d885563f0000000016b30bbf0000003f2a608941f46295c0cdcc4c3e3141a040d88556bf0000000016b30b3f0000003f2a608941f46295c00ad723bc3141a040d88556bf0000000016b30b3f0000803f2a608941dbae97c00ad723bc1a259c404a6b563f00000000d4db0bbf00000000dbf58941dbae97c0cdcc4c3e1a259c404a6b563f00000000d4db0bbf0000003fdbf5894178f397c0cdcc4c3edb519c404a6b56bf00000000d4db0b3f0000003fdbf5894178f397c00ad723bcdb519c404a6b56bf00000000d4db0b3f0000803fdbf58941df409ac00ad723bc1e359840a650563f00000000a4040cbf00000000b58b8a41df409ac0cdcc4c3e1e359840a650563f00000000a4040cbf0000003fb58b8a4174859ac0cdcc4c3eec619840a65056bf00000000a4040c3f0000003fb58b8a4174859ac00ad723bcec619840a65056bf00000000a4040c3f0000803fb58b8a4150d39cc00ad723bc1e469440c235563f00000000c72d0cbf000000007b218b4150d39cc0cdcc4c3e1e469440c235563f00000000c72d0cbf0000003f7b218b41dc179dc0cdcc4c3ef9729440c23556bf00000000c72d0c3f0000003f7b218b41dc179dc00ad723bcf9729440c23556bf00000000c72d0c3f0000803f7b218b4120659fc00ad723bcba5990407e1a563f0000000069570cbf00000000eeb68b4120659fc0cdcc4c3eba5990407e1a563f0000000069570cbf0000003feeb68b41a3a99fc0cdcc4c3ea28690407e1a56bf0000000069570c3f0000003feeb68b41a3a99fc00ad723bca28690407e1a56bf0000000069570c3f0000803feeb68b414af5a1c00ad723bc8b718c40b0fe553f00000000c4810cbf00000000d04b8c414af5a1c0cdcc4c3e8b718c40b0fe553f00000000c4810cbf0000003fd04b8c41c439a2c0cdcc4c3e819e8c40b0fe55bf00000000c4810c3f0000003fd04b8c41c439a2c00ad723bc819e8c40b0fe55bf00000000c4810c3f0000803fd04b8c41bb82a4c00ad723bc2d8f88403ee2553f000000000dad0cbf00000000e4df8c41bb82a4c0cdcc4c3e2d8f88403ee2553f000000000dad0cbf0000003fe4df8c412cc7a4c0cdcc4c3e31bc88403ee255bf000000000dad0c3f0000003fe4df8c412cc7a4c00ad723bc31bc88403ee255bf000000000dad0c3f0000803fe4df8c416e0ca7c00ad723bc3cb4844000c5553f000000007bd90cbf00000000eb728d416e0ca7c0cdcc4c3e3cb4844000c5553f000000007bd90cbf0000003feb728d41d650a7c0cdcc4c3e4ee1844000c555bf000000007bd90c3f0000003feb728d41d650a7c00ad723bc4ee1844000c555bf000000007bd90c3f0000803feb728d415991a9c00ad723bc54e28040c8a6553f000000004e070dbf00000000a6048e415991a9c0cdcc4c3e54e28040c8a6553f000000004e070dbf0000003fa6048e41b8d5a9c0cdcc4c3e750f8140c8a655bf000000004e070d3f0000003fa6048e41b8d5a9c00ad723bc750f8140c8a655bf000000004e070d3f0000803fa6048e417010acc00ad723bc17367a406087553f00000000d6360dbf00000000d8948e417010acc0cdcc4c3e17367a406087553f00000000d6360dbf0000003fd8948e41c554acc0cdcc4c3e77907a40608755bf00000000d6360d3f0000003fd8948e41c554acc00ad723bc77907a40608755bf00000000d6360d3f0000803fd8948e41ab88aec00ad723bcf7bf72409866553f000000005f680dbf0000000044238f41ab88aec0cdcc4c3ef7bf72409866553f000000005f680dbf0000003f44238f41f5ccaec0cdcc4c3e771a7340986655bf000000005f680d3f0000003f44238f41f5ccaec00ad723bc771a7340986655bf000000005f680d3f0000803f44238f4100f9b0c00ad723bc83656b403644553f000000002f9c0dbf00000000a9af8f4100f9b0c0cdcc4c3e83656b403644553f000000002f9c0dbf0000003fa9af8f413f3db1c0cdcc4c3e24c06b40364455bf000000002f9c0d3f0000003fa9af8f413f3db1c00ad723bc24c06b40364455bf000000002f9c0d3f0000803fa9af8f416960b3c00ad723bcdc296440fc1f553f00000000b4d20dbf00000000cc3990416960b3c0cdcc4c3edc296440fc1f553f00000000b4d20dbf0000003fcc3990419ca4b3c0cdcc4c3ea1846440fc1f55bf00000000b4d20d3f0000003fcc3990419ca4b3c00ad723bca1846440fc1f55bf00000000b4d20d3f0000803fcc399041debdb5c00ad723bc35105d408ef9543f00000000600c0ebf000000006cc19041debdb5c0cdcc4c3e35105d408ef9543f00000000600c0ebf0000003f6cc190410502b6c0cdcc4c3e1e6b5d408ef954bf00000000600c0e3f0000003f6cc190410502b6c00ad723bc1e6b5d408ef954bf00000000600c0e3f0000803f6cc190415a10b8c00ad723bcb51b5640a0d0543f00000000ab490ebf000000004d4691415a10b8c0cdcc4c3eb51b5640a0d0543f00000000ab490ebf0000003f4d4691417454b8c0cdcc4c3ec6765640a0d054bf00000000ab490e3f0000003f4d4691417454b8c00ad723bcc6765640a0d054bf00000000ab490e3f0000803f4d469141d956bac00ad723bc804f4f40caa4543f00000000288b0ebf0000000030c89141d956bac0cdcc4c3e804f4f40caa4543f00000000288b0ebf0000003f30c89141e59abac0cdcc4c3ebbaa4f40caa454bf00000000288b0e3f0000003f30c89141e59abac00ad723bcbbaa4f40caa454bf00000000288b0e3f0000803f30c891415990bcc00ad723bcb1ae48408075543f0000000099d10ebf00000000d84692415990bcc0cdcc4c3eb1ae48408075543f0000000099d10ebf0000003fd846924156d4bcc0cdcc4c3e180a4940807554bf0000000099d10e3f0000003fd846924156d4bcc00ad723bc180a4940807554bf0000000099d10e3f0000803fd8469241dbbbbec00ad723bc663c42403642543f00000000c91d0fbf0000000005c29241dbbbbec0cdcc4c3e663c42403642543f00000000c91d0fbf0000003f05c29241c7ffbec0cdcc4c3efe974240364254bf00000000c91d0f3f0000003f05c29241c7ffbec00ad723bcfe974240364254bf00000000c91d0f3f0000803f05c29241
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -4.830466, y: 0.095, z: 4.7727394}
-    m_Extent: {x: 1.138257, y: 0.105000004, z: 1.7378027}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!43 &821324673
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 360
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 93
-    localAABB:
-      m_Center: {x: -1.428297, y: 0, z: 9.055265}
-      m_Extent: {x: 1.0324535, y: 0, z: 1.71176}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000030003000400010002000100040004000500020004000300060006000700040005000400070007000800050007000600090009000a000700080007000a000a000b0008000a0009000c000c000d000a000b000a000d000d000e000b000d000c000f000f0010000d000e000d001000100011000e0010000f00120012001300100011001000130013001400110013001200150015001600130014001300160016001700140016001500180018001900160017001600190019001a001700190018001b001b001c0019001a0019001c001c001d001a001c001b001e001e001f001c001d001c001f001f0020001d001f001e002100210022001f0020001f002200220023002000220021002400240025002200230022002500250026002300250024002700270028002500260025002800280029002600280027002a002a002b002800290028002b002b002c0029002b002a002d002d002e002b002c002b002e002e002f002c002e002d003000300031002e002f002e003100310032002f0031003000330033003400310032003100340034003500320034003300360036003700340035003400370037003800350037003600390039003a003700380037003a003a003b0038003a0039003c003c003d003a003b003a003d003d003e003b003d003c003f003f0040003d003e003d004000400041003e0040003f00420042004300400041004000430043004400410043004200450045004600430044004300460046004700440046004500480048004900460047004600490049004a004700490048004b004b004c0049004a0049004c004c004d004a004c004b004e004e004f004c004d004c004f004f0050004d004f004e005100510052004f0050004f005200520053005000520051005400540055005200530052005500550056005300550054005700570058005500560055005800580059005600580057005a005a005b005800590058005b005b005c005900
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 93
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 2976
-    _typelessdata: fdabcabe00000000a7f4eb40000000800000803f00000000000000004335c5411f210bbf0000000084b80241000000800000803f000000000000003f4335c54140ec30bf00000000b4760f41000000800000803f000000000000803f4335c5412f4a14bf00000000be2beb40000000800000803f0000000000000000bc9ec541964325bf000000007f800241000000800000803f000000000000003fbc9ec541fd3c36bf000000001f6b0f41000000800000803f000000000000803fbc9ec541480843bf00000000fefdea40000000000000803f00000000000000003d04c641b7a03ebf0000000002740241000000000000803f000000000000003f3d04c64126393abf0000000005690f41000000000000803f000000000000803f3d04c641c50871bf00000000c669eb40000000000000803f00000000000000008866c641db2257bf00000000ab900241000000000000803f000000000000003f8866c641f13c3dbf00000000736c0f41000000000000803f000000000000803f8866c641cae28ebf00000000e569ec40000000000000803f00000000000000004dc6c64163b46ebf000000001cd40241000000000000803f000000000000003f4dc6c64132a33fbf0000000046730f41000000000000803f000000000000803f4dc6c6413262a4bf00000000f7f5ed40000000000000803f00000000000000002424c741d09f82bf00000000f03b0341000000000000803f000000000000003f2424c741ddba41bf00000000e57c0f41000000000000803f000000000000803f2424c7417acfb8bf000000006c03f040000000000000803f00000000000000008c80c7417e578dbf00000000ccc50341000000000000803f000000000000003f8c80c74104bf43bf00000000e2890f41000000000000803f000000000000803f8c80c741c402ccbf000000007886f240000000000000803f0000000000000000eedbc741657697bf000000004b6f0441000000000000803f000000000000003feedbc7410cd445bf000000005a9b0f41000000000000803f000000000000803feedbc74159dfddbf000000004873f540000000000000803f00000000000000009d36c841b6f1a0bf0000000013360541000000000000803f000000000000003f9d36c841260848bf0000000082b20f41000000000000803f000000000000803f9d36c8418451eebf000000009cbef840000000000000803f0000000000000000d590c8419abea9bf00000000bd170641000000000000803f000000000000003fd590c84160574abf000000002cd00f41000000000000803f000000000000803fd590c841004cfdbf00000000725efc40000000000000803f0000000000000000c2eac84144d2b1bf00000000ec110741000000000000803f000000000000003fc2eac84111b14cbf000000009ff40f41000000000000803f000000000000803fc2eac841966205c0000000000d250041000000000000803f00000000000000008444c941e321b9bf0000000040220841000000000000803f000000000000003f8444c94132fd4ebf00000000731f1041000000000000803f000000000000803f8444c941355a0bc0000000001a3d0241000000000000803f00000000000000002d9ec941a2a2bfbf000000005a460941000000000000803f000000000000003f2d9ec941b42151bf000000009a4f1041000000000000803f000000000000803f2d9ec941068810c00000000037740441000000000000803f0000000000000000cbf7c941b049c5bf00000000d67b0a41000000000000803f000000000000003fcbf7c941a90653bf0000000075831041000000000000803f000000000000803fcbf7c941d9e514c0000000009bc70641000000000000803f00000000000000006951ca413a0ccabf0000000056c00b41000000000000803f000000000000003f6951ca41859954bf0000000011b91041000000000000803f000000000000803f6951ca41a06b18c000000000a6340941000000000000803f000000000000000014abca416fdfcdbf000000007b110d41000000000000803f000000000000003f14abca413dcf55bf0000000050ee1041000000000000803f000000000000803f14abca412a0f1bc00000000099b80b41000000000000803f0000000000000000de04cb417eb8d0bf00000000e26c0e41000000000000803f000000000000003fde04cb414ea556bf000000002b211141000000000000803f000000000000803fde04cb4138c41cc00000000057500e41000000000000803f0000000000000000e35ecb41958cd2bf000000002dd00f41000000000000803f000000000000003fe35ecb41752157bf0000000003501141000000000000803f000000000000803fe35ecb41f07c1dc00000000011f81041000000000000803f00000000000000004cb9cb41e050d3bf00000000fb381141000000000000803f000000000000003f4cb9cb41c04f57bf00000000e5791141000000000000803f000000000000803f4cb9cb41d82a1dc00000000007ab1341000000000000803f00000000000000005314cc4190fad2bf00000000eba41241000000000000803f000000000000003f5314cc41e23e57bf00000000cf9e1141000000000000803f000000000000803f5314cc413ac01bc00000000055631641000000000000803f00000000000000004470cc41d07ed1bf000000009e111441000000000000803f000000000000003f4470cc415afa56bf00000000e7bf1141000000000000803f000000000000803f4470cc41023219c000000000e4191941000000000000803f000000000000000085cdcc41d0d2cebf00000000b37c1541000000000000803f000000000000003f85cdcc41398356bf0000000082df1141000000000000803f000000000000803f85cdcc41ae7915c00000000096c61b41000000000000803f0000000000000000912ccd41beebcabf00000000cae31641000000000000803f000000000000003f912ccd413fc855bf00000000fe001241000000000000803f000000000000803f912ccd41f69610c000000000b2601e41000000000000803f0000000000000000fc8dcd41c6bec5bf0000000082441841000000000000803f000000000000003ffc8dcd413f9f54bf0000000052281241000000000000803f000000000000803ffc8dcd419d900ac00000000080df2041000000000000803f000000000000000070f2cd411a41bfbf000000007c9c1941000000000000803f000000000000003f70f2cd41f3c152bf0000000078591241000000000000803f000000000000803f70f2cd41167403c000000000ff3a2341000000000000803f0000000000000000af5ace41e567b7bf0000000058e91a41000000000000803f000000000000003faf5ace413bcf4fbf00000000b1971241000000000000803f000000000000803faf5ace41cca7f6bf00000000816c2541000000000000803f000000000000000089c7ce415628aebf00000000b4281c41000000000000803f000000000000003f89c7ce41c1514bbf00000000e7e41241000000000000803f000000000000803f89c7ce415f8ae4bf00000000176f2741000000000000803f0000000000000000dc39cf419b77a3bf0000000031581d41000000000000803f000000000000003fdc39cf41aec944bf000000004b411341000000000000803f000000000000803fdc39cf41f9b9d0bf00000000a03f2941000000000000803f000000000000000093b2cf41e24a97bf000000006f751e41000000000000803f000000000000003f93b2cf4196b73bbf000000003eab1341000000000000803f000000000000803f93b2cf41d25bbbbf0000000098dc2a41000000000000803f00000000000000009a32d041599789bf000000000c7e1f41000000000000803f000000000000003f9a32d041c0a52fbf00000000801f1441000000000000803f000000000000803f9a32d041368da4bf00000000bc452c41000000000000803f0000000000000000e1bad04177a474bf00000000aa6f2041000000000000803f000000000000003fe1bad041832e20bf0000000098991441000000000000803f000000000000803fe1bad041
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -1.428297, y: 0, z: 9.055265}
-    m_Extent: {x: 1.0324535, y: 0, z: 1.71176}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!1 &821476871
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 821476872}
-  - component: {fileID: 821476876}
-  - component: {fileID: 821476875}
-  - component: {fileID: 821476874}
-  - component: {fileID: 821476873}
-  m_Layer: 0
-  m_Name: segment 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &821476872
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 821476871}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1272024235}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &821476873
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 821476871}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 525209673}
---- !u!114 &821476874
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 821476871}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &821476875
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 821476871}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &821476876
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 821476871}
-  m_Mesh: {fileID: 525209673}
---- !u!43 &834609602
+--- !u!43 &114129735
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5303,693 +772,7 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1 &883720338
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 883720339}
-  m_Layer: 0
-  m_Name: HUD
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &883720339
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 883720338}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 283461116}
-  m_Father: {fileID: 1104095457}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!43 &891327314
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 540
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 124
-    localAABB:
-      m_Center: {x: -5.8255835, y: 0.095, z: 2.8565073}
-      m_Extent: {x: 0.22314286, y: 0.105000004, z: 0.18401957}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 124
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 3968
-    _typelessdata: dbbbbec00ad723bc663c42403642543f00000000c91d0fbf0000000005c29241dbbbbec0cdcc4c3e663c42403642543f00000000c91d0fbf0000003f05c29241c7ffbec0cdcc4c3efe974240364254bf00000000c91d0f3f0000003f05c29241c7ffbec00ad723bcfe974240364254bf00000000c91d0f3f0000803f05c292413d8bbfc00ad723bc5e9b3f40c2815f3f0000000033a5f9be00000000033993413d8bbfc0cdcc4c3e5e9b3f40c2815f3f0000000033a5f9be0000003f03399341c2d2bfc0cdcc4c3e40eb3f40c2815fbf0000000033a5f93e0000003f03399341c2d2bfc00ad723bc40eb3f40c2815fbf0000000033a5f93e0000803f03399341c428c0c00ad723bc552b3d40865c693f000000002c82d2be00000000b0ab9341c428c0c0cdcc4c3e552b3d40865c693f000000002c82d2be0000003fb0ab93417173c0c0cdcc4c3eb26e3d40865c69bf000000002c82d23e0000003fb0ab93417173c0c00ad723bcb26e3d40865c69bf000000002c82d23e0000803fb0ab9341149cc0c00ad723bcd7eb3a40629f713f000000004c2ba9be000000008f1a9441149cc0c0cdcc4c3ed7eb3a40629f713f000000004c2ba9be0000003f8f1a944166e9c0c0cdcc4c3ef9213b40629f71bf000000004c2ba93e0000003f8f1a944166e9c0c00ad723bcf9213b40629f71bf000000004c2ba93e0000803f8f1a944103ecc0c00ad723bc3edb3840cc1f783f000000002c0b7cbe000000001486944103ecc0c0cdcc4c3e3edb3840cc1f783f000000002c0b7cbe0000003f14869441693bc1c0cdcc4c3e91033940cc1f78bf000000002c0b7c3e0000003f14869441693bc1c00ad723bc91033940cc1f78bf000000002c0b7c3e0000803f14869441561ec1c00ad723bc55f73640cabc7c3f0000000042f622be00000000a8ee9441561ec1c0cdcc4c3e55f73640cabc7c3f0000000042f622be0000003fa8ee9441376fc1c0cdcc4c3e68113740cabc7cbf0000000042f6223e0000003fa8ee9441376fc1c00ad723bc68113740cabc7cbf0000000042f6223e0000803fa8ee94410a38c1c00ad723bce23d3540205e7f3f00000000c5db8fbd00000000a95495410a38c1c0cdcc4c3ee23d3540205e7f3f00000000c5db8fbd0000003fa9549541c189c1c0cdcc4c3e64493540205e7fbf00000000c5db8f3d0000003fa9549541c189c1c00ad723bc64493540205e7fbf00000000c5db8f3d0000803fa9549541433dc1c00ad723bc1cad33402cf37f3f00000000fa13a23c000000006ab89541433dc1c0cdcc4c3e1cad33402cf37f3f00000000fa13a23c0000003f6ab895412b8fc1c0cdcc4c3edea933402cf37fbf00000000fa13a2bc0000003f6ab895412b8fc1c00ad723bcdea933402cf37fbf00000000fa13a2bc0000803f6ab89541a331c1c00ad723bcea433240c2707e3f0000000010b7e13d00000000331a9641a331c1c0cdcc4c3eea433240c2707e3f0000000010b7e13d0000003f331a96410f83c1c0cdcc4c3edc313240c2707ebf0000000010b7e1bd0000003f331a96410f83c1c00ad723bcdc313240c2707ebf0000000010b7e1bd0000803f331a96417218c1c00ad723bcf5013140f6ce7a3f00000000b12d4d3e00000000447a96417218c1c0cdcc4c3ef5013140f6ce7a3f00000000b12d4d3e0000003f447a9641b468c1c0cdcc4c3e21e13040f6ce7abf00000000b12d4dbe0000003f447a9641b468c1c00ad723bc21e13040f6ce7abf00000000b12d4dbe0000803f447a9641daf4c0c00ad723bc75e72f401a07753f00000000054a943e00000000d7d89641daf4c0c0cdcc4c3e75e72f401a07753f00000000054a943e0000003fd7d896414343c1c0cdcc4c3e01b82f401a0775bf00000000054a94be0000003fd7d896414343c1c00ad723bc01b82f401a0775bf00000000054a94be0000803fd7d896410bcac0c00ad723bcd0f42e4072126d3f00000000a236c13e00000000213697410bcac0c0cdcc4c3ed0f42e4072126d3f00000000a236c13e0000003f21369741e815c1c0cdcc4c3efbb62e4072126dbf00000000a236c1be0000003f21369741e815c1c00ad723bcfbb62e4072126dbf00000000a236c1be0000803f21369741389bc0c00ad723bc232a2e40b4e9623f000000004709ed3e0000000056929741389bc0c0cdcc4c3e232a2e40b4e9623f000000004709ed3e0000003f56929741d5e3c0c0cdcc4c3e49de2d40b4e962bf000000004709edbe0000003f56929741d5e3c0c00ad723bc49de2d40b4e962bf000000004709edbe0000803f56929741966bc0c00ad723bcac862d40e885563f0000000000b30b3f00000000abed9741966bc0c0cdcc4c3eac862d40e885563f0000000000b30b3f0000003fabed97413cb0c0c0cdcc4c3e442d2d40e88556bf0000000000b30bbf0000003fabed97413cb0c0c00ad723bc442d2d40e88556bf0000000000b30bbf0000803fabed9741103ec0c00ad723bc49082d409ce2473f000000008bf11f3f0000000058489841103ec0c0cdcc4c3e49082d409ce2473f000000008bf11f3f0000003f58489841067ec0c0cdcc4c3eeca12c409ce247bf000000008bf11fbf0000003f58489841067ec0c00ad723bceca12c409ce247bf000000008bf11fbf0000803f58489841fe14c0c00ad723bc16ab2c407e01373f00000000c502333f000000009ea29841fe14c0c0cdcc4c3e16ab2c407e01373f00000000c502333f0000003f9ea298418e4fc0c0cdcc4c3e85382c407e0137bf00000000c50233bf0000003f9ea298418e4fc0c00ad723bc85382c407e0137bf00000000c50233bf0000803f9ea298418af1bfc00ad723bc4a692c4076ef233f00000000e09f443f00000000c6fc98418af1bfc0cdcc4c3e4a692c4076ef233f00000000e09f443f0000003fc6fc98410026c0c0cdcc4c3e73eb2b4076ef23bf00000000e09f44bf0000003fc6fc98410026c0c00ad723bc73eb2b4076ef23bf00000000e09f44bf0000803fc6fc984137d3bfc00ad723bca13b2c40f6c90e3f00000000a27a543f000000002657994137d3bfc0cdcc4c3ea13b2c40f6c90e3f00000000a27a543f0000003f26579941e900c0c0cdcc4c3ea4b32b40f6c90ebf00000000a27a54bf0000003f26579941e900c0c00ad723bca4b32b40f6c90ebf00000000a27a54bf0000803f2657994149b7bfc00ad723bc231a2c401089ef3e000000007e41623f0000000025b2994149b7bfc0cdcc4c3e231a2c401089ef3e000000007e41623f0000003f25b299419cddbfc0cdcc4c3e56892b401089efbe000000007e4162bf0000003f25b299419cddbfc00ad723bc56892b401089efbe000000007e4162bf0000803f25b299416f98bfc00ad723bca8fd2b405458be3e00000000c3a66d3f00000000380e9a416f98bfc0cdcc4c3ea8fd2b405458be3e00000000c3a66d3f0000003f380e9a41e3b6bfc0cdcc4c3e8f652b405458bebe00000000c3a66dbf0000003f380e9a41e3b6bfc00ad723bc8f652b405458bebe00000000c3a66dbf0000803f380e9a41c46ebfc00ad723bc98e12b4024cf8a3e000000008c69763f00000000e56b9a41c46ebfc0cdcc4c3e98e12b4024cf8a3e000000008c69763f0000003fe56b9a41f984bfc0cdcc4c3ee4432b4024cf8abe000000008c6976bf0000003fe56b9a41f984bfc00ad723bce4432b4024cf8abe000000008c6976bf0000803fe56b9a412930bfc00ad723bcddc52b4078cc2b3e00000000155f7c3f00000000c6cb9a412930bfc0cdcc4c3eddc52b4078cc2b3e00000000155f7c3f0000003fc6cb9a41e73dbfc0cdcc4c3e59242b4078cc2bbe00000000155f7cbf0000003fc6cb9a41e73dbfc00ad723bc59242b4078cc2bbe00000000155f7cbf0000803fc6cb9a4132d1bec00ad723bc5fb02b4000c2823d000000004a7a7f3f00000000812e9b4132d1bec0cdcc4c3e5fb02b4000c2823d000000004a7a7f3f0000003f812e9b416dd6bec0cdcc4c3ede0c2b4000c282bd000000004a7a7fbf0000003f812e9b416dd6bec00ad723bcde0c2b4000c282bd000000004a7a7fbf0000803f812e9b414a46bec00ad723bcc2ad2b4050e21dbd000000004ccf7f3f00000000ce949b414a46bec0cdcc4c3ec2ad2b4050e21dbd000000004ccf7f3f0000003fce949b412143bec0cdcc4c3e0a0a2b4050e21d3d000000004ccf7fbf0000003fce949b412143bec00ad723bc0a0a2b4050e21d3d000000004ccf7fbf0000803fce949b41f884bdc00ad723bc15d12b40e0bf0cbe00000000f9917d3f000000006dff9b41f884bdc0cdcc4c3e15d12b40e0bf0cbe00000000f9917d3f0000003f6dff9b41b579bdc0cdcc4c3ecc2e2b40e0bf0c3e00000000f9917dbf0000003f6dff9b41b579bdc00ad723bccc2e2b40e0bf0c3e00000000f9917dbf0000803f6dff9b41e484bcc00ad723bc9b322c4088c96cbe00000000cd0f793f00000000296f9c41e484bcc0cdcc4c3e9b322c4088c96cbe00000000cd0f793f0000003f296f9c41f271bcc0cdcc4c3e35932b4088c96c3e00000000cd0f79bf0000003f296f9c41f271bcc00ad723bc35932b4088c96c3e00000000cd0f79bf0000803f296f9c418740bbc00ad723bce8ed2c40462ca3be00000000bba6723f00000000d2e49c418740bbc0cdcc4c3ee8ed2c40462ca3be00000000bba6723f0000003fd2e49c416b26bbc0cdcc4c3e9c522c40462ca33e00000000bba672bf0000003fd2e49c416b26bbc00ad723bc9c522c40462ca33e00000000bba672bf0000803fd2e49c4154b5b9c00ad723bce91f2e40ee52ccbe000000004cbb6a3f0000000039619d4154b5b9c0cdcc4c3ee91f2e40ee52ccbe000000004cbb6a3f0000003f39619d41a394b9c0cdcc4c3eae892d40ee52cc3e000000004cbb6abf0000003f39619d41a394b9c00ad723bcae892d40ee52cc3e000000004cbb6abf0000803f39619d4184e3b7c00ad723bc17e52f403aacf1be00000000d8af613f0000000034e59d4184e3b7c0cdcc4c3e17e52f403aacf1be00000000d8af613f0000003f34e59d41d9bcb7c0cdcc4c3ea6542f403aacf13e00000000d8af61bf0000003f34e59d41d9bcb7c00ad723bca6542f403aacf13e00000000d8af61bf0000803f34e59d41a6cdb5c00ad723bc30583240ad9c09bf000000002cde573f0000000093719e41a6cdb5c0cdcc4c3e30583240ad9c09bf000000002cde573f0000003f93719e419da1b5c0cdcc4c3e08ce3140ad9c093f000000002cde57bf0000003f93719e419da1b5c00ad723bc08ce3140ad9c093f000000002cde57bf0000803f93719e410378b3c00ad723bc76913540d48e18bf00000000d4934d3f0000000026079f410378b3c0cdcc4c3e76913540d48e18bf00000000d4934d3f0000003f26079f413247b3c0cdcc4c3ee40d3540d48e183f00000000d4934dbf0000003f26079f413247b3c00ad723bce40d3540d48e183f00000000d4934dbf0000803f26079f41
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -5.8255835, y: 0.095, z: 2.8565073}
-    m_Extent: {x: 0.22314286, y: 0.105000004, z: 0.18401957}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!1 &957949370
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 957949371}
-  - component: {fileID: 957949375}
-  - component: {fileID: 957949374}
-  - component: {fileID: 957949373}
-  - component: {fileID: 957949372}
-  m_Layer: 0
-  m_Name: segment 0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &957949371
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 957949370}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 539737851}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &957949372
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 957949370}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 612005129}
---- !u!114 &957949373
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 957949370}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &957949374
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 957949370}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &957949375
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 957949370}
-  m_Mesh: {fileID: 612005129}
---- !u!43 &1000880539
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 540
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 124
-    localAABB:
-      m_Center: {x: 1.4950119, y: 0.095, z: 8.378264}
-      m_Extent: {x: 2.1247947, y: 0.105000004, z: 1.0757525}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 124
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 3968
-    _typelessdata: 733921bf0ad723bc01bf14418a8bd0be000000003dcd693f00000000e1bad041733921bfcdcc4c3e01bf14418a8bd0be000000003dcd693f0000003fe1bad041832e20bfcdcc4c3e989914418a8bd03e000000003dcd69bf0000003fe1bad041832e20bf0ad723bc989914418a8bd03e000000003dcd69bf0000803fe1bad04134e60dbf0ad723bce2391541eaeaabbe000000001723713f00000000314dd14134e60dbfcdcc4c3ee2391541eaeaabbe000000001723713f0000003f314dd141260a0dbfcdcc4c3e4d131541eaeaab3e00000000172371bf0000003f314dd141260a0dbf0ad723bc4d131541eaeaab3e00000000172371bf0000803f314dd141a6c0eabe0ad723bc80b61541c2918bbe000000000e4e763f0000000072ead141a6c0eabecdcc4c3e80b61541c2918bbe000000000e4e763f0000003f72ead1415a5be9becdcc4c3e178f1541c2918b3e000000000e4e76bf0000003f72ead1415a5be9be0ad723bc178f1541c2918b3e000000000e4e76bf0000803f72ead1416ea2b0be0ad723bc132b16411c205dbe00000000bef5793f000000002492d2416ea2b0becdcc4c3e132b16411c205dbe00000000bef5793f0000003f2492d2416387afbecdcc4c3e150316411c205d3e00000000bef579bf0000003f2492d2416387afbe0ad723bc150316411c205d3e00000000bef579bf0000803f2492d2418d4a5dbe0ad723bce2901641343a28be0000000090857c3f00000000a843d3418d4a5dbecdcc4c3ee2901641343a28be0000000090857c3f0000003fa843d341e49b5bbecdcc4c3e7a681641343a283e0000000090857cbf0000003fa843d341e49b5bbe0ad723bc7a681641343a283e0000000090857cbf0000803fa843d341417c97bd0ad723bc0de316419854eebd00000000bb427e3f000000004afed341417c97bdcdcc4c3e0de316419854eebd00000000bb427e3f0000003f4afed341211a95bdcdcc4c3e5eba16419854ee3d00000000bb427ebf0000003f4afed341211a95bd0ad723bc5eba16419854ee3d00000000bb427ebf0000803f4afed3414ed0a23d0ad723bc001e1741b8d291bd00000000aa597f3f000000004cc1d4414ed0a23dcdcc4c3e001e1741b8d291bd00000000aa597f3f0000003f4cc1d4419d45a43dcdcc4c3e25f51641b8d2913d00000000aa597fbf0000003f4cc1d4419d45a43d0ad723bc25f51641b8d2913d00000000aa597fbf0000803f4cc1d441c956783e0ad723bcef3e1741a005e5bc0000000064e67f3f00000000e78bd541c956783ecdcc4c3eef3e1741a005e5bc0000000064e67f3f0000003fe78bd54113a0783ecdcc4c3efd151741a005e53c0000000064e67fbf0000003fe78bd54113a0783e0ad723bcfd151741a005e53c0000000064e67fbf0000803fe78bd541c0add33e0ad723bca743174180f4653c000000008df97f3f00000000535dd641c0add33ecdcc4c3ea743174180f4653c000000008df97f3f0000003f535dd6415a9bd33ecdcc4c3eb21a174180f465bc000000008df97fbf0000003f535dd6415a9bd33e0ad723bcb21a174180f465bc000000008df97fbf0000803f535dd641ab36173f0ad723bc582a174100a7623d00000000979b7f3f00000000c934d741ab36173fcdcc4c3e582a174100a7623d00000000979b7f3f0000003fc934d7416712173fcdcc4c3e7301174100a762bd00000000979b7fbf0000003fc934d7416712173f0ad723bc7301174100a762bd00000000979b7fbf0000803fc934d741bdd2453f0ad723bc85f116418076c53d00000000abce7e3f000000008411d841bdd2453fcdcc4c3e85f116418076c53d00000000abce7e3f0000003f8411d8418d93453fcdcc4c3ec1c816418076c5bd00000000abce7ebf0000003f8411d8418d93453f0ad723bcc1c816418076c5bd00000000abce7ebf0000803f8411d841574c753f0ad723bcf797164128fe0c3e00000000d08f7d3f00000000c6f2d841574c753fcdcc4c3ef797164128fe0c3e00000000d08f7d3f0000003fc6f2d8411bf2743fcdcc4c3e656f164128fe0cbe00000000d08f7dbf0000003fc6f2d8411bf2743f0ad723bc656f164128fe0cbe00000000d08f7dbf0000803fc6f2d841d2a3923f0ad723bca71c164198ce373e0000000093d77b3f00000000dad7d941d2a3923fcdcc4c3ea71c164198ce373e0000000093d77b3f0000003fdad7d9410169923fcdcc4c3e5bf4154198ce37be0000000093d77bbf0000003fdad7d9410169923f0ad723bc5bf4154198ce37be0000000093d77bbf0000803fdad7d941b3b5aa3f0ad723bcc77e1541507b633e000000006d9a793f0000000014c0da41b3b5aa3fcdcc4c3ec77e1541507b633e000000006d9a793f0000003f14c0da41e86caa3fcdcc4c3ed7561541507b63be000000006d9a79bf0000003f14c0da41e86caa3f0ad723bcd7561541507b63be000000006d9a79bf0000803f14c0da4174b0c23f0ad723bcbebd14414423883e00000000ddc8763f00000000d8aadb4174b0c23fcdcc4c3ebebd14414423883e00000000ddc8763f0000003fd8aadb415359c23fcdcc4c3e42961441442388be00000000ddc876bf0000003fd8aadb415359c23f0ad723bc42961441442388be00000000ddc876bf0000803fd8aadb41236ada3f0ad723bc23d9134164329f3e000000008c4f733f000000009997dc41236ada3fcdcc4c3e23d9134164329f3e000000008c4f733f0000003f9997dc414004da3fcdcc4c3e35b2134164329fbe000000008c4f73bf0000003f9997dc414004da3f0ad723bc35b2134164329fbe000000008c4f73bf0000803f9997dc4159baf13f0ad723bcbbd012414cfdb63e0000000069176f3f00000000dd85dd4159baf13fcdcc4c3ebbd012414cfdb63e0000000069176f3f0000003fdd85dd413c45f13fcdcc4c3e7aaa12414cfdb6be0000000069176fbf0000003fdd85dd413c45f13f0ad723bc7aaa12414cfdb6be0000000069176fbf0000803fdd85dd414d3d04400ad723bc76a41141cc8ccf3e00000000e3056a3f000000004275de414d3d0440cdcc4c3e76a41141cc8ccf3e00000000e3056a3f0000003f4275de41e3fa0340cdcc4c3e057f1141cc8ccfbe00000000e3056abf0000003f4275de41e3fa03400ad723bc057f1141cc8ccfbe00000000e3056abf0000803f4275de416e430f400ad723bc7154104188dde83e0000000071fd633f000000007e65df416e430f40cdcc4c3e7154104188dde83e0000000071fd633f0000003f7e65df41e9f80e40cdcc4c3ef72f104188dde8be0000000071fd63bf0000003f7e65df41e9f80e400ad723bcf72f104188dde8be0000000071fd63bf0000803f7e65df41fede19400ad723bcdce00e41bc6e013f0000000086de5c3f000000006856e041fede1940cdcc4c3edce00e41bc6e013f0000000086de5c3f0000003f6856e041278c1940cdcc4c3e85bd0e41bc6e01bf0000000086de5cbf0000003f6856e041278c19400ad723bc85bd0e41bc6e01bf0000000086de5cbf0000803f6856e041370124400ad723bcef490d415cb40e3f000000002489543f00000000f847e14137012440cdcc4c3eef490d415cb40e3f000000002489543f0000003ff847e141e2a52340cdcc4c3eee270d415cb40ebf00000000248954bf0000003ff847e141e2a523400ad723bcee270d415cb40ebf00000000248954bf0000803ff847e141699d2d400ad723bccb8f0b414c231c3f000000002ddf4a3f000000004a3ae241699d2d40cdcc4c3ecb8f0b414c231c3f000000002ddf4a3f0000003f4a3ae2417b392d40cdcc4c3e556f0b414c231cbf000000002ddf4abf0000003f4a3ae2417b392d400ad723bc556f0b414c231cbf000000002ddf4abf0000803f4a3ae24124a936400ad723bc4eb20941e293293f0000000096c73f3f00000000aa2de34124a93640cdcc4c3e4eb20941e293293f0000000096c73f3f0000003faa2de3419c3c3640cdcc4c3e9e930941e29329bf0000000096c73fbf0000003faa2de3419c3c36400ad723bc9e930941e29329bf0000000096c73fbf0000803faa2de341421c3f400ad723bce5b007410ed3363f000000003332333f000000008c22e441421c3f40cdcc4c3ee5b007410ed3363f000000003332333f0000003f8c22e44140a73e40cdcc4c3e399407410ed336bf00000000333233bf0000003f8c22e44140a73e400ad723bc399407410ed336bf00000000333233bf0000803f8c22e44199f046400ad723bc5a8a0541daa3433f00000000e51b253f000000009a19e54199f04640cdcc4c3e5a8a0541daa3433f00000000e51b253f0000003f9a19e54163734640cdcc4c3eef6f0541daa343bf00000000e51b25bf0000003f9a19e541637346400ad723bcef6f0541daa343bf00000000e51b25bf0000803f9a19e54160214e400ad723bc953c03415ec24f3f00000000b592153f00000000ab13e64160214e40cdcc4c3e953c03415ec24f3f00000000b592153f0000003fab13e641699c4d40cdcc4c3ea62403415ec24fbf00000000b59215bf0000003fab13e641699c4d400ad723bca62403415ec24fbf00000000b59215bf0000803fab13e6412aaa54400ad723bc86c40041e4e85a3f0000000044b8043f00000000ce11e7412aaa5440cdcc4c3e86c40041e4e85a3f0000000044b8043f0000003fce11e741101e5440cdcc4c3e4aaf0041e4e85abf0000000044b804bf0000003fce11e741101e54400ad723bc4aaf0041e4e85abf0000000044b804bf0000803fce11e741a9855a400ad723bc383cfc4036d6643f00000000de84e53e000000003f15e841a9855a40cdcc4c3e383cfc4036d6643f00000000de84e53e0000003f3f15e84134f35940cdcc4c3e7f17fc4036d664bf00000000de84e5be0000003f3f15e84134f359400ad723bc7f17fc4036d664bf00000000de84e5be0000803f3f15e84148ac5f400ad723bcbc88f6405e546d3f00000000cbf1bf3e00000000691fe94148ac5f40cdcc4c3ebc88f6405e546d3f00000000cbf1bf3e0000003f691fe94164145f40cdcc4c3e066af6405e546dbf00000000cbf1bfbe0000003f691fe94164145f400ad723bc066af6405e546dbf00000000cbf1bfbe0000803f691fe9410c1364400ad723bc6763f040663e743f000000002060993e00000000dd31ea410c136440cdcc4c3e6763f040663e743f000000002060993e0000003fdd31ea41bc766340cdcc4c3edd4af040663e74bf00000000206099be0000003fdd31ea41bc7663400ad723bcdd4af040663e74bf00000000206099be0000803fdd31ea41eaaa67400ad723bc80c0e940c683793f000000006907653e000000004c4eeb41eaaa6740cdcc4c3e80c0e940c683793f000000006907653e0000003f4c4eeb413a0b6740cdcc4c3e2daee940c68379bf00000000690765be0000003f4c4eeb413a0b67400ad723bc2daee940c68379bf00000000690765be0000803f4c4eeb41
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 1.4950119, y: 0.095, z: 8.378264}
-    m_Extent: {x: 2.1247947, y: 0.105000004, z: 1.0757525}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!1 &1003416108
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1003416109}
-  - component: {fileID: 1003416110}
-  m_Layer: 0
-  m_Name: Wheel FR Collider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1003416109
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1003416108}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.1, y: -0.024999999, z: 0.14}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1104095457}
-  m_RootOrder: 9
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!146 &1003416110
-WheelCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1003416108}
-  m_Center: {x: 0, y: 0, z: 0}
-  m_Radius: 0.035
-  m_SuspensionSpring:
-    spring: 35
-    damper: 5
-    targetPosition: 0.9
-  m_SuspensionDistance: 0.01
-  m_ForceAppPointDistance: 0
-  m_Mass: 0.1
-  m_WheelDampingRate: 0.25
-  m_ForwardFriction:
-    m_ExtremumSlip: 0.4
-    m_ExtremumValue: 1
-    m_AsymptoteSlip: 0.8
-    m_AsymptoteValue: 0.5
-    m_Stiffness: 2
-  m_SidewaysFriction:
-    m_ExtremumSlip: 0.2
-    m_ExtremumValue: 1
-    m_AsymptoteSlip: 0.5
-    m_AsymptoteValue: 0.75
-    m_Stiffness: 2
-  m_Enabled: 1
---- !u!43 &1011930731
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 360
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 93
-    localAABB:
-      m_Center: {x: -5.4979196, y: 0, z: 5.20432}
-      m_Extent: {x: 1.8057108, y: 0, z: 2.1693838}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000030003000400010002000100040004000500020004000300060006000700040005000400070007000800050007000600090009000a000700080007000a000a000b0008000a0009000c000c000d000a000b000a000d000d000e000b000d000c000f000f0010000d000e000d001000100011000e0010000f00120012001300100011001000130013001400110013001200150015001600130014001300160016001700140016001500180018001900160017001600190019001a001700190018001b001b001c0019001a0019001c001c001d001a001c001b001e001e001f001c001d001c001f001f0020001d001f001e002100210022001f0020001f002200220023002000220021002400240025002200230022002500250026002300250024002700270028002500260025002800280029002600280027002a002a002b002800290028002b002b002c0029002b002a002d002d002e002b002c002b002e002e002f002c002e002d003000300031002e002f002e003100310032002f0031003000330033003400310032003100340034003500320034003300360036003700340035003400370037003800350037003600390039003a003700380037003a003a003b0038003a0039003c003c003d003a003b003a003d003d003e003b003d003c003f003f0040003d003e003d004000400041003e0040003f00420042004300400041004000430043004400410043004200450045004600430044004300460046004700440046004500480048004900460047004600490049004a004700490048004b004b004c0049004a0049004c004c004d004a004c004b004e004e004f004c004d004c004f004f0050004d004f004e005100510052004f0050004f005200520053005000520051005400540055005200530052005500550056005300550054005700570058005500560055005800580059005600580057005a005a005b005800590058005b005b005c005900
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 93
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 2976
-    _typelessdata: 264d6cc000000000702ad040000000000000803f00000000000000005e438241df078cc000000000e90fde40000000000000803f000000000000003f5e4382412be9a1c00000000062f5eb40000000000000803f000000000000803f5e438241c98a70c000000000d7d4cc40000000000000803f0000000000000000dec08241a1228ec000000000b3c0da40000000000000803f000000000000003fdec08241ddffa3c0000000008face840000000000000803f000000000000803fdec0824155e674c000000000e469c940000000000000803f0000000000000000af418341984c90c000000000b95bd740000000000000803f000000000000003faf4183410626a6c0000000008e4de540000000000000803f000000000000803faf418341b05d79c00000000025ebc540000000000000803f000000000000000093c58341af8492c00000000097e2d340000000000000803f000000000000003f93c58341865aa8c00000000009dae140000000000000803f000000000000803f93c58341ddee7dc000000000305ac240000000000000803f00000000000000004c4c8441dec994c000000000f456d040000000000000803f000000000000003f4c4c84414e9caac000000000b853de40000000000000803f000000000000803f4c4c8441e04b81c00000000097b8be40000000000000803f00000000000000009bd58441111b97c00000000068bacc40000000000000803f000000000000003f9bd5844142eaacc00000000039bcda40000000000000803f000000000000803f9bd5844129ab83c000000000f307bb40000000000000803f0000000000000000436185413d7799c0000000009c0ec940000000000000803f000000000000003f436185415143afc0000000004515d740000000000000803f000000000000803f436185413b1486c000000000db49b740000000000000803f000000000000000006ef854150dd9bc0000000002b55c540000000000000803f000000000000003f06ef854165a6b1c0000000007b60d340000000000000803f000000000000803f06ef8541168688c000000000ea7fb340000000000000803f0000000000000000a47e8641424c9ec000000000bd8fc140000000000000803f000000000000003fa47e86416e12b4c000000000909fcf40000000000000803f000000000000803fa47e8641a4ff8ac000000000b8abaf40000000000000803f0000000000000000e10f8741fbc2a0c000000000edbfbd40000000000000803f000000000000003fe10f87415286b6c00000000022d4cb40000000000000803f000000000000803fe10f8741e37f8dc000000000ddceab40000000000000803f00000000000000007fa287417340a3c0000000005ce7b940000000000000803f000000000000003f7fa287410301b9c000000000dbffc740000000000000803f000000000000803f7fa28741c80590c000000000faeaa740000000000000803f00000000000000003e3688419cc3a5c000000000b107b640000000000000803f000000000000003f3e3688417081bbc0000000006824c440000000000000803f000000000000803f3e368841459092c000000000a601a440000000000000803f0000000000000000e1ca8841644ba8c0000000008722b240000000000000803f000000000000003fe1ca88418306bec0000000006843c040000000000000803f000000000000803fe1ca88414e1e95c0000000007d14a040000000000000803f00000000000000002a608941bdd6aac0000000008039ae40000000000000803f000000000000003f2a6089412c8fc0c000000000835ebc40000000000000803f000000000000803f2a608941dbae97c0000000001a259c40000000000000803f0000000000000000dbf589419964adc0000000003d4eaa40000000000000803f000000000000003fdbf58941571ac3c0000000006077b840000000000000803f000000000000803fdbf58941df409ac0000000001e359840000000000000803f0000000000000000b58b8a41ebf3afc0000000006362a640000000000000803f000000000000003fb58b8a41f7a6c5c000000000a88fb440000000000000803f000000000000803fb58b8a4150d39cc0000000001e469440000000000000803f00000000000000007b218b41a383b2c0000000008d77a240000000000000803f000000000000003f7b218b41f633c8c000000000fca8b040000000000000803f000000000000803f7b218b4120659fc000000000ba599040000000000000803f0000000000000000eeb68b41b012b5c000000000608f9e40000000000000803f000000000000003feeb68b4140c0cac00000000006c5ac40000000000000803f000000000000803feeb68b414af5a1c0000000008b718c40000000000000803f0000000000000000d04b8c4109a0b7c0000000007bab9a40000000000000803f000000000000003fd04b8c41c84acdc0000000006be5a840000000000000803f000000000000803fd04b8c41bb82a4c0000000002d8f8840000000000000803f0000000000000000e4df8c41992abac0000000007fcd9640000000000000803f000000000000003fe4df8c4177d2cfc000000000d10ba540000000000000803f000000000000803fe4df8c416e0ca7c0000000003cb48440000000000000803f0000000000000000eb728d4156b1bcc0000000000ef79240000000000000803f000000000000003feb728d413e56d2c000000000e039a140000000000000803f000000000000803feb728d415991a9c00000000054e28040000000000000803f0000000000000000a6048e413233bfc000000000ca298f40000000000000803f000000000000003fa6048e410bd5d4c00000000040719d40000000000000803f000000000000803fa6048e417010acc00000000017367a40000000000000803f0000000000000000d8948e411bafc1c00000000051678b40000000000000803f000000000000003fd8948e41c64dd7c00000000097b39940000000000000803f000000000000803fd8948e41ab88aec000000000f7bf7240000000000000803f000000000000000044238f410424c4c00000000045b18740000000000000803f000000000000003f44238f415dbfd9c0000000008f029640000000000000803f000000000000803f44238f4100f9b0c00000000083656b40000000000000803f0000000000000000a9af8f41de90c6c0000000004a098440000000000000803f000000000000003fa9af8f41bc28dcc000000000d35f9240000000000000803f000000000000803fa9af8f416960b3c000000000dc296440000000000000803f0000000000000000cc3990419cf4c8c000000000fc708040000000000000803f000000000000003fcc399041cf88dec0000000000acd8e40000000000000803f000000000000803fcc399041debdb5c00000000035105d40000000000000803f00000000000000006cc190412d4ecbc000000000fed37940000000000000803f000000000000003f6cc190417cdee0c000000000e44b8b40000000000000803f000000000000803f6cc190415a10b8c000000000b51b5640000000000000803f00000000000000004d469141849ccdc000000000e8eb7240000000000000803f000000000000003f4d469141ae28e3c0000000000dde8740000000000000803f000000000000803f4d469141d956bac000000000804f4f40000000000000803f000000000000000030c8914193decfc000000000f62c6c40000000000000803f000000000000003f30c891414d66e5c00000000036858440000000000000803f000000000000803f30c891415990bcc000000000b1ae4840000000000000803f0000000000000000d84692414913d2c0000000006a9a6540000000000000803f000000000000003fd84692413996e7c00000000012438140000000000000803f000000000000803fd8469241dbbbbec000000000663c4240000000000000803f000000000000000005c292419939d4c0000000008d375f40000000000000803f000000000000003f05c2924157b7e9c000000000b4327c40000000000000803f000000000000803f05c29241
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -5.4979196, y: 0, z: 5.20432}
-    m_Extent: {x: 1.8057108, y: 0, z: 2.1693838}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!43 &1044053487
+--- !u!43 &149870122
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6152,1045 +935,7 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1 &1062259792
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1062259793}
-  - component: {fileID: 1062259797}
-  - component: {fileID: 1062259796}
-  - component: {fileID: 1062259795}
-  - component: {fileID: 1062259794}
-  m_Layer: 0
-  m_Name: segment 5
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1062259793
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1062259792}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1272024235}
-  m_RootOrder: 5
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1062259794
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1062259792}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 390911214}
---- !u!114 &1062259795
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1062259792}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &1062259796
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1062259792}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1062259797
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1062259792}
-  m_Mesh: {fileID: 390911214}
---- !u!1 &1104095456
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1104095457}
-  - component: {fileID: 1104095459}
-  - component: {fileID: 1104095458}
-  - component: {fileID: 1104095460}
-  m_Layer: 0
-  m_Name: Car
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1104095457
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1104095456}
-  m_LocalRotation: {x: -0, y: -0.82514745, z: -0, w: 0.56491745}
-  m_LocalPosition: {x: -2.13, y: 0.1, z: 0.8}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 883720339}
-  - {fileID: 380988569}
-  - {fileID: 1687258585}
-  - {fileID: 1144056806}
-  - {fileID: 35796932}
-  - {fileID: 173503877}
-  - {fileID: 73127174}
-  - {fileID: 501547373}
-  - {fileID: 1835053460}
-  - {fileID: 1003416109}
-  - {fileID: 642513310}
-  - {fileID: 1697795922}
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: -111.20701, z: 0}
---- !u!54 &1104095458
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1104095456}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 80
-  m_CollisionDetection: 0
---- !u!65 &1104095459
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1104095456}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 0.25, y: 0.05, z: 0.35}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &1104095460
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1104095456}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a7ffb5ff4c77846fca7b161ea144b46a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  frontLeftWC: {fileID: 1835053461}
-  frontRightWC: {fileID: 1003416110}
-  rearLeftWC: {fileID: 642513311}
-  rearRightWC: {fileID: 1697795923}
-  frontLeftT: {fileID: 35796932}
-  frontRightT: {fileID: 173503877}
-  rearLeftT: {fileID: 73127174}
-  rearRightT: {fileID: 501547373}
-  maxSteerAngle: 30
-  motorForce: 150
-  maxAngleChangePerSecond: 10
-  angle: 0
-  forward: 0
---- !u!43 &1111941945
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 540
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 124
-    localAABB:
-      m_Center: {x: 1.9517306, y: 0.095, z: 9.363232}
-      m_Extent: {x: 3.23729, y: 0.105000004, z: 1.7006259}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 124
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 3968
-    _typelessdata: 368da4bf0ad723bcbc452c418a8bd0be000000003dcd693f00000000e1bad041368da4bfcdcc4c3ebc452c418a8bd0be000000003dcd693f0000003fe1bad041be07a4bfcdcc4c3e53202c418a8bd03e000000003dcd69bf0000003fe1bad041be07a4bf0ad723bc53202c418a8bd03e000000003dcd69bf0000803fe1bad0417f258cbf0ad723bc937d2d41eaeaabbe000000001723713f00000000314dd1417f258cbfcdcc4c3e937d2d41eaeaabbe000000001723713f0000003f314dd14178b78bbfcdcc4c3efe562d41eaeaab3e00000000172371bf0000003f314dd14178b78bbf0ad723bcfe562d41eaeaab3e00000000172371bf0000803f314dd141c7ba65bf0ad723bc517f2e41c2918bbe000000000e4e763f0000000072ead141c7ba65bfcdcc4c3e517f2e41c2918bbe000000000e4e763f0000003f72ead141210865bfcdcc4c3ee8572e41c2918b3e000000000e4e76bf0000003f72ead141210865bf0ad723bce8572e41c2918b3e000000000e4e76bf0000803f72ead141fa5131bf0ad723bc0b522f411c205dbe00000000bef5793f000000002492d241fa5131bfcdcc4c3e0b522f411c205dbe00000000bef5793f0000003f2492d24175c430bfcdcc4c3e0d2a2f411c205d3e00000000bef579bf0000003f2492d24175c430bf0ad723bc0d2a2f411c205d3e00000000bef579bf0000803f2492d2419211f6be0ad723bcd8f92f41343a28be0000000090857c3f00000000a843d3419211f6becdcc4c3ed8f92f41343a28be0000000090857c3f0000003fa843d3413e3af5becdcc4c3e70d12f41343a283e0000000090857cbf0000003fa843d3413e3af5be0ad723bc70d12f41343a283e0000000090857cbf0000803fa843d341a2cc85be0ad723bcce7830419854eebd00000000bb427e3f000000004afed341a2cc85becdcc4c3ece7830419854eebd00000000bb427e3f0000003f4afed3411a3485becdcc4c3e1f5030419854ee3d00000000bb427ebf0000003f4afed3411a3485be0ad723bc1f5030419854ee3d00000000bb427ebf0000803f4afed3414eec0fbd0ad723bcd3cf3041b8d291bd00000000aa597f3f000000004cc1d4414eec0fbdcdcc4c3ed3cf3041b8d291bd00000000aa597f3f0000003f4cc1d441b1010dbdcdcc4c3ef8a63041b8d2913d00000000aa597fbf0000003f4cc1d441b1010dbd0ad723bcf8a63041b8d2913d00000000aa597fbf0000803f4cc1d441933f4a3e0ad723bcebfe3041a005e5bc0000000064e67f3f00000000e78bd541933f4a3ecdcc4c3eebfe3041a005e5bc0000000064e67f3f0000003fe78bd541dd884a3ecdcc4c3ef9d53041a005e53c0000000064e67fbf0000003fe78bd541dd884a3e0ad723bcf9d53041a005e53c0000000064e67fbf0000803fe78bd541923fdf3e0ad723bc9005314180f4653c000000008df97f3f00000000535dd641923fdf3ecdcc4c3e9005314180f4653c000000008df97f3f0000003f535dd6412c2ddf3ecdcc4c3e9bdc304180f465bc000000008df97fbf0000003f535dd6412c2ddf3e0ad723bc9bdc304180f465bc000000008df97fbf0000803f535dd6413b052e3f0ad723bccde2304100a7623d00000000979b7f3f00000000c934d7413b052e3fcdcc4c3ecde2304100a7623d00000000979b7f3f0000003fc934d741f7e02d3fcdcc4c3ee8b9304100a762bd00000000979b7fbf0000003fc934d741f7e02d3f0ad723bce8b9304100a762bd00000000979b7fbf0000803fc934d74107906d3f0ad723bc5b9530418076c53d00000000abce7e3f000000008411d84107906d3fcdcc4c3e5b9530418076c53d00000000abce7e3f0000003f8411d841d7506d3fcdcc4c3e976c30418076c5bd00000000abce7ebf0000003f8411d841d7506d3f0ad723bc976c30418076c5bd00000000abce7ebf0000803f8411d8411f06973f0ad723bcb71b304128fe0c3e00000000d08f7d3f00000000c6f2d8411f06973fcdcc4c3eb71b304128fe0c3e00000000d08f7d3f0000003fc6f2d84100d9963fcdcc4c3e25f32f4128fe0cbe00000000d08f7dbf0000003fc6f2d84100d9963f0ad723bc25f32f4128fe0cbe00000000d08f7dbf0000803fc6f2d8418fa1b73f0ad723bc1b742f4198ce373e0000000093d77b3f00000000dad7d9418fa1b73fcdcc4c3e1b742f4198ce373e0000000093d77b3f0000003fdad7d941be66b73fcdcc4c3ecf4b2f4198ce37be0000000093d77bbf0000003fdad7d941be66b73f0ad723bccf4b2f4198ce37be0000000093d77bbf0000803fdad7d9418e7dd83f0ad723bc8f9c2e41507b633e000000006d9a793f0000000014c0da418e7dd83fcdcc4c3e8f9c2e41507b633e000000006d9a793f0000003f14c0da41c334d83fcdcc4c3e9f742e41507b63be000000006d9a79bf0000003f14c0da41c334d83f0ad723bc9f742e41507b63be000000006d9a79bf0000803f14c0da41177cf93f0ad723bcea922d414423883e00000000ddc8763f00000000d8aadb41177cf93fcdcc4c3eea922d414423883e00000000ddc8763f0000003fd8aadb41f624f93fcdcc4c3e6e6b2d41442388be00000000ddc876bf0000003fd8aadb41f624f93f0ad723bc6e6b2d41442388be00000000ddc876bf0000803fd8aadb41e43e0d400ad723bcd3542c4164329f3e000000008c4f733f000000009997dc41e43e0d40cdcc4c3ed3542c4164329f3e000000008c4f733f0000003f9997dc41f20b0d40cdcc4c3ee52d2c4164329fbe000000008c4f73bf0000003f9997dc41f20b0d400ad723bce52d2c4164329fbe000000008c4f73bf0000803f9997dc41cab01d400ad723bcbadf2a414cfdb63e0000000069176f3f00000000dd85dd41cab01d40cdcc4c3ebadf2a414cfdb63e0000000069176f3f0000003fdd85dd413c761d40cdcc4c3e79b92a414cfdb6be0000000069176fbf0000003fdd85dd413c761d400ad723bc79b92a414cfdb6be0000000069176fbf0000803fdd85dd4147022e400ad723bce5302941cc8ccf3e00000000e3056a3f000000004275de4147022e40cdcc4c3ee5302941cc8ccf3e00000000e3056a3f0000003f4275de41ddbf2d40cdcc4c3e740b2941cc8ccfbe00000000e3056abf0000003f4275de41ddbf2d400ad723bc740b2941cc8ccfbe00000000e3056abf0000803f4275de41a7203e400ad723bc7745274188dde83e0000000071fd633f000000007e65df41a7203e40cdcc4c3e7745274188dde83e0000000071fd633f0000003f7e65df4122d63d40cdcc4c3efd20274188dde8be0000000071fd63bf0000003f7e65df4122d63d400ad723bcfd20274188dde8be0000000071fd63bf0000803f7e65df41b9f74d400ad723bc731a2541bc6e013f0000000086de5c3f000000006856e041b9f74d40cdcc4c3e731a2541bc6e013f0000000086de5c3f0000003f6856e041e2a44d40cdcc4c3e1cf72441bc6e01bf0000000086de5cbf0000003f6856e041e2a44d400ad723bc1cf72441bc6e01bf0000000086de5cbf0000803f6856e0417e715d400ad723bcdaac22415cb40e3f000000002489543f00000000f847e1417e715d40cdcc4c3edaac22415cb40e3f000000002489543f0000003ff847e14129165d40cdcc4c3ed98a22415cb40ebf00000000248954bf0000003ff847e14129165d400ad723bcd98a22415cb40ebf00000000248954bf0000803ff847e141db756c400ad723bcc5f91f414c231c3f000000002ddf4a3f000000004a3ae241db756c40cdcc4c3ec5f91f414c231c3f000000002ddf4a3f0000003f4a3ae241ed116c40cdcc4c3e4fd91f414c231cbf000000002ddf4abf0000003f4a3ae241ed116c400ad723bc4fd91f414c231cbf000000002ddf4abf0000803f4a3ae2416cea7a400ad723bc8cfe1c41e293293f0000000096c73f3f00000000aa2de3416cea7a40cdcc4c3e8cfe1c41e293293f0000000096c73f3f0000003faa2de341e47d7a40cdcc4c3edcdf1c41e29329bf0000000096c73fbf0000003faa2de341e47d7a400ad723bcdcdf1c41e29329bf0000000096c73fbf0000803faa2de3413e5984400ad723bcfdb819410ed3363f000000003332333f000000008c22e4413e598440cdcc4c3efdb819410ed3363f000000003332333f0000003f8c22e441bd1e8440cdcc4c3e519c19410ed336bf00000000333233bf0000003f8c22e441bd1e84400ad723bc519c19410ed336bf00000000333233bf0000803f8c22e441acd78a400ad723bc8f271641daa3433f00000000e51b253f000000009a19e541acd78a40cdcc4c3e8f271641daa3433f00000000e51b253f0000003f9a19e54112998a40cdcc4c3e240d1641daa343bf00000000e51b25bf0000003f9a19e54112998a400ad723bc240d1641daa343bf00000000e51b25bf0000803f9a19e54172e090400ad723bc964912415ec24f3f00000000b592153f00000000ab13e64172e09040cdcc4c3e964912415ec24f3f00000000b592153f0000003fab13e641f69d9040cdcc4c3ea73112415ec24fbf00000000b59215bf0000003fab13e641f69d90400ad723bca73112415ec24fbf00000000b59215bf0000803fab13e641506396400ad723bc621f0e41e4e85a3f0000000044b8043f00000000ce11e74150639640cdcc4c3e621f0e41e4e85a3f0000000044b8043f0000003fce11e741431d9640cdcc4c3e260a0e41e4e85abf0000000044b804bf0000003fce11e741431d96400ad723bc260a0e41e4e85abf0000000044b804bf0000803fce11e74180509b400ad723bc50aa094136d6643f00000000de84e53e000000003f15e84180509b40cdcc4c3e50aa094136d6643f00000000de84e53e0000003f3f15e84146079b40cdcc4c3ef497094136d664bf00000000de84e5be0000003f3f15e84146079b400ad723bcf497094136d664bf00000000de84e5be0000803f3f15e8415c999f400ad723bc9dec04415e546d3f00000000cbf1bf3e00000000691fe9415c999f40cdcc4c3e9dec04415e546d3f00000000cbf1bf3e0000003f691fe9416a4d9f40cdcc4c3e42dd04415e546dbf00000000cbf1bfbe0000003f691fe9416a4d9f400ad723bc42dd04415e546dbf00000000cbf1bfbe0000803f691fe941f630a3400ad723bc5bd2ff40663e743f000000002060993e00000000dd31ea41f630a340cdcc4c3e5bd2ff40663e743f000000002060993e0000003fdd31ea41cee2a240cdcc4c3ed1b9ff40663e74bf00000000206099be0000003fdd31ea41cee2a2400ad723bcd1b9ff40663e74bf00000000206099be0000803fdd31ea41750ca6400ad723bc6546f540c683793f000000006907653e000000004c4eeb41750ca640cdcc4c3e6546f540c683793f000000006907653e0000003f4c4eeb419dbca540cdcc4c3e1234f540c68379bf00000000690765be0000003f4c4eeb419dbca5400ad723bc1234f540c68379bf00000000690765be0000803f4c4eeb41
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 1.9517306, y: 0.095, z: 9.363232}
-    m_Extent: {x: 3.23729, y: 0.105000004, z: 1.7006259}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!43 &1121393386
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 540
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 124
-    localAABB:
-      m_Center: {x: -1.8828241, y: 0.095, z: 3.7281961}
-      m_Extent: {x: 2.7661295, y: 0.105000004, z: 2.192113}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 124
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 3968
-    _typelessdata: 3ac494c00ad723bc84a5c53fd48e18bf00000000d4934d3f0000000026079f413ac494c0cdcc4c3e84a5c53fd48e18bf00000000d4934d3f0000003f26079f41699394c0cdcc4c3e619ec43fd48e183f00000000d4934dbf0000003f26079f41699394c00ad723bc619ec43fd48e183f00000000d4934dbf0000803f26079f41b39a90c00ad723bc2a09d23f0a1319bf0000000074314d3f000000001cab9f41b39a90c0cdcc4c3e2a09d23f0a1319bf0000000074314d3f0000003f1cab9f41b76990c0cdcc4c3e8402d13f0a13193f0000000074314dbf0000003f1cab9f41b76990c00ad723bc8402d13f0a13193f0000000074314dbf0000803f1cab9f41a0018cc00ad723bc8dc9df3f7e8019bf00000000a0df4c3f000000001e61a041a0018cc0cdcc4c3e8dc9df3f7e8019bf00000000a0df4c3f0000003f1e61a04181d08bc0cdcc4c3e50c3de3f7e80193f00000000a0df4cbf0000003f1e61a04181d08bc00ad723bc50c3de3f7e80193f00000000a0df4cbf0000803f1e61a041320187c00ad723bc76ceee3f22df19bf0000000095984c3f00000000c627a141320187c0cdcc4c3e76ceee3f22df19bf0000000095984c3f0000003fc627a141f5cf86c0cdcc4c3e94c8ed3f22df193f0000000095984cbf0000003fc627a141f5cf86c00ad723bc94c8ed3f22df193f0000000095984cbf0000803fc627a141eba181c00ad723bcecfefe3f07341abf000000009f584c3f00000000affda141eba181c0cdcc4c3eecfefe3f07341abf000000009f584c3f0000003faffda141927081c0cdcc4c3e5cf9fd3f07341a3f000000009f584cbf0000003faffda141927081c00ad723bc5cf9fd3f07341a3f000000009f584cbf0000803faffda141dad877c00ad723bcaf20084074821abf000000005a1d4c3f0000000073e1a241dad877c0cdcc4c3eaf20084074821abf000000005a1d4c3f0000003f73e1a241f77577c0cdcc4c3e0d9e074074821a3f000000005a1d4cbf0000003f73e1a241f77577c00ad723bc0d9e074074821a3f000000005a1d4cbf0000803f73e1a241ffd26bc00ad723bc0e3e1140d7cc1abf00000000f6e44b3f00000000aed1a341ffd26bc0cdcc4c3e0e3e1140d7cc1abf00000000f6e44b3f0000003faed1a341ed6f6bc0cdcc4c3e90bb1040d7cc1a3f00000000f6e44bbf0000003faed1a341ed6f6bc00ad723bc90bb1040d7cc1a3f00000000f6e44bbf0000803faed1a341e6435fc00ad723bc8eca1a40e6141bbf000000002cae4b3f00000000facca441e6435fc0cdcc4c3e8eca1a40e6141bbf000000002cae4b3f0000003ffacca441a5e05ec0cdcc4c3e33481a40e6141b3f000000002cae4bbf0000003ffacca441a5e05ec00ad723bc33481a40e6141b3f000000002cae4bbf0000803ffacca441403d52c00ad723bc2cb92440165c1bbf00000000e4774b3f00000000f3d1a541403d52c0cdcc4c3e2cb92440165c1bbf00000000e4774b3f0000003ff3d1a541d2d951c0cdcc4c3ef4362440165c1b3f00000000e4774bbf0000003ff3d1a541d2d951c00ad723bcf4362440165c1b3f00000000e4774bbf0000803ff3d1a541ced044c00ad723bcd6fc2e408fa31bbf000000003f414b3f0000000032dfa641ced044c0cdcc4c3ed6fc2e408fa31bbf000000003f414b3f0000003f32dfa641326d44c0cdcc4c3ec07a2e408fa31b3f000000003f414bbf0000003f32dfa641326d44c00ad723bcc07a2e408fa31b3f000000003f414bbf0000803f32dfa641591037c00ad723bc768839405aec1bbf000000006c094b3f0000000052f3a741591037c0cdcc4c3e768839405aec1bbf000000006c094b3f0000003f52f3a7418eac36c0cdcc4c3e840639405aec1b3f000000006c094bbf0000003f52f3a7418eac36c00ad723bc840639405aec1b3f000000006c094bbf0000803f52f3a741af0d29c00ad723bcfa4e444072371cbf00000000aacf4a3f00000000f00ca941af0d29c0cdcc4c3efa4e444072371cbf00000000aacf4a3f0000003ff00ca941b5a928c0cdcc4c3e2ecd434072371c3f00000000aacf4abf0000003ff00ca941b5a928c00ad723bc2ecd434072371c3f00000000aacf4abf0000803ff00ca94199da1ac00ad723bc48434f40ce851cbf0000000037934a3f00000000a42aaa4199da1ac0cdcc4c3e48434f40ce851cbf0000000037934a3f0000003fa42aaa416c761ac0cdcc4c3ea2c14e40ce851c3f0000000037934abf0000003fa42aaa416c761ac00ad723bca2c14e40ce851c3f0000000037934abf0000803fa42aaa41dd880cc00ad723bc4c585a406ad81cbf0000000048534a3f000000000b4bab41dd880cc0cdcc4c3e4c585a406ad81cbf0000000048534a3f0000003f0b4bab417c240cc0cdcc4c3eced659406ad81c3f0000000048534abf0000003f0b4bab417c240cc00ad723bcced659406ad81c3f0000000048534abf0000803f0b4bab418854fcbf0ad723bcf080654064301dbf00000000f50e4a3f00000000bf6cac418854fcbfcdcc4c3ef080654064301dbf00000000f50e4a3f0000003fbf6cac41548bfbbfcdcc4c3e9eff644064301d3f00000000f50e4abf0000003fbf6cac41548bfbbf0ad723bc9eff644064301d3f00000000f50e4abf0000803fbf6cac411ca1dfbf0ad723bc30b07040ea8e1dbf0000000049c5493f000000005b8ead411ca1dfbfcdcc4c3e30b07040ea8e1dbf0000000049c5493f0000003f5b8ead4170d7debfcdcc4c3e0e2f7040ea8e1d3f0000000049c549bf0000003f5b8ead4170d7debf0ad723bc0e2f7040ea8e1d3f0000000049c549bf0000803f5b8ead41d81ac3bf0ad723bc06d97b406cf51dbf000000001375493f000000007aaeae41d81ac3bfcdcc4c3e06d97b406cf51dbf000000001375493f0000003f7aaeae41a850c2bfcdcc4c3e18587b406cf51d3f00000000137549bf0000003f7aaeae41a850c2bf0ad723bc18587b406cf51d3f00000000137549bf0000803f7aaeae4110e5a6bf0ad723bc3e7783408c651ebf00000000f71c493f00000000b8cbaf4110e5a6bfcdcc4c3e3e7783408c651ebf00000000f71c493f0000003fb8cbaf41511aa6bfcdcc4c3ee33683408c651e3f00000000f71c49bf0000003fb8cbaf41511aa6bf0ad723bce33683408c651e3f00000000f71c49bf0000803fb8cbaf41f3228bbf0ad723bcd5f188404de11ebf0000000042bb483f00000000aee4b041f3228bbfcdcc4c3ed5f188404de11ebf0000000042bb483f0000003faee4b04195578abfcdcc4c3e99b188404de11e3f0000000042bb48bf0000003faee4b04195578abf0ad723bc99b188404de11e3f0000000042bb48bf0000803faee4b041f4ee5fbf0ad723bcdf558e402a6b1fbf00000000d64d483f00000000f9f7b141f4ee5fbfcdcc4c3edf558e402a6b1fbf00000000d64d483f0000003ff9f7b141d7565ebfcdcc4c3ec6158e402a6b1f3f00000000d64d48bf0000003ff9f7b141d7565ebf0ad723bcc6158e402a6b1f3f00000000d64d48bf0000803ff9f7b141c10a2bbf0ad723bc029d93403f0620bf0000000006d2473f000000003404b341c10a2bbfcdcc4c3e029d93403f0620bf0000000006d2473f0000003f3404b341177129bfcdcc4c3e115d93403f06203f0000000006d247bf0000003f3404b341177129bf0ad723bc115d93403f06203f0000000006d247bf0000803f3404b3411ebcefbe0ad723bcf8c098408cb620bf000000005644473f00000000fb07b4411ebcefbecdcc4c3ef8c098408cb620bf000000005644473f0000003ffb07b4414485ecbecdcc4c3e348198408cb6203f00000000564447bf0000003ffb07b4414485ecbe0ad723bc348198408cb6203f00000000564447bf0000803ffb07b44144598dbe0ad723bc99bb9d404f8121bf0000000023a0463f00000000e801b54144598dbecdcc4c3e99bb9d404f8121bf0000000023a0463f0000003fe801b5415c1e8abecdcc4c3e097c9d404f81213f0000000023a046bf0000003fe801b5415c1e8abe0ad723bc097c9d404f81213f0000000023a046bf0000803fe801b54168c6bdbd0ad723bce486a2408a6d22bf0000000023df453f0000000099f0b54168c6bdbdcdcc4c3ee486a2408a6d22bf0000000023df453f0000003f99f0b541e0c7b0bdcdcc4c3e9347a2408a6d223f0000000023df45bf0000003f99f0b541e0c7b0bd0ad723bc9347a2408a6d223f0000000023df45bf0000803f99f0b54110e9a53d0ad723bc201da740d18423bf0000000097f8443f00000000a9d2b64110e9a53dcdcc4c3e201da740d18423bf0000000097f8443f0000003fa9d2b641f0fdb23dcdcc4c3e19dea640d184233f0000000097f844bf0000003fa9d2b641f0fdb23d0ad723bc19dea640d184233f0000000097f844bf0000803fa9d2b64174e0793e0ad723bcee78ab40c0d424bf00000000cfdf433f00000000b6a6b74174e0793ecdcc4c3eee78ab40c0d424bf00000000cfdf433f0000003fb6a6b741283c803ecdcc4c3e403aab40c0d4243f00000000cfdf43bf0000003fb6a6b741283c803e0ad723bc403aab40c0d4243f00000000cfdf43bf0000803fb6a6b7410380ca3e0ad723bc9695af40207126bf00000000e081423f000000005d6bb8410380ca3ecdcc4c3e9695af40207126bf00000000e081423f0000003f5d6bb84131d4cd3ecdcc4c3e5857af402071263f00000000e08142bf0000003f5d6bb84131d4cd3e0ad723bc5857af402071263f00000000e08142bf0000803f5d6bb841f7e4083f0ad723bc6f6fb340117828bf0000000015c1403f000000003e1fb941f7e4083fcdcc4c3e6f6fb340117828bf0000000015c1403f0000003f3e1fb9413f940a3fcdcc4c3ec031b3401178283f0000000015c140bf0000003f3e1fb9413f940a3f0ad723bcc031b3401178283f0000000015c140bf0000803f3e1fb9417145293f0ad723bcc704b74092192bbf000000003b6c3e3f00000000f8c0b9417145293fcdcc4c3ec704b74092192bbf000000003b6c3e3f0000003ff8c0b94175fb2a3fcdcc4c3ed8c7b64092192b3f000000003b6c3ebf0000003ff8c0b94175fb2a3f0ad723bcd8c7b64092192b3f000000003b6c3ebf0000803ff8c0b941ae5a463f0ad723bccc57ba4024a72ebf000000005c2b3b3f00000000304fba41ae5a463fcdcc4c3ecc57ba4024a72ebf000000005c2b3b3f0000003f304fba41cb19483fcdcc4c3ee71bba4024a72e3f000000005c2b3bbf0000003f304fba41cb19483f0ad723bce71bba4024a72e3f000000005c2b3bbf0000803f304fba413c54603f0ad723bc2c73bd403ab633bf000000004651363f0000000090c8ba413c54603fcdcc4c3e2c73bd403ab633bf000000004651363f0000003f90c8ba414c20623fcdcc4c3ed538bd403ab6333f00000000465136bf0000003f90c8ba414c20623f0ad723bcd538bd403ab6333f00000000465136bf0000803f90c8ba41
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -1.8828241, y: 0.095, z: 3.7281961}
-    m_Extent: {x: 2.7661295, y: 0.105000004, z: 2.192113}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!1 &1144056805
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1144056806}
-  - component: {fileID: 1144056809}
-  - component: {fileID: 1144056808}
-  m_Layer: 0
-  m_Name: Body
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1144056806
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1144056805}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.15, y: 0.05, z: 0.3}
-  m_Children: []
-  m_Father: {fileID: 1104095457}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!23 &1144056808
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1144056805}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a5aaee4111611af43b5abbff184fe5fa, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1144056809
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1144056805}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &1184662544
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1184662545}
-  - component: {fileID: 1184662549}
-  - component: {fileID: 1184662548}
-  - component: {fileID: 1184662547}
-  - component: {fileID: 1184662546}
-  m_Layer: 0
-  m_Name: segment 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1184662545
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1184662544}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1236410749}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1184662546
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1184662544}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1215602285}
---- !u!114 &1184662547
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1184662544}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &1184662548
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1184662544}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1184662549
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1184662544}
-  m_Mesh: {fileID: 1215602285}
---- !u!43 &1203178056
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 540
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 124
-    localAABB:
-      m_Center: {x: -4.8949666, y: 0.095, z: 8.176058}
-      m_Extent: {x: 1.5281821, y: 0.105000004, z: 1.670877}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 124
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 3968
-    _typelessdata: 6f8acdc00ad723bcec051c41b03885be00000000a12e773f00000000762868416f8acdc0cdcc4c3eec051c41b03885be00000000a12e773f0000003f762868411e75cdc0cdcc4c3e5fde1b41b038853e00000000a12e77bf0000003f762868411e75cdc00ad723bc5fde1b41b038853e00000000a12e77bf0000803f762868419d0ec7c00ad723bc30c61c4104e642be0000000002527b3f00000000715b69419d0ec7c0cdcc4c3e30c61c4104e642be0000000002527b3f0000003f715b694106ffc6c0cdcc4c3efa9d1c4104e6423e0000000002527bbf0000003f715b694106ffc6c00ad723bcfa9d1c4104e6423e0000000002527bbf0000803f715b6941c99bc0c00ad723bc20471d41a8ebf0bd00000000f6387e3f000000001b836a41c99bc0c0cdcc4c3e20471d41a8ebf0bd00000000f6387e3f0000003f1b836a412692c0c0cdcc4c3e731e1d41a8ebf03d00000000f6387ebf0000003f1b836a412692c0c00ad723bc731e1d41a8ebf03d00000000f6387ebf0000803f1b836a416f38bac00ad723bc27891d41f0312fbd0000000007c47f3f00000000afa06b416f38bac0cdcc4c3e27891d41f0312fbd0000000007c47f3f0000003fafa06b41ee34bac0cdcc4c3e3b601d41f0312f3d0000000007c47fbf0000003fafa06b41ee34bac00ad723bc3b601d41f0312f3d0000000007c47fbf0000803fafa06b41acebb3c00ad723bc0b8d1d41c04b093d000000002cdb7f3f0000000051b56c41acebb3c0cdcc4c3e0b8d1d41c04b093d000000002cdb7f3f0000003f51b56c416beeb3c0cdcc4c3e1b641d41c04b09bd000000002cdb7fbf0000003f51b56c416beeb3c00ad723bc1b641d41c04b09bd000000002cdb7fbf0000803f51b56c41e3bcadc00ad723bc01541d418032e23d000000000d6f7e3f0000000018c26d41e3bcadc0cdcc4c3e01541d418032e23d000000000d6f7e3f0000003f18c26d41efc5adc0cdcc4c3e4c2b1d418032e2bd000000000d6f7ebf0000003f18c26d41efc5adc00ad723bc4c2b1d418032e2bd000000000d6f7ebf0000803f18c26d419ab3a7c00ad723bcbadf1c41c0b33f3e0000000056797b3f00000000fdc76e419ab3a7c0cdcc4c3ebadf1c41c0b33f3e0000000056797b3f0000003ffdc76e41f0c2a7c0cdcc4c3e7eb71c41c0b33fbe0000000056797bbf0000003ffdc76e41f0c2a7c00ad723bc7eb71c41c0b33fbe0000000056797bbf0000803ffdc76e4111d7a1c00ad723bc50321c4168ac863e0000000041fc763f00000000e9c76f4111d7a1c0cdcc4c3e50321c4168ac863e0000000041fc763f0000003fe9c76f419deca1c0cdcc4c3ecc0a1c4168ac86be0000000041fc76bf0000003fe9c76f419deca1c00ad723bccc0a1c4168ac86be0000000041fc76bf0000803fe9c76f412a2e9cc00ad723bc414e1b4130a7ac3e000000007301713f00000000a6c270412a2e9cc0cdcc4c3e414e1b4130a7ac3e000000007301713f0000003fa6c27041c9499cc0cdcc4c3eb1271b4130a7acbe00000000730171bf0000003fa6c27041c9499cc00ad723bcb1271b4130a7acbe00000000730171bf0000803fa6c2704125bf96c00ad723bc4b361a413479d13e000000001898693f00000000ebb8714125bf96c0cdcc4c3e4b361a413479d13e000000001898693f0000003febb87141a9e096c0cdcc4c3eeb101a413479d1be00000000189869bf0000003febb87141a9e096c00ad723bceb101a413479d1be00000000189869bf0000803febb871419e8f91c00ad723bc65ed184174def43e00000000efd2603f0000000052ab72419e8f91c0cdcc4c3e65ed184174def43e00000000efd2603f0000003f52ab7241cbb691c0cdcc4c3e6cc9184174def4be00000000efd260bf0000003f52ab7241cbb691c00ad723bc6cc9184174def4be00000000efd260bf0000803f52ab724188a48cc00ad723bc9476174110500b3f0000000031c6563f000000005d9a734188a48cc0cdcc4c3e9476174110500b3f0000000031c6563f0000003f5d9a73411dd18cc0cdcc4c3e3754174110500bbf0000000031c656bf0000003f5d9a73411dd18cc00ad723bc3754174110500bbf0000000031c656bf0000803f5d9a7341310288c00ad723bcd8d41541ea491b3f00000000c7854b3f000000007e867441310288c0cdcc4c3ed8d41541ea491b3f00000000c7854b3f0000003f7e867441e23388c0cdcc4c3e48b41541ea491bbf00000000c7854bbf0000003f7e867441e23388c00ad723bc48b41541ea491bbf00000000c7854bbf0000803f7e86744168ac83c00ad723bc190b14415e4c2a3f00000000d7233f3f000000001270754168ac83c0cdcc4c3e190b14415e4c2a3f00000000d7233f3f0000003f12707541e7e283c0cdcc4c3e84ec13415e4c2abf00000000d7233fbf0000003f12707541e7e283c00ad723bc84ec13415e4c2abf00000000d7233fbf0000803f127075414b4d7fc00ad723bc1f1c1241a64a383f00000000d6af313f00000000645776414b4d7fc0cdcc4c3e1f1c1241a64a383f00000000d6af313f0000003f645776413dc37fc0cdcc4c3eb1ff1141a64a38bf00000000d6af31bf0000003f645776413dc37fc00ad723bcb1ff1141a64a38bf00000000d6af31bf0000803f645776415ce877c00ad723bc8c0a1041d839453f000000001736233f00000000b43c77415ce877c0cdcc4c3e8c0a1041d839453f000000001736233f0000003fb43c7741966678c0cdcc4c3e6ff00f41d83945bf00000000173623bf0000003fb43c7741966678c00ad723bc6ff00f41d83945bf00000000173623bf0000803fb43c7741773071c00ad723bcd2d80d41620f513f00000000dbbf133f000000003c207841773071c0cdcc4c3ed2d80d41620f513f00000000dbbf133f0000003f3c20784144b671c0cdcc4c3e2ec10d41620f51bf00000000dbbf13bf0000003f3c20784144b671c00ad723bc2ec10d41620f51bf00000000dbbf13bf0000803f3c207841592c6bc00ad723bc4c890b416abf5b3f00000000e653033f000000002b027941592c6bc0cdcc4c3e4c890b416abf5b3f00000000e653033f0000003f2b027941fdb86bc0cdcc4c3e49740b416abf5bbf00000000e65303bf0000003f2b027941fdb86bc00ad723bc49740b416abf5bbf00000000e65303bf0000803f2b0279413ee365c00ad723bc391e0941903b653f00000000f2eee33e00000000b5e279413ee365c0cdcc4c3e391e0941903b653f00000000f2eee33e0000003fb5e27941f47566c0cdcc4c3efd0b0941903b65bf00000000f2eee3be0000003fb5e27941f47566c00ad723bcfd0b0941903b65bf00000000f2eee3be0000803fb5e27941195d61c00ad723bcde990641de716d3f00000000bb5fbf3e000000000fc27a41195d61c0cdcc4c3ede990641de716d3f00000000bb5fbf3e0000003f0fc27a4110f561c0cdcc4c3e8f8a0641de716dbf00000000bb5fbfbe0000003f0fc27a4110f561c00ad723bc8f8a0641de716dbf00000000bb5fbfbe0000803f0fc27a41bea25dc00ad723bc98fe03412a4c743f000000005708993e0000000075a07b41bea25dc0cdcc4c3e98fe03412a4c743f000000005708993e0000003f75a07b41183f5ec0cdcc4c3e5af203412a4c74bf00000000570899be0000003f75a07b41183f5ec00ad723bc5af203412a4c74bf00000000570899be0000803f75a07b41d6bd5ac00ad723bcf34e014112b0793f00000000f4fd613e00000000327e7c41d6bd5ac0cdcc4c3ef34e014112b0793f00000000f4fd613e0000003f327e7c41a25d5bc0cdcc4c3ee945014112b079bf00000000f4fd61be0000003f327e7c41a25d5bc00ad723bce945014112b079bf00000000f4fd61be0000803f327e7c41c8b858c00ad723bca41bfd409c7f7d3f0000000076cd0e3e00000000a05b7d41c8b858c0cdcc4c3ea41bfd409c7f7d3f0000000076cd0e3e0000003fa05b7d41055b59c0cdcc4c3e3810fd409c7f7dbf0000000076cd0ebe0000003fa05b7d41055b59c00ad723bc3810fd409c7f7dbf0000000076cd0ebe0000803fa05b7d41649e57c00ad723bc157df740ba9a7f3f00000000d0a3633d000000002e397e41649e57c0cdcc4c3e157df740ba9a7f3f00000000d0a3633d0000003f2e397e41fa4158c0cdcc4c3e8778f740ba9a7fbf00000000d0a363bd0000003f2e397e41fa4158c00ad723bc8778f740ba9a7fbf00000000d0a363bd0000803f2e397e41657957c00ad723bc02caf140c4e17f3f00000000cfd0f8bc0000000063177f41657957c0cdcc4c3e02caf140c4e17f3f00000000cfd0f8bc0000003f63177f41291d58c0cdcc4c3e7fccf140c4e17fbf00000000cfd0f83c0000003f63177f41291d58c00ad723bc7fccf140c4e17fbf00000000cfd0f83c0000803f63177f41bd5358c00ad723bc6a0bec40fe387e3f00000000cceaf0bd00000000e4f67f41bd5358c0cdcc4c3e6a0bec40fe387e3f00000000cceaf0bd0000003fe4f67f4171f658c0cdcc4c3e0d15ec40fe387ebf00000000cceaf03d0000003fe4f67f4171f658c00ad723bc0d15ec40fe387ebf00000000cceaf03d0000803fe4f67f41c8355ac00ad723bc934be640848c7a3f00000000133152be00000000396c8041c8355ac0cdcc4c3e934be640848c7a3f00000000133152be0000003f396c804122d65ac0cdcc4c3e645ce640848c7abf000000001331523e0000003f396c804122d65ac00ad723bc645ce640848c7abf000000001331523e0000803f396c804160255dc00ad723bcd695e040bcd4743f000000004b9595be0000000078de804160255dc0cdcc4c3ed695e040bcd4743f000000004b9595be0000003f78de804111c25dc0cdcc4c3ec5ade040bcd474bf000000004b95953e0000003f78de804111c25dc00ad723bcc5ade040bcd474bf000000004b95953e0000803f78de8041282561c00ad723bc46f6da40101a6d3f000000003511c1be00000000b0528141282561c0cdcc4c3e46f6da40101a6d3f000000003511c1be0000003fb0528141e7bc61c0cdcc4c3e2a15db40101a6dbf000000003511c13e0000003fb0528141e7bc61c00ad723bc2a15db40101a6dbf000000003511c13e0000803fb05281410a3466c00ad723bc2d79d5402c77633f0000000073e8eabe0000000073c981410a3466c0cdcc4c3e2d79d5402c77633f0000000073e8eabe0000003f73c981419ec566c0cdcc4c3ec29ed5402c7763bf0000000073e8ea3e0000003f73c981419ec566c00ad723bcc29ed5402c7763bf0000000073e8ea3e0000803f73c98141264d6cc00ad723bc702ad0407619583f00000000863f09bf000000005e438241264d6cc0cdcc4c3e702ad0407619583f00000000863f09bf0000003f5e43824173d76cc0cdcc4c3e5c56d040761958bf00000000863f093f0000003f5e43824173d76cc00ad723bc5c56d040761958bf00000000863f093f0000803f5e438241
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -4.8949666, y: 0.095, z: 8.176058}
-    m_Extent: {x: 1.5281821, y: 0.105000004, z: 1.670877}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!43 &1210551775
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 540
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 124
-    localAABB:
-      m_Center: {x: -8.678727, y: 0.095, z: 0.4487927}
-      m_Extent: {x: 1.7886868, y: 0.105000004, z: 2.5596082}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 124
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 3968
-    _typelessdata: 367bdcc00ad723bce463f9bff4eca43e00000000d95a72bf000000005ad1fe40367bdcc0cdcc4c3ee463f9bff4eca43e00000000d95a72bf0000003f5ad1fe409a95dcc0cdcc4c3eae2df8bff4eca4be00000000d95a723f0000003f5ad1fe409a95dcc00ad723bcae2df8bff4eca4be00000000d95a723f0000803f5ad1fe40b0e4e3c00ad723bc792a01c0acd2813e0000000044a277bf0000000062e10041b0e4e3c0cdcc4c3e792a01c0acd2813e0000000044a277bf0000003f62e1004175f9e3c0cdcc4c3efc8b00c0acd281be0000000044a2773f0000003f62e1004175f9e3c00ad723bcfc8b00c0acd281be0000000044a2773f0000803f62e100411250ebc00ad723bcdb7104c0105d343e0000000067ff7bbf000000002b4402411250ebc0cdcc4c3edb7104c0105d343e0000000067ff7bbf0000003f2b4402417f5eebc0cdcc4c3e94d003c0105d34be0000000067ff7b3f0000003f2b4402417f5eebc00ad723bc94d003c0105d34be0000000067ff7b3f0000803f2b4402417ebef2c00ad723bc8a7306c060cdb73d0000000089f77ebf000000007f9303417ebef2c0cdcc4c3e8a7306c060cdb73d0000000089f77ebf0000003f7f930341d8c5f2c0cdcc4c3e5dd005c060cdb7bd0000000089f77e3f0000003f7f930341d8c5f2c00ad723bc5dd005c060cdb7bd0000000089f77e3f0000803f7f930341712cfac00ad723bc9a1707c000bfa3bb000000002fff7fbf000000001dd20441712cfac0cdcc4c3e9a1707c000bfa3bb000000002fff7fbf0000003f1dd20441082cfac0cdcc4c3ec37306c000bfa33b000000002fff7f3f0000003f1dd20441082cfac00ad723bcc37306c000bfa33b000000002fff7f3f0000803f1dd2044108c800c10ad723bc184606c00834dabd00000000f88a7ebf000000000603064108c800c1cdcc4c3e184606c00834dabd00000000f88a7ebf0000003f06030641abc300c1cdcc4c3e30a305c00834da3d00000000f88a7e3f0000003f06030641abc300c10ad723bc30a305c00834da3d00000000f88a7e3f0000803f060306415a6c04c10ad723bc82ec03c0b06559be000000000d2a7abf000000007e2907415a6c04c1cdcc4c3e82ec03c0b06559be000000000d2a7abf0000003f7e290741a86304c1cdcc4c3e664c03c0b065593e000000000d2a7a3f0000003f7e290741a86304c10ad723bc664c03c0b065593e000000000d2a7a3f0000803f7e290741e6f707c10ad723bcc80300c0f439a3be000000006fa472bf00000000ec480841e6f707c1cdcc4c3ec80300c0f439a3be000000006fa472bf0000003fec480841d7ea07c1cdcc4c3efad0febff439a33e000000006fa4723f0000003fec480841d7ea07c10ad723bcfad0febff439a33e000000006fa4723f0000803fec480841125e0bc10ad723bc012af5bfd025d8be00000000ad1168bf00000000cf640941125e0bc1cdcc4c3e012af5bfd025d8be00000000ad1168bf0000003fcf640941c74c0bc1cdcc4c3ef500f4bfd025d83e00000000ad11683f0000003fcf640941c74c0bc10ad723bcf500f4bfd025d83e00000000ad11683f0000803fcf6409410b930ec10ad723bc0f74e7bf2ccd04bf0000000034dc5abf0000000093800a410b930ec1cdcc4c3e0f74e7bf2ccd04bf0000000034dc5abf0000003f93800a41cc7d0ec1cdcc4c3eeb5be6bf2ccd043f0000000034dc5a3f0000003f93800a41cc7d0ec10ad723bceb5be6bf2ccd043f0000000034dc5a3f0000803f93800a41e08d11c10ad723bced32d7bfee151bbf0000000063ad4bbf000000007c9f0b41e08d11c1cdcc4c3eed32d7bfee151bbf0000000063ad4bbf0000003f7c9f0b41107511c1cdcc4c3e382ed6bfee151b3f0000000063ad4b3f0000003f7c9f0b41107511c10ad723bc382ed6bfee151b3f0000000063ad4b3f0000803f7c9f0b41914914c10ad723bc2cbfc4bfa2852ebf000000009a4a3bbf0000000086c40c41914914c1cdcc4c3e2cbfc4bfa2852ebf000000009a4a3bbf0000003f86c40c41a52d14c1cdcc4c3e70cfc3bfa2852e3f000000009a4a3b3f0000003f86c40c41a52d14c10ad723bc70cfc3bfa2852e3f000000009a4a3b3f0000803f86c40c4113c516c10ad723bc2a6eb0bfcc023fbf000000006b712abf0000000055f20d4113c516c1cdcc4c3e2a6eb0bfcc023fbf000000006b712abf0000003f55f20d4184a616c1cdcc4c3efe93afbfcc023f3f000000006b712a3f0000003f55f20d4184a616c10ad723bcfe93afbfcc023f3f000000006b712a3f0000803f55f20d416e0219c10ad723bc2a889abfbcb04cbf00000000ffbe19bf000000002b2b0f416e0219c1cdcc4c3e2a889abfbcb04cbf00000000ffbe19bf0000003f2b2b0f41aee118c1cdcc4c3e5ec399bfbcb04c3f00000000ffbe193f0000003f2b2b0f41aee118c10ad723bc5ec399bfbcb04c3f00000000ffbe193f0000803f2b2b0f4196051bc10ad723bc124483bf7ad857bf000000009ca509bf00000000ee70104196051bc1cdcc4c3e124483bf7ad857bf000000009ca509bf0000003fee7010410de31ac1cdcc4c3ee29382bf7ad8573f000000009ca5093f0000003fee7010410de31ac10ad723bce29382bf7ad8573f000000009ca5093f0000803fee70104154d31cc10ad723bcd68f55bfa7d360bf00000000c7dbf4be0000000028c5114154d31cc1cdcc4c3ed68f55bfa7d360bf00000000c7dbf4be0000003f28c511415baf1cc1cdcc4c3e6c5654bfa7d3603f00000000c7dbf43e0000003f28c511415baf1cc10ad723bc6c5654bfa7d3603f00000000c7dbf43e0000803f28c5114183701ec10ad723bcca5722bf70fd67bf00000000a57cd8be000000001029134183701ec1cdcc4c3eca5722bf70fd67bf00000000a57cd8be0000003f10291341654b1ec1cdcc4c3eb04221bf70fd673f00000000a57cd83e0000003f10291341654b1ec10ad723bcb04221bf70fd673f00000000a57cd83e0000803f10291341a5e11fc10ad723bc23f8d9beeaa96dbf000000009748bebe000000009b9d1441a5e11fc1cdcc4c3e23f8d9beeaa96dbf000000009748bebe0000003f9b9d14419ebb1fc1cdcc4c3e0311d8beeaa96d3f000000009748be3e0000003f9b9d14419ebb1fc10ad723bc0311d8beeaa96d3f000000009748be3e0000803f9b9d1441ae2a21c10ad723bc2e2d56be142272bf000000003039a6be000000007f231641ae2a21c1cdcc4c3e2e2d56be142272bf000000003039a6be0000003f7f231641f00321c1cdcc4c3e1eda52be1422723f000000003039a63e0000003f7f231641f00321c10ad723bc1eda52be1422723f000000003039a63e0000803f7f231641f14e22c10ad723bc60047d3c00a375bf00000000df3390be0000000042bb1741f14e22c1cdcc4c3e60047d3c00a375bf00000000df3390be0000003f42bb1741a32722c1cdcc4c3eb894953c00a3753f00000000df33903e0000003f42bb1741a32722c10ad723bcb894953c00a3753f00000000df33903e0000803f42bb1741355123c10ad723bc66ff7d3e895e78bf00000000d82678be000000003f651941355123c1cdcc4c3e66ff7d3e895e78bf00000000d82678be0000003f3f651941772923c1cdcc4c3e553d803e895e783f00000000d826783e0000003f3f651941772923c10ad723bc553d803e895e783f00000000d826783e0000803f3f651941c33324c10ad723bc8a2ffa3ec67c7abf00000000285c53be00000000af211b41c33324c1cdcc4c3e8a2ffa3ec67c7abf00000000285c53be0000003faf211b41af0b24c1cdcc4c3e143efb3ec67c7a3f00000000285c533e0000003faf211b41af0b24c10ad723bc143efb3ec67c7a3f00000000285c533e0000803faf211b4176f824c10ad723bcb0bb3c3fab1d7cbf0000000028b331be00000000aef01c4176f824c1cdcc4c3eb0bb3c3fab1d7cbf0000000028b331be0000003faef01c411fd024c1cdcc4c3e6b2d3d3fab1d7c3f0000000028b3313e0000003faef01c411fd024c10ad723bc6b2d3d3fab1d7c3f0000000028b3313e0000803faef01c41d5a025c10ad723bce16a7e3f905a7dbf0000000081da12be000000003ed21e41d5a025c1cdcc4c3ee16a7e3f905a7dbf0000000081da12be0000003f3ed21e414c7825c1cdcc4c3eddc87e3f905a7d3f0000000081da123e0000003f3ed21e414c7825c10ad723bcddc87e3f905a7d3f0000000081da123e0000803f3ed21e41282e26c10ad723bcbc11a13f84477ebf00000000b10cedbd0000000052c62041282e26c1cdcc4c3ebc11a13f84477ebf00000000b10cedbd0000003f52c62041790526c1cdcc4c3eaa37a13f84477e3f00000000b10ced3d0000003f52c62041790526c10ad723bcaa37a13f84477e3f00000000b10ced3d0000803f52c6204178a126c10ad723bc12f1c33f63f47ebf000000001de4b8bd00000000c6cc224178a126c1cdcc4c3e12f1c33f63f47ebf000000001de4b8bd0000003fc6cc2241ad7826c1cdcc4c3ea70ec43f63f47e3f000000001de4b83d0000003fc6cc2241ad7826c10ad723bca70ec43f63f47e3f000000001de4b83d0000803fc6cc2241a8fb26c10ad723bc25d1e73fc06d7fbf0000000075be88bd000000006de52441a8fb26c1cdcc4c3e25d1e73fc06d7fbf0000000075be88bd0000003f6de52441cad226c1cdcc4c3e06e7e73fc06d7f3f0000000075be883d0000003f6de52441cad226c10ad723bc06e7e73fc06d7f3f0000000075be883d0000803f6de524417b3d27c10ad723bc7657064096bd7fbf000000005d5b38bd000000000d1027417b3d27c1cdcc4c3e7657064096bd7fbf000000005d5b38bd0000003f0d102741901427c1cdcc4c3ed65e064096bd7f3f000000005d5b383d0000003f0d102741901427c10ad723bcd65e064096bd7f3f000000005d5b383d0000803f0d102741946727c10ad723bc66431940d4eb7fbf00000000fa3bcbbc00000000614c2941946727c1cdcc4c3e66431940d4eb7fbf00000000fa3bcbbc0000003f614c2941a23e27c1cdcc4c3e76471940d4eb7f3f00000000fa3bcb3c0000003f614c2941a23e27c10ad723bc76471940d4eb7f3f00000000fa3bcb3c0000803f614c2941877a27c10ad723bc42aa2c40d2fe7fbf00000000aebfc4bb000000001c9a2b41877a27c1cdcc4c3e42aa2c40d2fe7fbf00000000aebfc4bb0000003f1c9a2b41925127c1cdcc4c3e3eab2c40d2fe7f3f00000000aebfc43b0000003f1c9a2b41925127c10ad723bc3eab2c40d2fe7f3f00000000aebfc43b0000803f1c9a2b41d57627c10ad723bca4894040a1fb7fbf000000008c443d3c00000000eaf82d41d57627c1cdcc4c3ea4894040a1fb7fbf000000008c443d3c0000003feaf82d41e04d27c1cdcc4c3ebf874040a1fb7f3f000000008c443dbc0000003feaf82d41e04d27c10ad723bcbf874040a1fb7f3f000000008c443dbc0000803feaf82d41
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -8.678727, y: 0.095, z: 0.4487927}
-    m_Extent: {x: 1.7886868, y: 0.105000004, z: 2.5596082}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!43 &1215602285
+--- !u!43 &255452631
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -7207,8 +952,8 @@ Mesh:
     firstVertex: 0
     vertexCount: 93
     localAABB:
-      m_Center: {x: -2.4059653, y: 0, z: 0.66727567}
-      m_Extent: {x: 5.0059104, y: 0, z: 2.6156366}
+      m_Center: {x: -5.4979196, y: 0, z: 5.20432}
+      m_Extent: {x: 1.8057108, y: 0, z: 2.1693838}
   m_Shapes:
     vertices: []
     shapes: []
@@ -7287,7 +1032,7 @@ Mesh:
       format: 0
       dimension: 0
     m_DataSize: 2976
-    _typelessdata: 8165264000000000a887eb3f000000800000803f0000000000000000e34d3a4001d30e400000000088ef2340000000800000803f000000000000003fe34d3a400381ee3f000000003c1b5240000000800000803f000000000000803fe34d3a40f2b31c400000000044fbe13f000000800000803f00000000000000006f093f40075506400000000063c11f40000000800000803f000000000000003f6f093f4037ecdf3f0000000024854e40000000800000803f000000000000803f6f093f403a5a114000000000425dd73f000000800000803f0000000000000000a7e344406e75f73f0000000015cc1a40000000800000803f000000000000003fa7e344406836cc3f0000000089e94940000000800000803f000000000000803fa7e344408e44044000000000f089cb3f000000800000803f00000000000000009ac94b404c50de3f00000000bc1d1540000000800000803f000000000000003f9ac94b407c17b43f0000000080764440000000800000803f000000000000803f9ac94b40edfbea3f00000000e482be3f000000800000803f00000000000000001fa85340e282c13f0000000082c40e40000000800000803f000000000000003f1fa85340d709983f0000000092473e40000000800000803f000000000000803f1fa853402c3bca3f000000003657b03f000000800000803f0000000000000000fd6b5c405455a13f0000000087ce0740000000800000803f000000000000003ffd6b5c40f8de703f0000000073713740000000800000803f000000000000803ffd6b5c406380a63f00000000061ca13f000000800000803f0000000000000000e7016640bf1f7c3f00000000f3490040000000800000803f000000000000003fe7016640b83e2b3f00000000e3053040000000800000803f000000000000803fe7016640c40a803f0000000050e9903f000000800000803f00000000000000008f56704051f52f3f00000000cd89f03f000000800000803f000000000000003f8f56704032aabf3e0000000025152840000000800000803f000000000000803f8f56704067392e3f0000000064b17f3f000000800000803f00000000000000009c567b409c77bd3e00000000179bdf3f000000800000803f000000000000003f9c567b4050e3733d00000000beae1f40000000800000803f000000000000803f9c567b40d4e9af3e000000003f095c3f000000800000803f00000000000000005b7783404439103d0000000003e4cd3f000000800000803f000000000000003f5b77834084db8bbe00000000b3e11640000000800000803f000000000000803f5b778340804a0bbc000000004b10373f000000800000803f0000000000000000c28589400646a1be00000000dd80bb3f000000800000803f000000000000003fc2858940dc181fbf00000000cabc0d40000000800000803f000000000000803fc2858940de40bfbe000000005afd103f000000800000803f0000000000000000d2cc8f4087a72dbf00000000f48da83f000000800000803f000000000000003fd2cc8f409fae7bbf000000009e4e0440000000800000803f000000000000803fd2cc8f40add73fbf000000002a0fd43e000000800000803f0000000000000000e0429640d6bc86bf000000008a27953f000000800000803f000000000000003fe0429640d68dadbf000000004a4bf53f000000800000803f000000000000803fe0429640742291bf000000000acd843e000000800000803f00000000000000003bde9c4082c4b7bf00000000e969813f000000800000803f000000000000003f3bde9c409066debf0000000090a0e13f000000800000803f000000000000803f3bde9c40db2cc3bf00000000308fd23d000000800000803f00000000000000003495a34096a2e9bf00000000b3e25a3f000000800000803f000000000000003f3495a340280c08c000000000c0b9cd3f000000800000803f000000000000803f3495a340b8c3f5bf00000000e0e55fbd000000800000803f00000000000000001a5eaa4074070ec00000000054b4323f000000800000803f000000000000003f1a5eaa400c2d21c00000000083b3b93f000000800000803f000000000000803f1a5eaa40c84f14c000000000844959be000000800000803f0000000000000000402fb140a26027c0000000003b810a3f000000800000803f000000000000003f402fb1407c713ac0000000006caaa53f000000800000803f000000000000803f402fb14076bc2dc00000000030e4bcbe000000800000803f0000000000000000f4feb740bcb840c000000000f803c53e000000800000803f000000000000003ff4feb74002b553c00000000008bb913f000000800000803f000000000000803ff4feb740280447c0000000007e2506bf000000800000803f000000000000000088c3be40aeeb59c000000000b0bc6b3e000000800000803f000000000000003f88c3be4034d36cc000000000d6037c3f000000800000803f000000000000803f88c3be401e0360c0000000008f342dbf000000800000803f00000000000000004c73c5405ad572c000000000e80aa03d000000800000803f000000000000003f4c73c540cbd382c0000000004937553f000000800000803f000000000000803f4c73c540a89578c000000000546753bf000000800000803f00000000000000008e04cc40d6a885c000000000f47690bd000000800000803f000000000000003f8e04cc40d8068fc00000000096492f3f000000800000803f000000000000803f8e04cc40104c88c000000000ed8578bf000000800000803f0000000000000000a06dd240449e91c000000000d4235cbe000000800000803f000000000000003fa06dd24078f09ac00000000003740a3f000000800000803f000000000000803fa06dd24081f393c0000000004a2c8ebf000000800000803f0000000000000000d4a4d840ed389dc000000000aa68b5be000000800000803f000000000000003fd4a4d840597ea6c000000000d6dfcd3e000000800000803f000000000000803fd4a4d840742f9fc000000000e4539fbf000000800000803f000000000000000076a0de40c266a8c000000000d8b0f9be000000800000803f000000000000003f76a0de40109eb1c000000000e0ed893e000000800000803f000000000000803f76a0de405aeea9c000000000259eafbf000000800000803f0000000000000000de56e440bb15b3c000000000a83c1dbf000000800000803f000000000000003fde56e4401c3dbcc000000000e80b133e000000800000803f000000000000803fde56e440c71eb4c000000000adefbebf000000800000803f000000000000000058bee940c833bdc00000000077a83bbf000000800000803f000000000000003f58bee940c948c6c00000000080cdd13c000000800000803f000000000000803f58bee940a1afbdc000000000772dcdbf000000800000803f000000000000000038cdee40e0aec6c00000000046e357bf000000800000803f000000000000003f38cdee401faecfc000000000f05cabbd000000800000803f000000000000803f38cdee403e90c6c0000000001c3ddabf000000800000803f0000000000000000d279f340f474cfc00000000084b471bf000000800000803f000000000000003fd279f340aa59d8c0000000003cbb3bbe000000800000803f000000000000803fd279f340c6b0cec0000000003605e6bf000000800000803f00000000000000007abaf740fb73d7c000000000cf7184bf000000800000803f000000000000003f7abaf7403037e0c000000000a2798bbe000000800000803f000000000000803f7abaf740dd02d6c0000000002c6ef0bf000000800000803f00000000000000008a85fb40e699dec000000000019c8ebf000000800000803f000000000000003f8a85fb40ef30e7c0000000005827b3be000000800000803f000000000000803f8a85fb40367bdcc000000000e463f9bf000000800000803f00000000000000005ad1fe40a6d4e4c0000000008a3c97bf000000800000803f000000000000003f5ad1fe40162eedc000000000be54d4be000000800000803f000000000000803f5ad1fe40
+    _typelessdata: 264d6cc000000000702ad040000000000000803f00000000000000005e438241df078cc000000000e90fde40000000000000803f000000000000003f5e4382412be9a1c00000000062f5eb40000000000000803f000000000000803f5e438241c98a70c000000000d7d4cc40000000000000803f0000000000000000dec08241a1228ec000000000b3c0da40000000000000803f000000000000003fdec08241ddffa3c0000000008face840000000000000803f000000000000803fdec0824155e674c000000000e469c940000000000000803f0000000000000000af418341984c90c000000000b95bd740000000000000803f000000000000003faf4183410626a6c0000000008e4de540000000000000803f000000000000803faf418341b05d79c00000000025ebc540000000000000803f000000000000000093c58341af8492c00000000097e2d340000000000000803f000000000000003f93c58341865aa8c00000000009dae140000000000000803f000000000000803f93c58341ddee7dc000000000305ac240000000000000803f00000000000000004c4c8441dec994c000000000f456d040000000000000803f000000000000003f4c4c84414e9caac000000000b853de40000000000000803f000000000000803f4c4c8441e04b81c00000000097b8be40000000000000803f00000000000000009bd58441111b97c00000000068bacc40000000000000803f000000000000003f9bd5844142eaacc00000000039bcda40000000000000803f000000000000803f9bd5844129ab83c000000000f307bb40000000000000803f0000000000000000436185413d7799c0000000009c0ec940000000000000803f000000000000003f436185415143afc0000000004515d740000000000000803f000000000000803f436185413b1486c000000000db49b740000000000000803f000000000000000006ef854150dd9bc0000000002b55c540000000000000803f000000000000003f06ef854165a6b1c0000000007b60d340000000000000803f000000000000803f06ef8541168688c000000000ea7fb340000000000000803f0000000000000000a47e8641424c9ec000000000bd8fc140000000000000803f000000000000003fa47e86416e12b4c000000000909fcf40000000000000803f000000000000803fa47e8641a4ff8ac000000000b8abaf40000000000000803f0000000000000000e10f8741fbc2a0c000000000edbfbd40000000000000803f000000000000003fe10f87415286b6c00000000022d4cb40000000000000803f000000000000803fe10f8741e37f8dc000000000ddceab40000000000000803f00000000000000007fa287417340a3c0000000005ce7b940000000000000803f000000000000003f7fa287410301b9c000000000dbffc740000000000000803f000000000000803f7fa28741c80590c000000000faeaa740000000000000803f00000000000000003e3688419cc3a5c000000000b107b640000000000000803f000000000000003f3e3688417081bbc0000000006824c440000000000000803f000000000000803f3e368841459092c000000000a601a440000000000000803f0000000000000000e1ca8841644ba8c0000000008722b240000000000000803f000000000000003fe1ca88418306bec0000000006843c040000000000000803f000000000000803fe1ca88414e1e95c0000000007d14a040000000000000803f00000000000000002a608941bdd6aac0000000008039ae40000000000000803f000000000000003f2a6089412c8fc0c000000000835ebc40000000000000803f000000000000803f2a608941dbae97c0000000001a259c40000000000000803f0000000000000000dbf589419964adc0000000003d4eaa40000000000000803f000000000000003fdbf58941571ac3c0000000006077b840000000000000803f000000000000803fdbf58941df409ac0000000001e359840000000000000803f0000000000000000b58b8a41ebf3afc0000000006362a640000000000000803f000000000000003fb58b8a41f7a6c5c000000000a88fb440000000000000803f000000000000803fb58b8a4150d39cc0000000001e469440000000000000803f00000000000000007b218b41a383b2c0000000008d77a240000000000000803f000000000000003f7b218b41f633c8c000000000fca8b040000000000000803f000000000000803f7b218b4120659fc000000000ba599040000000000000803f0000000000000000eeb68b41b012b5c000000000608f9e40000000000000803f000000000000003feeb68b4140c0cac00000000006c5ac40000000000000803f000000000000803feeb68b414af5a1c0000000008b718c40000000000000803f0000000000000000d04b8c4109a0b7c0000000007bab9a40000000000000803f000000000000003fd04b8c41c84acdc0000000006be5a840000000000000803f000000000000803fd04b8c41bb82a4c0000000002d8f8840000000000000803f0000000000000000e4df8c41992abac0000000007fcd9640000000000000803f000000000000003fe4df8c4177d2cfc000000000d10ba540000000000000803f000000000000803fe4df8c416e0ca7c0000000003cb48440000000000000803f0000000000000000eb728d4156b1bcc0000000000ef79240000000000000803f000000000000003feb728d413e56d2c000000000e039a140000000000000803f000000000000803feb728d415991a9c00000000054e28040000000000000803f0000000000000000a6048e413233bfc000000000ca298f40000000000000803f000000000000003fa6048e410bd5d4c00000000040719d40000000000000803f000000000000803fa6048e417010acc00000000017367a40000000000000803f0000000000000000d8948e411bafc1c00000000051678b40000000000000803f000000000000003fd8948e41c64dd7c00000000097b39940000000000000803f000000000000803fd8948e41ab88aec000000000f7bf7240000000000000803f000000000000000044238f410424c4c00000000045b18740000000000000803f000000000000003f44238f415dbfd9c0000000008f029640000000000000803f000000000000803f44238f4100f9b0c00000000083656b40000000000000803f0000000000000000a9af8f41de90c6c0000000004a098440000000000000803f000000000000003fa9af8f41bc28dcc000000000d35f9240000000000000803f000000000000803fa9af8f416960b3c000000000dc296440000000000000803f0000000000000000cc3990419cf4c8c000000000fc708040000000000000803f000000000000003fcc399041cf88dec0000000000acd8e40000000000000803f000000000000803fcc399041debdb5c00000000035105d40000000000000803f00000000000000006cc190412d4ecbc000000000fed37940000000000000803f000000000000003f6cc190417cdee0c000000000e44b8b40000000000000803f000000000000803f6cc190415a10b8c000000000b51b5640000000000000803f00000000000000004d469141849ccdc000000000e8eb7240000000000000803f000000000000003f4d469141ae28e3c0000000000dde8740000000000000803f000000000000803f4d469141d956bac000000000804f4f40000000000000803f000000000000000030c8914193decfc000000000f62c6c40000000000000803f000000000000003f30c891414d66e5c00000000036858440000000000000803f000000000000803f30c891415990bcc000000000b1ae4840000000000000803f0000000000000000d84692414913d2c0000000006a9a6540000000000000803f000000000000003fd84692413996e7c00000000012438140000000000000803f000000000000803fd8469241dbbbbec000000000663c4240000000000000803f000000000000000005c292419939d4c0000000008d375f40000000000000803f000000000000003f05c2924157b7e9c000000000b4327c40000000000000803f000000000000803f05c29241
   m_CompressedMesh:
     m_Vertices:
       m_NumItems: 0
@@ -7341,8 +1086,8 @@ Mesh:
       m_BitSize: 0
     m_UVInfo: 0
   m_LocalAABB:
-    m_Center: {x: -2.4059653, y: 0, z: 0.66727567}
-    m_Extent: {x: 5.0059104, y: 0, z: 2.6156366}
+    m_Center: {x: -5.4979196, y: 0, z: 5.20432}
+    m_Extent: {x: 1.8057108, y: 0, z: 2.1693838}
   m_MeshUsageFlags: 0
   m_BakedConvexCollisionMesh: 
   m_BakedTriangleCollisionMesh: 
@@ -7353,2503 +1098,7 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1 &1236410748
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1236410749}
-  m_Layer: 0
-  m_Name: generated by SplineExtrusion
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1236410749
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1236410748}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 103254123}
-  - {fileID: 1184662545}
-  - {fileID: 150282010}
-  - {fileID: 1904266821}
-  - {fileID: 581401479}
-  - {fileID: 716379424}
-  - {fileID: 1517055540}
-  - {fileID: 459612992}
-  - {fileID: 1834044262}
-  - {fileID: 1757001463}
-  - {fileID: 1801657008}
-  m_Father: {fileID: 1614957931}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1240106738
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1240106739}
-  - component: {fileID: 1240106743}
-  - component: {fileID: 1240106742}
-  - component: {fileID: 1240106741}
-  - component: {fileID: 1240106740}
-  m_Layer: 0
-  m_Name: segment 6
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1240106739
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1240106738}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 539737851}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1240106740
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1240106738}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 891327314}
---- !u!114 &1240106741
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1240106738}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &1240106742
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1240106738}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1240106743
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1240106738}
-  m_Mesh: {fileID: 891327314}
---- !u!1 &1272024234
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1272024235}
-  m_Layer: 0
-  m_Name: generated by SplineExtrusion
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1272024235
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1272024234}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 821476872}
-  - {fileID: 2079892565}
-  - {fileID: 2074913392}
-  - {fileID: 1401999871}
-  - {fileID: 253818113}
-  - {fileID: 1062259793}
-  - {fileID: 146459550}
-  - {fileID: 1864002381}
-  - {fileID: 1926398521}
-  - {fileID: 380648187}
-  - {fileID: 94385859}
-  m_Father: {fileID: 139875388}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1291100383
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1291100384}
-  - component: {fileID: 1291100388}
-  - component: {fileID: 1291100387}
-  - component: {fileID: 1291100386}
-  - component: {fileID: 1291100385}
-  m_Layer: 0
-  m_Name: segment 7
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1291100384
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1291100383}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 539737851}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1291100385
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1291100383}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1974503200}
---- !u!114 &1291100386
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1291100383}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &1291100387
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1291100383}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1291100388
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1291100383}
-  m_Mesh: {fileID: 1974503200}
---- !u!1 &1297241109
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1297241110}
-  - component: {fileID: 1297241114}
-  - component: {fileID: 1297241113}
-  - component: {fileID: 1297241112}
-  - component: {fileID: 1297241111}
-  m_Layer: 0
-  m_Name: segment 3
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1297241110
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1297241109}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 539737851}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1297241111
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1297241109}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 595044863}
---- !u!114 &1297241112
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1297241109}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &1297241113
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1297241109}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1297241114
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1297241109}
-  m_Mesh: {fileID: 595044863}
---- !u!43 &1390907342
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 540
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 124
-    localAABB:
-      m_Center: {x: -2.1466584, y: 0.095, z: -0.049688578}
-      m_Extent: {x: 4.7466035, y: 0.105000004, z: 1.8986723}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 124
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 3968
-    _typelessdata: 816526400ad723bca887eb3ffccfe83e00000000e60064bf00000000e34d3a4081652640cdcc4c3ea887eb3ffccfe83e00000000e60064bf0000003fe34d3a40011b2640cdcc4c3e80abec3ffccfe8be00000000e600643f0000003fe34d3a40011b26400ad723bc80abec3ffccfe8be00000000e600643f0000803fe34d3a40f2b31c400ad723bc44fbe13f2cf2dc3e00000000c5ef66bf000000006f093f40f2b31c40cdcc4c3e44fbe13f2cf2dc3e00000000c5ef66bf0000003f6f093f403f6d1c40cdcc4c3ede22e33f2cf2dcbe00000000c5ef663f0000003f6f093f403f6d1c400ad723bcde22e33f2cf2dcbe00000000c5ef663f0000803f6f093f403a5a11400ad723bc425dd73fb88fd53e00000000bbaa68bf00000000a7e344403a5a1140cdcc4c3e425dd73fb88fd53e00000000bbaa68bf0000003fa7e34440e3151140cdcc4c3e1287d83fb88fd5be00000000bbaa683f0000003fa7e34440e31511400ad723bc1287d83fb88fd5be00000000bbaa683f0000803fa7e344408e4404400ad723bcf089cb3fdc80d03e00000000a1cf69bf000000009ac94b408e440440cdcc4c3ef089cb3fdc80d03e00000000a1cf69bf0000003f9ac94b40d6010440cdcc4c3e38b5cc3fdc80d0be00000000a1cf693f0000003f9ac94b40d60104400ad723bc38b5cc3fdc80d0be00000000a1cf693f0000803f9ac94b40edfbea3f0ad723bce482be3fd8cdcc3e0000000083a06abf000000001fa85340edfbea3fcdcc4c3ee482be3fd8cdcc3e0000000083a06abf0000003f1fa85340da78ea3fcdcc4c3e36afbf3fd8cdccbe0000000083a06a3f0000003f1fa85340da78ea3f0ad723bc36afbf3fd8cdccbe0000000083a06a3f0000803f1fa853402c3bca3f0ad723bc3657b03ff0f6c93e00000000d63d6bbf00000000fd6b5c402c3bca3fcdcc4c3e3657b03ff0f6c93e00000000d63d6bbf0000003ffd6b5c40eab9c93fcdcc4c3e5284b13ff0f6c9be00000000d63d6b3f0000003ffd6b5c40eab9c93f0ad723bc5284b13ff0f6c9be00000000d63d6b3f0000803ffd6b5c406380a63f0ad723bc061ca13f88b3c73e000000005fb96bbf00000000e70166406380a63fcdcc4c3e061ca13f88b3c73e000000005fb96bbf0000003fe70166409400a63fcdcc4c3ec049a23f88b3c7be000000005fb96b3f0000003fe70166409400a63f0ad723bcc049a23f88b3c7be000000005fb96b3f0000803fe7016640c40a803f0ad723bc50e9903f74d7c53e00000000a71d6cbf000000008f567040c40a803fcdcc4c3e50e9903f74d7c53e00000000a71d6cbf0000003f8f5670404c187f3fcdcc4c3e8a17923f74d7c5be00000000a71d6c3f0000003f8f5670404c187f3f0ad723bc8a17923f74d7c5be00000000a71d6c3f0000803f8f56704067392e3f0ad723bc64b17f3fec45c43e000000005e716cbf000000009c567b4067392e3fcdcc4c3e64b17f3fec45c43e000000005e716cbf0000003f9c567b402c3e2d3fcdcc4c3e5807813fec45c4be000000005e716c3f0000003f9c567b402c3e2d3f0ad723bc5807813fec45c4be000000005e716c3f0000803f9c567b40d4e9af3e0ad723bc3f095c3f98ebc23e00000000f6b86cbf000000005b778340d4e9af3ecdcc4c3e3f095c3f98ebc23e00000000f6b86cbf0000003f5b778340d6f6ad3ecdcc4c3e41675e3f98ebc2be00000000f6b86c3f0000003f5b778340d6f6ad3e0ad723bc41675e3f98ebc2be00000000f6b86c3f0000803f5b778340804a0bbc0ad723bc4b10373fb0bac13e0000000080f76cbf00000000c2858940804a0bbccdcc4c3e4b10373fb0bac13e0000000080f76cbf0000003fc2858940c04849bccdcc4c3eed6e393fb0bac1be0000000080f76c3f0000003fc2858940c04849bc0ad723bced6e393fb0bac1be0000000080f76c3f0000803fc2858940de40bfbe0ad723bc5afd103f38a9c03e00000000342f6dbf00000000d2cc8f40de40bfbecdcc4c3e5afd103f38a9c03e00000000342f6dbf0000003fd2cc8f40142ec1becdcc4c3e8b5c133f38a9c0be00000000342f6d3f0000003fd2cc8f40142ec1be0ad723bc8b5c133f38a9c0be00000000342f6d3f0000803fd2cc8f40add73fbf0ad723bc2a0fd43e98afbf3e00000000c0616dbf00000000e0429640add73fbfcdcc4c3e2a0fd43e98afbf3e00000000c0616dbf0000003fe042964008cd40bfcdcc4c3e8eced83e98afbfbe00000000c0616d3f0000003fe042964008cd40bf0ad723bc8eced83e98afbfbe00000000c0616d3f0000803fe0429640742291bf0ad723bc0acd843ec4c7be3e000000006c906dbf000000003bde9c40742291bfcdcc4c3e0acd843ec4c7be3e000000006c906dbf0000003f3bde9c408e9c91bfcdcc4c3e5e8d893ec4c7bebe000000006c906d3f0000003f3bde9c408e9c91bf0ad723bc5e8d893ec4c7bebe000000006c906d3f0000803f3bde9c40db2cc3bf0ad723bc308fd23de4ecbd3e0000000040bc6dbf000000003495a340db2cc3bfcdcc4c3e308fd23de4ecbd3e0000000040bc6dbf0000003f3495a34068a6c3bfcdcc4c3e0094e53de4ecbdbe0000000040bc6d3f0000003f3495a34068a6c3bf0ad723bc0094e53de4ecbdbe0000000040bc6d3f0000803f3495a340b8c3f5bf0ad723bce0e55fbdd01abd3e0000000018e66dbf000000001a5eaa40b8c3f5bfcdcc4c3ee0e55fbdd01abd3e0000000018e66dbf0000003f1a5eaa40be3cf6bfcdcc4c3e90d539bdd01abdbe0000000018e66d3f0000003f1a5eaa40be3cf6bf0ad723bc90d539bdd01abdbe0000000018e66d3f0000803f1a5eaa40c84f14c00ad723bc844959beec4dbc3e00000000ba0e6ebf00000000402fb140c84f14c0cdcc4c3e844959beec4dbc3e00000000ba0e6ebf0000003f402fb1400a8c14c0cdcc4c3ed0c34fbeec4dbcbe00000000ba0e6e3f0000003f402fb1400a8c14c00ad723bcd0c34fbeec4dbcbe00000000ba0e6e3f0000803f402fb14076bc2dc00ad723bc30e4bcbeb882bb3e00000000d0366ebf00000000f4feb74076bc2dc0cdcc4c3e30e4bcbeb882bb3e00000000d0366ebf0000003ff4feb74076f82dc0cdcc4c3e8820b8beb882bbbe00000000d0366e3f0000003ff4feb74076f82dc00ad723bc8820b8beb882bbbe00000000d0366e3f0000803ff4feb740280447c00ad723bc7e2506bfc0b5ba3e000000000b5f6ebf0000000088c3be40280447c0cdcc4c3e7e2506bfc0b5ba3e000000000b5f6ebf0000003f88c3be40e83f47c0cdcc4c3e43c303bfc0b5babe000000000b5f6e3f0000003f88c3be40e83f47c00ad723bc43c303bfc0b5babe000000000b5f6e3f0000803f88c3be401e0360c00ad723bc8f342dbf84e3b93e000000001a886ebf000000004c73c5401e0360c0cdcc4c3e8f342dbf84e3b93e000000001a886ebf0000003f4c73c5409a3e60c0cdcc4c3eebd12abf84e3b9be000000001a886e3f0000003f4c73c5409a3e60c00ad723bcebd12abf84e3b9be000000001a886e3f0000803f4c73c540a89578c00ad723bc546753bf1008b93e00000000bdb26ebf000000008e04cc40a89578c0cdcc4c3e546753bf1008b93e00000000bdb26ebf0000003f8e04cc40ded078c0cdcc4c3e420451bf1008b9be00000000bdb26e3f0000003f8e04cc40ded078c00ad723bc420451bf1008b9be00000000bdb26e3f0000803f8e04cc40104c88c00ad723bced8578bfe81eb83e00000000d0df6ebf00000000a06dd240104c88c0cdcc4c3eed8578bfe81eb83e00000000d0df6ebf0000003fa06dd240856988c0cdcc4c3e682276bfe81eb8be00000000d0df6e3f0000003fa06dd240856988c00ad723bc682276bfe81eb8be00000000d0df6e3f0000803fa06dd24081f393c00ad723bc4a2c8ebf6c22b73e000000004f106fbf00000000d4a4d84081f393c0cdcc4c3e4a2c8ebf6c22b73e000000004f106fbf0000003fd4a4d840ce1094c0cdcc4c3e4afa8cbf6c22b7be000000004f106f3f0000003fd4a4d840ce1094c00ad723bc4afa8cbf6c22b7be000000004f106f3f0000803fd4a4d840742f9fc00ad723bce4539fbf8c0bb63e0000000088456fbf0000000076a0de40742f9fc0cdcc4c3ee4539fbf8c0bb63e0000000088456fbf0000003f76a0de40954c9fc0cdcc4c3ea0219ebf8c0bb6be0000000088456f3f0000003f76a0de40954c9fc00ad723bca0219ebf8c0bb6be0000000088456f3f0000803f76a0de405aeea9c00ad723bc259eafbf00d1b43e0000000020816fbf00000000de56e4405aeea9c0cdcc4c3e259eafbf00d1b43e0000000020816fbf0000003fde56e440480baac0cdcc4c3e946baebf00d1b4be0000000020816f3f0000003fde56e440480baac00ad723bc946baebf00d1b4be0000000020816f3f0000803fde56e440c71eb4c00ad723bcadefbebf0066b33e0000000057c56fbf0000000058bee940c71eb4c0cdcc4c3eadefbebf0066b33e0000000057c56fbf0000003f58bee9407b3bb4c0cdcc4c3ec5bcbdbf0066b3be0000000057c56f3f0000003f58bee9407b3bb4c00ad723bcc5bcbdbf0066b3be0000000057c56f3f0000803f58bee940a1afbdc00ad723bc772dcdbf34b8b13e000000004e1570bf0000000038cdee40a1afbdc0cdcc4c3e772dcdbf34b8b13e000000004e1570bf0000003f38cdee4011ccbdc0cdcc4c3e28facbbf34b8b1be000000004e15703f0000003f38cdee4011ccbdc00ad723bc28facbbf34b8b1be000000004e15703f0000803f38cdee403e90c6c00ad723bc1c3ddabf10acaf3e00000000aa7570bf00000000d279f3403e90c6c0cdcc4c3e1c3ddabf10acaf3e00000000aa7570bf0000003fd279f3405aacc6c0cdcc4c3e5309d9bf10acafbe00000000aa75703f0000003fd279f3405aacc6c00ad723bc5309d9bf10acafbe00000000aa75703f0000803fd279f340c6b0cec00ad723bc3605e6bf4416ad3e0000000088ed70bf000000007abaf740c6b0cec0cdcc4c3e3605e6bf4416ad3e0000000088ed70bf0000003f7abaf74078cccec0cdcc4c3ed2d0e4bf4416adbe0000000088ed703f0000003f7abaf74078cccec00ad723bcd2d0e4bf4416adbe0000000088ed703f0000803f7abaf740dd02d6c00ad723bc2c6ef0bfbcada93e00000000838871bf000000008a85fb40dd02d6c0cdcc4c3e2c6ef0bfbcada93e00000000838871bf0000003f8a85fb40031ed6c0cdcc4c3e0239efbfbcada9be000000008388713f0000003f8a85fb40031ed6c00ad723bc0239efbfbcada9be000000008388713f0000803f8a85fb40367bdcc00ad723bce463f9bff4eca43e00000000d95a72bf000000005ad1fe40367bdcc0cdcc4c3ee463f9bff4eca43e00000000d95a72bf0000003f5ad1fe409a95dcc0cdcc4c3eae2df8bff4eca4be00000000d95a723f0000003f5ad1fe409a95dcc00ad723bcae2df8bff4eca4be00000000d95a723f0000803f5ad1fe40
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -2.1466584, y: 0.095, z: -0.049688578}
-    m_Extent: {x: 4.7466035, y: 0.105000004, z: 1.8986723}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!1 &1394308946
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1394308949}
-  - component: {fileID: 1394308948}
-  - component: {fileID: 1394308947}
-  m_Layer: 0
-  m_Name: EventSystem
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1394308947
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1394308946}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 1077351063, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
---- !u!114 &1394308948
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1394308946}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: -619905303, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!4 &1394308949
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1394308946}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1401999870
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1401999871}
-  - component: {fileID: 1401999875}
-  - component: {fileID: 1401999874}
-  - component: {fileID: 1401999873}
-  - component: {fileID: 1401999872}
-  m_Layer: 0
-  m_Name: segment 3
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1401999871
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1401999870}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1272024235}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1401999872
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1401999870}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1880345464}
---- !u!114 &1401999873
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1401999870}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &1401999874
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1401999870}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1401999875
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1401999870}
-  m_Mesh: {fileID: 1880345464}
---- !u!43 &1446604457
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 360
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 93
-    localAABB:
-      m_Center: {x: -2.3625474, y: 0, z: 4.3014994}
-      m_Extent: {x: 3.2458525, y: 0, z: 2.765416}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000030003000400010002000100040004000500020004000300060006000700040005000400070007000800050007000600090009000a000700080007000a000a000b0008000a0009000c000c000d000a000b000a000d000d000e000b000d000c000f000f0010000d000e000d001000100011000e0010000f00120012001300100011001000130013001400110013001200150015001600130014001300160016001700140016001500180018001900160017001600190019001a001700190018001b001b001c0019001a0019001c001c001d001a001c001b001e001e001f001c001d001c001f001f0020001d001f001e002100210022001f0020001f002200220023002000220021002400240025002200230022002500250026002300250024002700270028002500260025002800280029002600280027002a002a002b002800290028002b002b002c0029002b002a002d002d002e002b002c002b002e002e002f002c002e002d003000300031002e002f002e003100310032002f0031003000330033003400310032003100340034003500320034003300360036003700340035003400370037003800350037003600390039003a003700380037003a003a003b0038003a0039003c003c003d003a003b003a003d003d003e003b003d003c003f003f0040003d003e003d004000400041003e0040003f00420042004300400041004000430043004400410043004200450045004600430044004300460046004700440046004500480048004900460047004600490049004a004700490048004b004b004c0049004a0049004c004c004d004a004c004b004e004e004f004c004d004c004f004f0050004d004f004e005100510052004f0050004f005200520053005000520051005400540055005200530052005500550056005300550054005700570058005500560055005800580059005600580057005a005a005b005800590058005b005b005c005900
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 93
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 2976
-    _typelessdata: 0378b3c00000000076913540000000000000803f000000000000000026079f41b605a4c00000000053f00b40000000000000803f000000000000003f26079f41699394c000000000619ec43f000000000000803f000000000000803f26079f411769afc000000000b09b3b40000000000000803f00000000000000001cab9f4167e99fc000000000790e1240000000000000803f000000000000003f1cab9f41b76990c0000000008402d13f000000000000803f000000000000803f1cab9f410be6aac000000000f25a4240000000000000803f00000000000000001e61a041465b9bc0000000004dde1840000000000000803f000000000000003f1e61a04181d08bc00000000050c3de3f000000000000803f000000000000803f1e61a041a9f8a5c000000000cec04940000000000000803f0000000000000000c627a1414f6496c0000000008c522040000000000000803f000000000000003fc627a141f5cf86c00000000094c8ed3f000000000000803f000000000000803fc627a14178aaa0c0000000004abf5140000000000000803f0000000000000000affda141850d91c000000000fc5d2840000000000000803f000000000000003faffda141927081c0000000005cf9fd3f000000000000803f000000000000803faffda141c2049bc000000000a9485a40000000000000803f000000000000000073e1a241df5f8bc0000000005bf33040000000000000803f000000000000003f73e1a241f77577c0000000000d9e0740000000000000803f000000000000803f73e1a241ce1095c000000000544f6340000000000000803f0000000000000000aed1a341626485c00000000072053a40000000000000803f000000000000003faed1a341ed6f6bc00000000090bb1040000000000000803f000000000000803faed1a341c1d78ec000000000c7c56c40000000000000803f0000000000000000facca44114487ec000000000fd864340000000000000803f000000000000003ffacca441a5e05ec00000000033481a40000000000000803f000000000000803ffacca441c26288c0000000008c9e7640000000000000803f0000000000000000f3d1a541ab4f71c000000000c06a4d40000000000000803f000000000000003ff3d1a541d2d951c000000000f4362440000000000000803f000000000000803ff3d1a541ebba81c0000000001c668040000000000000803f000000000000000032dfa64184f163c0000000007ca35740000000000000803f000000000000003f32dfa641326d44c000000000c07a2e40000000000000803f000000000000803f32dfa641aed275c000000000b0a08540000000000000803f000000000000000052f3a7419e3f56c000000000f2236240000000000000803f000000000000003f52f3a7418eac36c00000000084063940000000000000803f000000000000803f52f3a7413dee67c00000000052f88a40000000000000803f0000000000000000f00ca941f94b48c000000000e9de6c40000000000000803f000000000000003ff00ca941b5a928c0000000002ecd4340000000000000803f000000000000803ff00ca941b2da59c0000000004f669040000000000000803f0000000000000000a42aaa418f283ac00000000020c77740000000000000803f000000000000003fa42aaa416c761ac000000000a2c14e40000000000000803f000000000000803fa42aaa4136aa4bc000000000f3e39540000000000000803f00000000000000000b4bab4159e72bc000000000ad678140000000000000803f000000000000003f0b4bab417c240cc000000000ced65940000000000000803f000000000000803f0b4bab41066f3dc000000000856a9b40000000000000803f0000000000000000bf6cac41589a1dc0000000002af58640000000000000803f000000000000003fbf6cac41548bfbbf000000009eff6440000000000000803f000000000000803fbf6cac415c3b2fc00000000051f3a040000000000000803f00000000000000005b8ead418a530fc0000000006c858c40000000000000803f000000000000003f5b8ead4170d7debf000000000e2f7040000000000000803f000000000000803f5b8ead417c2121c0000000009877a640000000000000803f00000000000000007aaeae41e82401c000000000d2119240000000000000803f000000000000003f7aaeae41a850c2bf0000000018587b40000000000000803f000000000000803f7aaeae41ba3313c00000000097f0ab40000000000000803f0000000000000000b8cbaf41e240e6bf00000000bd939740000000000000803f000000000000003fb8cbaf41511aa6bf00000000e3368340000000000000803f000000000000803fb8cbaf417a8405c0000000008557b140000000000000803f0000000000000000aee4b04145b0cabf000000008f049d40000000000000803f000000000000003faee4b04195578abf0000000099b18840000000000000803f000000000000803faee4b041764cf0bf000000008aa5b640000000000000803f0000000000000000f9f7b141f1bbafbf00000000a85da240000000000000803f000000000000003ff9f7b141d7565ebf00000000c6158e40000000000000803f000000000000803ff9f7b1413457d6bf00000000c1d3bb40000000000000803f00000000000000003404b341e08795bf000000006998a740000000000000803f000000000000003f3404b341177129bf00000000115d9340000000000000803f000000000000803f3404b341c74ebdbf0000000034dbc040000000000000803f0000000000000000fb07b441187078bf0000000034aeac40000000000000803f000000000000003ffb07b4414485ecbe0000000034819840000000000000803f000000000000803ffb07b4414a59a5bf00000000c9b4c540000000000000803f0000000000000000e801b541e1e047bf000000006998b140000000000000803f000000000000003fe801b5415c1e8abe00000000097c9d40000000000000803f000000000000803fe801b5418a9d8ebf000000003d59ca40000000000000803f000000000000000099f0b54108aa19bf000000006850b640000000000000803f000000000000003f99f0b541e0c7b0bd000000009347a240000000000000803f000000000000803f99f0b541c88672bf0000000013c1ce40000000000000803f0000000000000000a9d2b6410a27dcbe0000000096cfba40000000000000803f000000000000003fa9d2b641f0fdb23d0000000019dea640000000000000803f000000000000803fa9d2b641a8e84abf0000000060e4d240000000000000803f0000000000000000b6a6b74194ca8abe00000000500fbf40000000000000803f000000000000003fb6a6b741283c803e00000000403aab40000000000000803f000000000000803fb6a6b741b0b826bf000000009abad640000000000000803f00000000000000005d6bb8415c3affbd00000000f908c340000000000000803f000000000000003f5d6bb84131d4cd3e000000005857af40000000000000803f000000000000803f5d6bb841395706bf00000000223ada40000000000000803f00000000000000003e1fb941d0a0073c00000000f1b5c640000000000000803f000000000000003f3e1fb9413f940a3f00000000c031b340000000000000803f000000000000803f3e1fb9412a66d4be000000005c57dd40000000000000803f0000000000000000f8c0b941bf90013e000000009a0fca40000000000000803f000000000000003ff8c0b94175fb2a3f00000000d8c7b640000000000000803f000000000000803ff8c0b94182aca5be00000000c302e040000000000000803f0000000000000000304fba4113876a3e00000000550fcd40000000000000803f000000000000003f304fba41cb19483f00000000e71bba40000000000000803f000000000000803f304fba41980382be000000002b24e240000000000000803f000000000000000090c8ba41801ea13e0000000080aecf40000000000000803f000000000000003f90c8ba414c20623f00000000d538bd40000000000000803f000000000000803f90c8ba41
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -2.3625474, y: 0, z: 4.3014994}
-    m_Extent: {x: 3.2458525, y: 0, z: 2.765416}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!1 &1517055539
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1517055540}
-  - component: {fileID: 1517055544}
-  - component: {fileID: 1517055543}
-  - component: {fileID: 1517055542}
-  - component: {fileID: 1517055541}
-  m_Layer: 0
-  m_Name: segment 6
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1517055540
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1517055539}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1236410749}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1517055541
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1517055539}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1844291866}
---- !u!114 &1517055542
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1517055539}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &1517055543
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1517055539}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1517055544
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1517055539}
-  m_Mesh: {fileID: 1844291866}
---- !u!1 &1532668705
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1532668706}
-  - component: {fileID: 1532668710}
-  - component: {fileID: 1532668709}
-  - component: {fileID: 1532668708}
-  - component: {fileID: 1532668707}
-  m_Layer: 0
-  m_Name: segment 9
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1532668706
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1532668705}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 539737851}
-  m_RootOrder: 9
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1532668707
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1532668705}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 680000683}
---- !u!114 &1532668708
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1532668705}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &1532668709
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1532668705}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1532668710
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1532668705}
-  m_Mesh: {fileID: 680000683}
---- !u!1 &1614957930
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1614957931}
-  - component: {fileID: 1614957932}
-  m_Layer: 0
-  m_Name: Floor
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1614957931
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1614957930}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1236410749}
-  m_Father: {fileID: 809433128}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1614957932
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1614957930}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8d1eb05ecfaa05444b40d40a2ea2268f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  shapeVertices:
-  - point: {x: -0.81, y: 0}
-    normal: {x: 0, y: 1}
-    uCoord: 0
-  - point: {x: 0, y: 0}
-    normal: {x: 0, y: 1}
-    uCoord: 0.5
-  - point: {x: 0.81, y: 0}
-    normal: {x: 0, y: 1}
-    uCoord: 1
-  loopAround: 0
-  material: {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
-  textureScale: 0.5
---- !u!1 &1629610887
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1629610888}
-  - component: {fileID: 1629610890}
-  - component: {fileID: 1629610889}
-  m_Layer: 5
-  m_Name: Speed
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1629610888
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1629610887}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 283461116}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.99}
-  m_AnchorMax: {x: 0.33, y: 0.99}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 100}
-  m_Pivot: {x: 0, y: 1}
---- !u!114 &1629610889
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1629610887}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 2100000, guid: 63fd4656f763f4c1c8d8d300a7726304, type: 2}
-  m_Color: {r: 0, g: 0.7411765, b: 0, a: 1}
-  m_RaycastTarget: 0
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 30
-    m_FontStyle: 1
-    m_BestFit: 0
-    m_MinSize: 0
-    m_MaxSize: 40
-    m_Alignment: 0
-    m_AlignByGeometry: 0
-    m_RichText: 0
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: S 0
---- !u!222 &1629610890
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1629610887}
-  m_CullTransparentMesh: 0
---- !u!43 &1637640996
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 540
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 124
-    localAABB:
-      m_Center: {x: -6.150703, y: 0.095, z: 2.5021393}
-      m_Extent: {x: 1.5077085, y: 0.105000004, z: 1.4384553}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 124
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 3968
-    _typelessdata: 6b73e9c00ad723bc1cd77b403642543f00000000c91d0fbf0000000005c292416b73e9c0cdcc4c3e1cd77b403642543f00000000c91d0fbf0000003f05c2924157b7e9c0cdcc4c3eb4327c40364254bf00000000c91d0f3f0000003f05c2924157b7e9c00ad723bcb4327c40364254bf00000000c91d0f3f0000803f05c292415086ecc00ad723bc18d97140c2815f3f0000000033a5f9be00000000033993415086ecc0cdcc4c3e18d97140c2815f3f0000000033a5f9be0000003f03399341d5cdecc0cdcc4c3efa287240c2815fbf0000000033a5f93e0000003f03399341d5cdecc00ad723bcfa287240c2815fbf0000000033a5f93e0000803f033993418b1fefc00ad723bcba886740865c693f000000002c82d2be00000000b0ab93418b1fefc0cdcc4c3eba886740865c693f000000002c82d2be0000003fb0ab9341386aefc0cdcc4c3e17cc6740865c69bf000000002c82d23e0000003fb0ab9341386aefc00ad723bc17cc6740865c69bf000000002c82d23e0000803fb0ab93417a3cf1c00ad723bc6ff75c40629f713f000000004c2ba9be000000008f1a94417a3cf1c0cdcc4c3e6ff75c40629f713f000000004c2ba9be0000003f8f1a9441cc89f1c0cdcc4c3e912d5d40629f71bf000000004c2ba93e0000003f8f1a9441cc89f1c00ad723bc912d5d40629f71bf000000004c2ba93e0000803f8f1a94415fdbf2c00ad723bce3375240cc1f783f000000002c0b7cbe00000000148694415fdbf2c0cdcc4c3ee3375240cc1f783f000000002c0b7cbe0000003f14869441c52af3c0cdcc4c3e36605240cc1f78bf000000002c0b7c3e0000003f14869441c52af3c00ad723bc36605240cc1f78bf000000002c0b7c3e0000803f148694415ffbf3c00ad723bc3c5d4740cabc7c3f0000000042f622be00000000a8ee94415ffbf3c0cdcc4c3e3c5d4740cabc7c3f0000000042f622be0000003fa8ee9441404cf4c0cdcc4c3e4f774740cabc7cbf0000000042f6223e0000003fa8ee9441404cf4c00ad723bc4f774740cabc7cbf0000000042f6223e0000803fa8ee9441959cf4c00ad723bcc87a3c40205e7f3f00000000c5db8fbd00000000a9549541959cf4c0cdcc4c3ec87a3c40205e7f3f00000000c5db8fbd0000003fa95495414ceef4c0cdcc4c3e4a863c40205e7fbf00000000c5db8f3d0000003fa95495414ceef4c00ad723bc4a863c40205e7fbf00000000c5db8f3d0000803fa9549541cdbff4c00ad723bc38a331402cf37f3f00000000fa13a23c000000006ab89541cdbff4c0cdcc4c3e38a331402cf37f3f00000000fa13a23c0000003f6ab89541b511f5c0cdcc4c3efa9f31402cf37fbf00000000fa13a2bc0000003f6ab89541b511f5c00ad723bcfa9f31402cf37fbf00000000fa13a2bc0000803f6ab895416966f4c00ad723bcb4e82640c2707e3f0000000010b7e13d00000000331a96416966f4c0cdcc4c3eb4e82640c2707e3f0000000010b7e13d0000003f331a9641d5b7f4c0cdcc4c3ea6d62640c2707ebf0000000010b7e1bd0000003f331a9641d5b7f4c00ad723bca6d62640c2707ebf0000000010b7e1bd0000803f331a96411892f3c00ad723bc8f5c1c40f6ce7a3f00000000b12d4d3e00000000447a96411892f3c0cdcc4c3e8f5c1c40f6ce7a3f00000000b12d4d3e0000003f447a96415ae2f3c0cdcc4c3ebb3b1c40f6ce7abf00000000b12d4dbe0000003f447a96415ae2f3c00ad723bcbb3b1c40f6ce7abf00000000b12d4dbe0000803f447a9641af44f2c00ad723bc990f12401a07753f00000000054a943e00000000d7d89641af44f2c0cdcc4c3e990f12401a07753f00000000054a943e0000003fd7d896411893f2c0cdcc4c3e25e011401a0775bf00000000054a94be0000003fd7d896411893f2c00ad723bc25e011401a0775bf00000000054a94be0000803fd7d89641fe7ff0c00ad723bc7512084072126d3f00000000a236c13e0000000021369741fe7ff0c0cdcc4c3e7512084072126d3f00000000a236c13e0000003f21369741dbcbf0c0cdcc4c3ea0d4074072126dbf00000000a236c1be0000003f21369741dbcbf0c00ad723bca0d4074072126dbf00000000a236c1be0000803f21369741c545eec00ad723bc0eecfc3fb4e9623f000000004709ed3e0000000056929741c545eec0cdcc4c3e0eecfc3fb4e9623f000000004709ed3e0000003f56929741628eeec0cdcc4c3e5a54fc3fb4e962bf000000004709edbe0000003f56929741628eeec00ad723bc5a54fc3fb4e962bf000000004709edbe0000803f56929741d097ebc00ad723bc2198ea3fe885563f0000000000b30b3f00000000abed9741d097ebc0cdcc4c3e2198ea3fe885563f0000000000b30b3f0000003fabed974176dcebc0cdcc4c3e50e5e93fe88556bf0000000000b30bbf0000003fabed974176dcebc00ad723bc50e5e93fe88556bf0000000000b30bbf0000803fabed97412678e8c00ad723bc684fd93f9ce2473f000000008bf11f3f00000000584898412678e8c0cdcc4c3e684fd93f9ce2473f000000008bf11f3f0000003f584898411cb8e8c0cdcc4c3eae82d83f9ce247bf000000008bf11fbf0000003f584898411cb8e8c00ad723bcae82d83f9ce247bf000000008bf11fbf0000803f5848984174e9e4c00ad723bc9e3bc93f7e01373f00000000c502333f000000009ea2984174e9e4c0cdcc4c3e9e3bc93f7e01373f00000000c502333f0000003f9ea298410424e5c0cdcc4c3e7c56c83f7e0137bf00000000c50233bf0000003f9ea298410424e5c00ad723bc7c56c83f7e0137bf00000000c50233bf0000803f9ea298417eefe0c00ad723bc328aba3f76ef233f00000000e09f443f00000000c6fc98417eefe0c0cdcc4c3e328aba3f76ef233f00000000e09f443f0000003fc6fc9841f423e1c0cdcc4c3e848eb93f76ef23bf00000000e09f44bf0000003fc6fc9841f423e1c00ad723bc848eb93f76ef23bf00000000e09f44bf0000803fc6fc9841b38fdcc00ad723bc946bad3ff6c90e3f00000000a27a543f0000000026579941b38fdcc0cdcc4c3e946bad3ff6c90e3f00000000a27a543f0000003f2657994165bddcc0cdcc4c3e9a5bac3ff6c90ebf00000000a27a54bf0000003f2657994165bddcc00ad723bc9a5bac3ff6c90ebf00000000a27a54bf0000803f26579941b8d1d7c00ad723bc7911a23f1089ef3e000000007e41623f0000000025b29941b8d1d7c0cdcc4c3e7911a23f1089ef3e000000007e41623f0000003f25b299410bf8d7c0cdcc4c3edeefa03f1089efbe000000007e4162bf0000003f25b299410bf8d7c00ad723bcdeefa03f1089efbe000000007e4162bf0000803f25b29941b9bfd2c00ad723bc1aac983f5458be3e00000000c3a66d3f00000000380e9a41b9bfd2c0cdcc4c3e1aac983f5458be3e00000000c3a66d3f0000003f380e9a412dded2c0cdcc4c3ee97b973f5458bebe00000000c3a66dbf0000003f380e9a412dded2c00ad723bce97b973f5458bebe00000000c3a66dbf0000803f380e9a417d66cdc00ad723bc8a66913f24cf8a3e000000008c69763f00000000e56b9a417d66cdc0cdcc4c3e8a66913f24cf8a3e000000008c69763f0000003fe56b9a41b27ccdc0cdcc4c3e222b903f24cf8abe000000008c6976bf0000003fe56b9a41b27ccdc00ad723bc222b903f24cf8abe000000008c6976bf0000803fe56b9a41edd4c7c00ad723bc06638c3f78cc2b3e00000000155f7c3f00000000c6cb9a41edd4c7c0cdcc4c3e06638c3f78cc2b3e00000000155f7c3f0000003fc6cb9a41abe2c7c0cdcc4c3efe1f8b3f78cc2bbe00000000155f7cbf0000003fc6cb9a41abe2c7c00ad723bcfe1f8b3f78cc2bbe00000000155f7cbf0000803fc6cb9a41471bc2c00ad723bce6b7893f00c2823d000000004a7a7f3f00000000812e9b41471bc2c0cdcc4c3ee6b7893f00c2823d000000004a7a7f3f0000003f812e9b418220c2c0cdcc4c3ee470883f00c282bd000000004a7a7fbf0000003f812e9b418220c2c00ad723bce470883f00c282bd000000004a7a7fbf0000803f812e9b41e749bcc00ad723bc3c6e893f50e21dbd000000004ccf7f3f00000000ce949b41e749bcc0cdcc4c3e3c6e893f50e21dbd000000004ccf7f3f0000003fce949b41be46bcc0cdcc4c3ecd26883f50e21d3d000000004ccf7fbf0000003fce949b41be46bcc00ad723bccd26883f50e21d3d000000004ccf7fbf0000803fce949b411d70b6c00ad723bc6b828b3fe0bf0cbe00000000f9917d3f000000006dff9b411d70b6c0cdcc4c3e6b828b3fe0bf0cbe00000000f9917d3f0000003f6dff9b41da64b6c0cdcc4c3eda3d8a3fe0bf0c3e00000000f9917dbf0000003f6dff9b41da64b6c00ad723bcda3d8a3fe0bf0c3e00000000f9917dbf0000803f6dff9b41129bb0c00ad723bc92e68f3f88c96cbe00000000cd0f793f00000000296f9c41129bb0c0cdcc4c3e92e68f3f88c96cbe00000000cd0f793f0000003f296f9c412088b0c0cdcc4c3ec6a78e3f88c96c3e00000000cd0f79bf0000003f296f9c412088b0c00ad723bcc6a78e3f88c96c3e00000000cd0f79bf0000803f296f9c4131d5aac00ad723bc3d86963f462ca3be00000000bba6723f00000000d2e49c4131d5aac0cdcc4c3e3d86963f462ca3be00000000bba6723f0000003fd2e49c4115bbaac0cdcc4c3ea54f953f462ca33e00000000bba672bf0000003fd2e49c4115bbaac00ad723bca54f953f462ca33e00000000bba672bf0000803fd2e49c41f125a5c00ad723bc534a9f3fee52ccbe000000004cbb6a3f0000000039619d41f125a5c0cdcc4c3e534a9f3fee52ccbe000000004cbb6a3f0000003f39619d414005a5c0cdcc4c3ede1d9e3fee52cc3e000000004cbb6abf0000003f39619d414005a5c00ad723bcde1d9e3fee52cc3e000000004cbb6abf0000803f39619d4107929fc00ad723bca01caa3f3aacf1be00000000d8af613f0000000034e59d4107929fc0cdcc4c3ea01caa3f3aacf1be00000000d8af613f0000003f34e59d415c6b9fc0cdcc4c3ebefba83f3aacf13e00000000d8af61bf0000003f34e59d415c6b9fc00ad723bcbefba83f3aacf13e00000000d8af61bf0000803f34e59d41e11b9ac00ad723bc54eab63fad9c09bf000000002cde573f0000000093719e41e11b9ac0cdcc4c3e54eab63fad9c09bf000000002cde573f0000003f93719e41d8ef99c0cdcc4c3e04d6b53fad9c093f000000002cde57bf0000003f93719e41d8ef99c00ad723bc04d6b53fad9c093f000000002cde57bf0000803f93719e413ac494c00ad723bc84a5c53fd48e18bf00000000d4934d3f0000000026079f413ac494c0cdcc4c3e84a5c53fd48e18bf00000000d4934d3f0000003f26079f41699394c0cdcc4c3e619ec43fd48e183f00000000d4934dbf0000003f26079f41699394c00ad723bc619ec43fd48e183f00000000d4934dbf0000803f26079f41
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -6.150703, y: 0.095, z: 2.5021393}
-    m_Extent: {x: 1.5077085, y: 0.105000004, z: 1.4384553}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!1 &1647536394
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1647536395}
-  - component: {fileID: 1647536399}
-  - component: {fileID: 1647536398}
-  - component: {fileID: 1647536397}
-  - component: {fileID: 1647536396}
-  m_Layer: 0
-  m_Name: segment 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1647536395
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1647536394}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 539737851}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1647536396
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1647536394}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1210551775}
---- !u!114 &1647536397
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1647536394}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &1647536398
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1647536394}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1647536399
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1647536394}
-  m_Mesh: {fileID: 1210551775}
---- !u!1 &1687258581
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1687258585}
-  - component: {fileID: 1687258584}
-  - component: {fileID: 1687258586}
-  - component: {fileID: 1687258582}
-  m_Layer: 0
-  m_Name: Stream Camera
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1687258582
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1687258581}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8660950fa3cc14a69be99edddcf2d3dc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!20 &1687258584
-Camera:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1687258581}
-  m_Enabled: 1
-  serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
-  m_projectionMatrixMode: 1
-  m_GateFitMode: 2
-  m_FOVAxisMode: 0
-  m_SensorSize: {x: 36, y: 24}
-  m_LensShift: {x: 0, y: 0}
-  m_FocalLength: 50
-  m_NormalizedViewPortRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 0.2
-    height: 0.2
-  near clip plane: 0.01
-  far clip plane: 20
-  field of view: 48.8
-  orthographic: 0
-  orthographic size: 5
-  m_Depth: -1
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingPath: -1
-  m_TargetTexture: {fileID: 0}
-  m_TargetDisplay: 0
-  m_TargetEye: 3
-  m_HDR: 1
-  m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
-  m_ForceIntoRT: 1
-  m_OcclusionCulling: 1
-  m_StereoConvergence: 10
-  m_StereoSeparation: 0.022
---- !u!4 &1687258585
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1687258581}
-  m_LocalRotation: {x: 0.08280819, y: 0, z: 0, w: 0.9965655}
-  m_LocalPosition: {x: 0, y: 0.1, z: 0.08}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1104095457}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 9.5, y: 0, z: 0}
---- !u!114 &1687258586
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1687258581}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 948f4100a11a5c24981795d21301da5c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  volumeTrigger: {fileID: 1687258585}
-  volumeLayer:
-    serializedVersion: 2
-    m_Bits: 256
-  stopNaNPropagation: 1
-  finalBlitToCameraTarget: 1
-  antialiasingMode: 1
-  temporalAntialiasing:
-    jitterSpread: 0.75
-    sharpness: 0.25
-    stationaryBlending: 0.95
-    motionBlending: 0.85
-  subpixelMorphologicalAntialiasing:
-    quality: 2
-  fastApproximateAntialiasing:
-    fastMode: 1
-    keepAlpha: 0
-  fog:
-    enabled: 1
-    excludeSkybox: 1
-  debugLayer:
-    lightMeter:
-      width: 512
-      height: 256
-      showCurves: 1
-    histogram:
-      width: 512
-      height: 256
-      channel: 3
-    waveform:
-      exposure: 0.12
-      height: 256
-    vectorscope:
-      size: 256
-      exposure: 0.12
-    overlaySettings:
-      linearDepth: 0
-      motionColorIntensity: 4
-      motionGridSize: 64
-      colorBlindnessType: 0
-      colorBlindnessStrength: 1
-  m_Resources: {fileID: 11400000, guid: d82512f9c8e5d4a4d938b575d47f88d4, type: 2}
-  m_ShowToolkit: 1
-  m_ShowCustomSorter: 1
-  breakBeforeColorGrading: 0
-  m_BeforeTransparentBundles: []
-  m_BeforeStackBundles: []
-  m_AfterStackBundles: []
---- !u!1 &1697795921
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1697795922}
-  - component: {fileID: 1697795923}
-  m_Layer: 0
-  m_Name: Wheel RR Collider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1697795922
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1697795921}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0.1, y: -0.024999999, z: -0.14}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1104095457}
-  m_RootOrder: 11
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!146 &1697795923
-WheelCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1697795921}
-  m_Center: {x: 0, y: 0, z: 0}
-  m_Radius: 0.035
-  m_SuspensionSpring:
-    spring: 35
-    damper: 5
-    targetPosition: 0.9
-  m_SuspensionDistance: 0.01
-  m_ForceAppPointDistance: 0
-  m_Mass: 0.1
-  m_WheelDampingRate: 0.25
-  m_ForwardFriction:
-    m_ExtremumSlip: 0.4
-    m_ExtremumValue: 1
-    m_AsymptoteSlip: 0.8
-    m_AsymptoteValue: 0.5
-    m_Stiffness: 2
-  m_SidewaysFriction:
-    m_ExtremumSlip: 0.2
-    m_ExtremumValue: 1
-    m_AsymptoteSlip: 0.5
-    m_AsymptoteValue: 0.75
-    m_Stiffness: 2
-  m_Enabled: 1
---- !u!1 &1707151189
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1707151190}
-  - component: {fileID: 1707151192}
-  - component: {fileID: 1707151191}
-  m_Layer: 0
-  m_Name: Tire
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1707151190
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1707151189}
-  m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.07000003, y: 0.020000014, z: 0.07000003}
-  m_Children: []
-  m_Father: {fileID: 73127174}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
---- !u!23 &1707151191
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1707151189}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: c05de7c865075334786e6a47a543af72, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1707151192
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1707151189}
-  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
---- !u!43 &1723624959
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 360
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 93
-    localAABB:
-      m_Center: {x: 0.391029, y: 0, z: 7.457205}
-      m_Extent: {x: 1.0821339, y: 0, z: 1.5440176}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000030003000400010002000100040004000500020004000300060006000700040005000400070007000800050007000600090009000a000700080007000a000a000b0008000a0009000c000c000d000a000b000a000d000d000e000b000d000c000f000f0010000d000e000d001000100011000e0010000f00120012001300100011001000130013001400110013001200150015001600130014001300160016001700140016001500180018001900160017001600190019001a001700190018001b001b001c0019001a0019001c001c001d001a001c001b001e001e001f001c001d001c001f001f0020001d001f001e002100210022001f0020001f002200220023002000220021002400240025002200230022002500250026002300250024002700270028002500260025002800280029002600280027002a002a002b002800290028002b002b002c0029002b002a002d002d002e002b002c002b002e002e002f002c002e002d003000300031002e002f002e003100310032002f0031003000330033003400310032003100340034003500320034003300360036003700340035003400370037003800350037003600390039003a003700380037003a003a003b0038003a0039003c003c003d003a003b003a003d003d003e003b003d003c003f003f0040003d003e003d004000400041003e0040003f00420042004300400041004000430043004400410043004200450045004600430044004300460046004700440046004500480048004900460047004600490049004a004700490048004b004b004c0049004a0049004c004c004d004a004c004b004e004e004f004c004d004c004f004f0050004d004f004e005100510052004f0050004f005200520053005000520051005400540055005200530052005500550056005300550054005700570058005500560055005800580059005600580057005a005a005b005800590058005b005b005c005900
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 93
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 2976
-    _typelessdata: 980382be000000002b24e240000000000000803f000000000000000090c8ba41801ea13e0000000080aecf40000000000000803f000000000000003f90c8ba414c20623f00000000d538bd40000000000000803f000000000000803f90c8ba41d42265be00000000662ae340000000000000803f0000000000000000b034bb41922bc63e000000006b24d240000000000000803f000000000000003fb034bb4147747f3f00000000701ec140000000000000803f000000000000803fb034bb4126004dbe00000000f019e440000000000000803f0000000000000000669cbb416daee63e00000000caaad440000000000000803f000000000000003f669cbb413bf78c3f00000000a43bc540000000000000803f000000000000803f669cbb4104a13abe0000000063f1e440000000000000803f00000000000000002c00bc41e360013f00000000903ed740000000000000803f000000000000003f2c00bc4104b5983f00000000bd8bc940000000000000803f000000000000803f2c00bc414c0c2dbe00000000a1b0e540000000000000803f00000000000000007860bc4130400d3f00000000bedcd940000000000000803f000000000000003f7860bc41bae1a23f00000000db08ce40000000000000803f000000000000803f7860bc41305823be000000009858e640000000000000803f0000000000000000b8bdbc417602173f000000004282dc40000000000000803f000000000000003fb8bdbc417c6dab3f00000000ecabd240000000000000803f000000000000803fb8bdbc4180b31cbe0000000041ebe640000000000000803f00000000000000005918bd4119b51e3f00000000222cdf40000000000000803f000000000000003f5918bd41894bb23f00000000036dd740000000000000803f000000000000803f5918bd41706c18be000000002c6be740000000000000803f0000000000000000b970bd417265243f000000004cd7e140000000000000803f000000000000003fb970bd410073b73f000000006c43dc40000000000000803f000000000000803fb970bd4114f415be0000000058dbe740000000000000803f000000000000000034c7bd41e320283f00000000c280e440000000000000803f000000000000003f34c7bd4166dfba3f000000002c26e140000000000000803f000000000000803f34c7bd41a4de14be00000000c73ee840000000000000803f00000000000000001b1cbe41c6f4293f000000007825e740000000000000803f000000000000003f1b1cbe419a90bc3f00000000290ce640000000000000803f000000000000803f1b1cbe4150e014be000000004498e840000000000000803f0000000000000000b96fbe4179ee293f0000000067c2e940000000000000803f000000000000003fb96fbe41838abc3f000000008aecea40000000000000803f000000000000803fb96fbe41c0c715be0000000037eae840000000000000803f000000000000000051c2be415f1b283f000000008e54ec40000000000000803f000000000000003f51c2be4157d4ba3f00000000e5beef40000000000000803f000000000000803f51c2be41f47717be000000007836e940000000000000803f00000000000000001d14bf41d088243f00000000e1d8ee40000000000000803f000000000000003f1d14bf41ce77b73f000000004a7bf440000000000000803f000000000000803f1d14bf4184e119be000000005a7ee940000000000000803f00000000000000005465bf412c441f3f000000005a4cf140000000000000803f000000000000003f5465bf415c80b23f000000005a1af940000000000000803f000000000000803f5465bf417cfd1cbe00000000b4c2e940000000000000803f000000000000000027b6bf41d05a183f00000000f3abf340000000000000803f000000000000003f27b6bf4180faab3f000000003295fd40000000000000803f000000000000803f27b6bf416cc920be00000000fc03ea40000000000000803f0000000000000000c506c0411dda0f3f00000000a7f4f540000000000000803f000000000000003fc506c0414af3a33f00000000a9f20041000000000000803f000000000000803fc506c041104625be000000006542ea40000000000000803f00000000000000005757c0416ccf053f000000006c23f840000000000000803f000000000000003f5757c0412e789a3f0000000039020341000000000000803f000000000000803f5757c0416a772abe000000000c7eea40000000000000803f00000000000000000aa8c0413d90f43e000000003d35fa40000000000000803f000000000000003f0aa8c0410c978f3f0000000037f60441000000000000803f000000000000803f0aa8c041406730be0000000007b7ea40000000000000803f00000000000000000bf9c0411ea3da3e000000001327fc40000000000000803f000000000000003f0bf9c041775e833f000000008fcb0641000000000000803f000000000000803f0bf9c041be2837be000000007dedea40000000000000803f0000000000000000874ac1413bf2bd3e00000000e6f5fd40000000000000803f000000000000003f874ac1416abc6b3f00000000287f0841000000000000803f000000000000803f874ac1414cdd3ebe00000000a721eb40000000000000803f0000000000000000b19cc14152989e3e00000000b29eff40000000000000803f000000000000003fb19cc141a54f4e3f00000000df0d0a41000000000000803f000000000000803fb19cc141dab847be00000000ba53eb40000000000000803f0000000000000000c1efc1413660793e00000000388f0041000000000000803f000000000000003fc1efc141529e2e3f0000000093740b41000000000000803f000000000000803fc1efc141620652be00000000c683eb40000000000000803f0000000000000000f643c241a4a8303e000000000b390141000000000000803f000000000000003ff643c241ead50c3f0000000033b00c41000000000000803f000000000000803ff643c241a5295ebe000000008ab1eb40000000000000803f00000000000000009299c241d27ec63d000000004fcb0141000000000000803f000000000000003f9299c2413c54d23e00000000d9bd0d41000000000000803f000000000000803f9299c241f39d6cbe0000000036dceb40000000000000803f0000000000000000e5f0c241a0cf8a3c0000000083440241000000000000803f000000000000003fe5f0c241eea8873e00000000eb9a0e41000000000000803f000000000000803fe5f0c24151f47dbe000000002102ec40000000000000803f0000000000000000414ac3416ea489bd0000000020a30241000000000000803f000000000000003f414ac341c69fe83d000000002f450f41000000000000803f000000000000803f414ac341726589be00000000b020ec40000000000000803f000000000000000004a6c341a90f1fbe00000000a6e50241000000000000803f000000000000003f04a6c341b8512dbd00000000f4ba0f41000000000000803f000000000000803f04a6c341a9e295be000000001534ec40000000000000803f00000000000000009004c441e8287dbe000000008f0a0341000000000000803f000000000000003f9004c4417e8c4ebe0000000013fb0f41000000000000803f000000000000803f9004c4416ac0a4be000000006437ec40000000800000803f00000000000000005366c4414074afbe000000005a100341000000800000803f000000000000003f5366c4411628babe0000000002051041000000800000803f000000000000803f5366c4419845b6be000000009124ec40000000800000803f0000000000000000bccbc4417a0ce2be0000000082f50241000000800000803f000000000000003fbccbc441aee906bf00000000bbd80f41000000800000803f000000000000803fbccbc441fdabcabe00000000a7f4eb40000000800000803f00000000000000004335c5411f210bbf0000000084b80241000000800000803f000000000000003f4335c54140ec30bf00000000b4760f41000000800000803f000000000000803f4335c541
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0.391029, y: 0, z: 7.457205}
-    m_Extent: {x: 1.0821339, y: 0, z: 1.5440176}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!43 &1740683110
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 540
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 124
-    localAABB:
-      m_Center: {x: -0.73838425, y: 0.095, z: 9.124887}
-      m_Extent: {x: 0.112674505, y: 0.105000004, z: 0.17174482}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 124
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 24
-      format: 0
-      dimension: 2
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 3968
-    _typelessdata: ce7430bf0ad723bc6e4e0f4168a23a3e000000004cb67bbf000000004335c541ce7430bfcdcc4c3e6e4e0f4168a23a3e000000004cb67bbf0000003f4335c54140ec30bfcdcc4c3eb4760f4168a23abe000000004cb67b3f0000003f4335c54140ec30bf0ad723bcb4760f4168a23abe000000004cb67b3f0000803f4335c541580736bf0ad723bc4d420f4190a5a73d000000000f247fbf00000000bc9ec541580736bfcdcc4c3e4d420f4190a5a73d000000000f247fbf0000003fbc9ec541fd3c36bfcdcc4c3e1f6b0f4190a5a7bd000000000f247f3f0000003fbc9ec541fd3c36bf0ad723bc1f6b0f4190a5a7bd000000000f247f3f0000803fbc9ec54111473abf0ad723bc12400f41e001aebc0000000038f17fbf000000003d04c64111473abfcdcc4c3e12400f41e001aebc0000000038f17fbf0000003f3d04c64126393abfcdcc4c3e05690f41e001ae3c0000000038f17f3f0000003f3d04c64126393abf0ad723bc05690f41e001ae3c0000000038f17f3f0000803f3d04c641cb8e3dbf0ad723bcd0430f41a0c8ffbd00000000dbfe7dbf000000008866c641cb8e3dbfcdcc4c3ed0430f41a0c8ffbd00000000dbfe7dbf0000003f8866c641f13c3dbfcdcc4c3e736c0f41a0c8ff3d00000000dbfe7d3f0000003f8866c641f13c3dbf0ad723bc736c0f41a0c8ff3d00000000dbfe7d3f0000803f8866c641f33740bf0ad723bc624b0f41306e68be000000006e5179bf000000004dc6c641f33740bfcdcc4c3e624b0f41306e68be000000006e5179bf0000003f4dc6c64132a33fbfcdcc4c3e46730f41306e683e000000006e51793f0000003f4dc6c64132a33fbf0ad723bc46730f41306e683e000000006e51793f0000803f4dc6c641429042bf0ad723bc2a560f416cb6a6be000000008d0c72bf000000002424c741429042bfcdcc4c3e2a560f416cb6a6be000000008d0c72bf0000003f2424c741ddba41bfcdcc4c3ee57c0f416cb6a63e000000008d0c723f0000003f2424c741ddba41bf0ad723bce57c0f416cb6a63e000000008d0c723f0000803f2424c741c7d144bf0ad723bcb2640f4104a9d6be00000000fb6968bf000000008c80c741c7d144bfcdcc4c3eb2640f4104a9d6be00000000fb6968bf0000003f8c80c74104bf43bfcdcc4c3ee2890f4104a9d63e00000000fb69683f0000003f8c80c74104bf43bf0ad723bce2890f4104a9d63e00000000fb69683f0000803f8c80c741342047bf0ad723bc0b780f41bcbf01bf00000000faae5cbf00000000eedbc741342047bfcdcc4c3e0b780f41bcbf01bf00000000faae5cbf0000003feedbc7410cd445bfcdcc4c3e5a9b0f41bcbf013f00000000faae5c3f0000003feedbc7410cd445bf0ad723bc5a9b0f41bcbf013f00000000faae5c3f0000803feedbc741468949bf0ad723bc5e910f41b07016bf00000000d9214fbf000000009d36c841468949bfcdcc4c3e5e910f41b07016bf00000000d9214fbf0000003f9d36c841260848bfcdcc4c3e82b20f41b070163f00000000d9214f3f0000003f9d36c841260848bf0ad723bc82b20f41b070163f00000000d9214f3f0000803f9d36c841d5084cbf0ad723bc73b10f41775129bf000000003a0240bf00000000d590c841d5084cbfcdcc4c3e73b10f41775129bf000000003a0240bf0000003fd590c84160574abfcdcc4c3e2cd00f417751293f000000003a02403f0000003fd590c84160574abf0ad723bc2cd00f417751293f000000003a02403f0000803fd590c841258e4ebf0ad723bc8ad80f41fb5b3abf0000000059842fbf00000000c2eac841258e4ebfcdcc4c3e8ad80f41fb5b3abf0000000059842fbf0000003fc2eac84111b14cbfcdcc4c3e9ff40f41fb5b3a3f0000000059842f3f0000003fc2eac84111b14cbf0ad723bc9ff40f41fb5b3a3f0000000059842f3f0000803fc2eac8413a0151bf0ad723bc330610412f9349bf00000000ffce1dbf000000008444c9413a0151bfcdcc4c3e330610412f9349bf00000000ffce1dbf0000003f8444c94132fd4ebfcdcc4c3e731f10412f93493f00000000ffce1d3f0000003f8444c94132fd4ebf0ad723bc731f10412f93493f00000000ffce1d3f0000803f8444c941114853bf0ad723bc5d39104180fc56bf0000000035fc0abf000000002d9ec941114853bfcdcc4c3e5d39104180fc56bf0000000035fc0abf0000003f2d9ec941b42151bfcdcc4c3e9a4f104180fc563f0000000035fc0a3f0000003f2d9ec941b42151bf0ad723bc9a4f104180fc563f0000000035fc0a3f0000803f2d9ec941c44a55bf0ad723bc67701041c29a62bf000000009736eebe00000000cbf7c941c44a55bfcdcc4c3e67701041c29a62bf000000009736eebe0000003fcbf7c941a90653bfcdcc4c3e75831041c29a623f000000009736ee3e0000003fcbf7c941a90653bf0ad723bc75831041c29a623f000000009736ee3e0000803fcbf7c941bdf656bf0ad723bc5ba91041246a6cbf00000000b868c4be000000006951ca41bdf656bfcdcc4c3e5ba91041246a6cbf00000000b868c4be0000003f6951ca41859954bfcdcc4c3e11b91041246a6c3f00000000b868c43e0000003f6951ca41859954bf0ad723bc11b91041246a6c3f00000000b868c43e0000803f6951ca41d04058bf0ad723bc1be21041915d74bf00000000fa9898be0000000014abca41d04058bfcdcc4c3e1be21041915d74bf00000000fa9898be0000003f14abca413dcf55bfcdcc4c3e50ee1041915d743f00000000fa98983e0000003f14abca413dcf55bf0ad723bc50ee1041915d743f00000000fa98983e0000803f14abca413d2659bf0ad723bc9f1811416e5d7abf0000000017ab55be00000000de04cb413d2659bfcdcc4c3e9f1811416e5d7abf0000000017ab55be0000003fde04cb414ea556bfcdcc4c3e2b2111416e5d7a3f0000000017ab553e0000003fde04cb414ea556bf0ad723bc2b2111416e5d7a3f0000000017ab553e0000803fde04cb416aac59bf0ad723bc464b1141f0477ebf00000000caefecbd00000000e35ecb416aac59bfcdcc4c3e464b1141f0477ebf00000000caefecbd0000003fe35ecb41752157bfcdcc4c3e03501141f0477e3f00000000caefec3d0000003fe35ecb41752157bf0ad723bc03501141f0477e3f00000000caefec3d0000803fe35ecb41fcde59bf0ad723bc1879114174f37fbf00000000c547a0bc000000004cb9cb41fcde59bfcdcc4c3e1879114174f37fbf00000000c547a0bc0000003f4cb9cb41c04f57bfcdcc4c3ee579114174f37f3f00000000c547a03c0000003f4cb9cb41c04f57bf0ad723bce579114174f37f3f00000000c547a03c0000803f4cb9cb4132cc59bf0ad723bc0ba211412a337fbf00000000ffcba13d000000005314cc4132cc59bfcdcc4c3e0ba211412a337fbf00000000ffcba13d0000003f5314cc41e23e57bfcdcc4c3ecf9e11412a337f3f00000000ffcba1bd0000003f5314cc41e23e57bf0ad723bccf9e11412a337f3f00000000ffcba1bd0000803f5314cc41217f59bf0ad723bc3bc711411ede7bbf00000000ef3e373e000000004470cc41217f59bfcdcc4c3e3bc711411ede7bbf00000000ef3e373e0000003f4470cc415afa56bfcdcc4c3ee7bf11411ede7b3f00000000ef3e37be0000003f4470cc415afa56bf0ad723bce7bf11411ede7b3f00000000ef3e37be0000803f4470cc4196f858bf0ad723bceeea11414cd875bf00000000c4c68e3e0000000085cdcc4196f858bfcdcc4c3eeeea11414cd875bf00000000c4c68e3e0000003f85cdcc41398356bfcdcc4c3e82df11414cd8753f00000000c4c68ebe0000003f85cdcc41398356bf0ad723bc82df11414cd8753f00000000c4c68ebe0000803f85cdcc413f2758bf0ad723bc6f1012414c1c6dbf000000003b06c13e00000000912ccd413f2758bfcdcc4c3e6f1012414c1c6dbf000000003b06c13e0000003f912ccd413fc855bfcdcc4c3efe0012414c1c6d3f000000003b06c1be0000003f912ccd413fc855bf0ad723bcfe0012414c1c6d3f000000003b06c1be0000803f912ccd4133e156bf0ad723bca23b12416fc361bf00000000fd62f13e00000000fc8dcd4133e156bfcdcc4c3ea23b12416fc361bf00000000fd62f13e0000003ffc8dcd413f9f54bfcdcc4c3e522812416fc3613f00000000fd62f1be0000003ffc8dcd413f9f54bf0ad723bc522812416fc3613f00000000fd62f1be0000803ffc8dcd41c5e054bf0ad723bc6b701241cb0954bf000000004e710f3f0000000070f2cd41c5e054bfcdcc4c3e6b701241cb0954bf000000004e710f3f0000003f70f2cd41f3c152bfcdcc4c3e78591241cb09543f000000004e710fbf0000003f70f2cd41f3c152bf0ad723bc78591241cb09543f000000004e710fbf0000803f70f2cd41c2c551bf0ad723bcfcb112418a4c44bf000000003553243f00000000af5ace41c2c551bfcdcc4c3efcb112418a4c44bf000000003553243f0000003faf5ace413bcf4fbfcdcc4c3eb19712418a4c443f00000000355324bf0000003faf5ace413bcf4fbf0ad723bcb19712418a4c443f00000000355324bf0000803faf5ace41031c4dbf0ad723bc2f021341d40133bf000000006902373f0000000089c7ce41031c4dbfcdcc4c3e2f021341d40133bf000000006902373f0000003f89c7ce41c1514bbfcdcc4c3ee7e41241d401333f00000000690237bf0000003f89c7ce41c1514bbf0ad723bce7e41241d401333f00000000690237bf0000803f89c7ce41016546bf0ad723bc2e611341c2ac20bf000000003a4c473f00000000dc39cf41016546bfcdcc4c3e2e611341c2ac20bf000000003a4c473f0000003fdc39cf41aec944bfcdcc4c3e4b411341c2ac203f000000003a4c47bf0000003fdc39cf41aec944bf0ad723bc4b411341c2ac203f000000003a4c47bf0000803fdc39cf41a0223dbf0ad723bc58cd1341eccf0dbf00000000d321553f0000000093b2cf41a0223dbfcdcc4c3e58cd1341eccf0dbf00000000d321553f0000003f93b2cf4196b73bbfcdcc4c3e3eab1341eccf0d3f00000000d32155bf0000003f93b2cf4196b73bbf0ad723bc3eab1341eccf0d3f00000000d32155bf0000803f93b2cf4154e030bf0ad723bc6f431441eac3f5be000000004b94603f000000009a32d04154e030bfcdcc4c3e6f431441eac3f5be000000004b94603f0000003f9a32d041c0a52fbfcdcc4c3e801f1441eac3f53e000000004b9460bf0000003f9a32d041c0a52fbf0ad723bc801f1441eac3f53e000000004b9460bf0000803f9a32d041733921bf0ad723bc01bf14418a8bd0be000000003dcd693f00000000e1bad041733921bfcdcc4c3e01bf14418a8bd0be000000003dcd693f0000003fe1bad041832e20bfcdcc4c3e989914418a8bd03e000000003dcd69bf0000003fe1bad041832e20bf0ad723bc989914418a8bd03e000000003dcd69bf0000803fe1bad041
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -0.73838425, y: 0.095, z: 9.124887}
-    m_Extent: {x: 0.112674505, y: 0.105000004, z: 0.17174482}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    offset: 0
-    size: 0
-    path: 
---- !u!1 &1757001462
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1757001463}
-  - component: {fileID: 1757001467}
-  - component: {fileID: 1757001466}
-  - component: {fileID: 1757001465}
-  - component: {fileID: 1757001464}
-  m_Layer: 0
-  m_Name: segment 9
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1757001463
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1757001462}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1236410749}
-  m_RootOrder: 9
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1757001464
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1757001462}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 821324673}
---- !u!114 &1757001465
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1757001462}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &1757001466
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1757001462}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1757001467
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1757001462}
-  m_Mesh: {fileID: 821324673}
---- !u!1 &1801657007
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1801657008}
-  - component: {fileID: 1801657012}
-  - component: {fileID: 1801657011}
-  - component: {fileID: 1801657010}
-  - component: {fileID: 1801657009}
-  m_Layer: 0
-  m_Name: segment 10
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1801657008
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1801657007}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1236410749}
-  m_RootOrder: 10
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1801657009
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1801657007}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1044053487}
---- !u!114 &1801657010
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1801657007}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &1801657011
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1801657007}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1801657012
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1801657007}
-  m_Mesh: {fileID: 1044053487}
---- !u!1 &1834044261
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1834044262}
-  - component: {fileID: 1834044266}
-  - component: {fileID: 1834044265}
-  - component: {fileID: 1834044264}
-  - component: {fileID: 1834044263}
-  m_Layer: 0
-  m_Name: segment 8
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1834044262
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1834044261}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1236410749}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1834044263
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1834044261}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1723624959}
---- !u!114 &1834044264
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1834044261}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &1834044265
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1834044261}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1834044266
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1834044261}
-  m_Mesh: {fileID: 1723624959}
---- !u!1 &1835053459
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1835053460}
-  - component: {fileID: 1835053461}
-  m_Layer: 0
-  m_Name: Wheel FL Collider
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1835053460
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1835053459}
-  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0.1, y: -0.024999999, z: 0.14}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1104095457}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
---- !u!146 &1835053461
-WheelCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1835053459}
-  m_Center: {x: 0, y: 0, z: 0}
-  m_Radius: 0.035
-  m_SuspensionSpring:
-    spring: 35
-    damper: 5
-    targetPosition: 0.9
-  m_SuspensionDistance: 0.01
-  m_ForceAppPointDistance: 0
-  m_Mass: 0.1
-  m_WheelDampingRate: 0.25
-  m_ForwardFriction:
-    m_ExtremumSlip: 0.4
-    m_ExtremumValue: 1
-    m_AsymptoteSlip: 0.8
-    m_AsymptoteValue: 0.5
-    m_Stiffness: 2
-  m_SidewaysFriction:
-    m_ExtremumSlip: 0.2
-    m_ExtremumValue: 1
-    m_AsymptoteSlip: 0.5
-    m_AsymptoteValue: 0.75
-    m_Stiffness: 2
-  m_Enabled: 1
---- !u!43 &1844291866
+--- !u!43 &311070365
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -10012,112 +1261,170 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1 &1864002380
-GameObject:
+--- !u!43 &535687184
+Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1864002381}
-  - component: {fileID: 1864002385}
-  - component: {fileID: 1864002384}
-  - component: {fileID: 1864002383}
-  - component: {fileID: 1864002382}
-  m_Layer: 0
-  m_Name: segment 7
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1864002381
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1864002380}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1272024235}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1864002382
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1864002380}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1121393386}
---- !u!114 &1864002383
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1864002380}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &1864002384
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1864002380}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1864002385
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1864002380}
-  m_Mesh: {fileID: 1121393386}
---- !u!43 &1880345464
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 360
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 93
+    localAABB:
+      m_Center: {x: -4.8949666, y: 0, z: 8.176058}
+      m_Extent: {x: 1.5281821, y: 0, z: 1.670877}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000030003000400010002000100040004000500020004000300060006000700040005000400070007000800050007000600090009000a000700080007000a000a000b0008000a0009000c000c000d000a000b000a000d000d000e000b000d000c000f000f0010000d000e000d001000100011000e0010000f00120012001300100011001000130013001400110013001200150015001600130014001300160016001700140016001500180018001900160017001600190019001a001700190018001b001b001c0019001a0019001c001c001d001a001c001b001e001e001f001c001d001c001f001f0020001d001f001e002100210022001f0020001f002200220023002000220021002400240025002200230022002500250026002300250024002700270028002500260025002800280029002600280027002a002a002b002800290028002b002b002c0029002b002a002d002d002e002b002c002b002e002e002f002c002e002d003000300031002e002f002e003100310032002f0031003000330033003400310032003100340034003500320034003300360036003700340035003400370037003800350037003600390039003a003700380037003a003a003b0038003a0039003c003c003d003a003b003a003d003d003e003b003d003c003f003f0040003d003e003d004000400041003e0040003f00420042004300400041004000430043004400410043004200450045004600430044004300460046004700440046004500480048004900460047004600490049004a004700490048004b004b004c0049004a0049004c004c004d004a004c004b004e004e004f004c004d004c004f004f0050004d004f004e005100510052004f0050004f005200520053005000520051005400540055005200530052005500550056005300550054005700570058005500560055005800580059005600580057005a005a005b005800590058005b005b005c005900
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 93
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 2976
+    _typelessdata: 6f8acdc000000000ec051c41000000000000803f000000000000000076286841e2cbc6c00000000071820f41000000000000803f000000000000003f76286841550dc0c000000000f6fe0241000000000000803f000000000000803f762868419d0ec7c00000000030c61c41000000000000803f0000000000000000715b6941ac1fc2c000000000130d1041000000000000803f000000000000003f715b6941bb30bdc000000000f6530341000000000000803f000000000000803f715b6941c99bc0c00000000020471d41000000000000803f00000000000000001b836a41348fbdc00000000067681041000000000000803f000000000000003f1b836a419f82bac000000000ae890341000000000000803f000000000000803f1b836a416f38bac00000000027891d41000000000000803f0000000000000000afa06b419e1cb9c0000000006e961041000000000000803f000000000000003fafa06b41cd00b8c000000000b5a30341000000000000803f000000000000803fafa06b41acebb3c0000000000b8d1d41000000000000803f000000000000000051b56c4117cab4c00000000026991041000000000000803f000000000000003f51b56c4182a8b5c00000000041a50341000000000000803f000000000000803f51b56c41e3bcadc00000000001541d41000000000000803f000000000000000018c26d41c499b0c0000000008b721041000000000000803f000000000000003f18c26d41a576b3c00000000015910341000000000000803f000000000000803f18c26d419ab3a7c000000000badf1c41000000000000803f0000000000000000fdc76e41d58dacc000000000a0241041000000000000803f000000000000003ffdc76e411068b1c00000000086690341000000000000803f000000000000803ffdc76e4111d7a1c00000000050321c41000000000000803f0000000000000000e9c76f416fa8a8c00000000062b10f41000000000000803f000000000000003fe9c76f41cd79afc00000000074300341000000000000803f000000000000803fe9c76f412a2e9cc000000000414e1b41000000000000803f0000000000000000a6c27041bfeba4c000000000d21a0f41000000000000803f000000000000003fa6c2704154a9adc00000000063e70241000000000000803f000000000000803fa6c2704125bf96c0000000004b361a41000000000000803f0000000000000000ebb87141ec59a1c000000000ea620e41000000000000803f000000000000003febb87141b3f4abc000000000898f0241000000000000803f000000000000803febb871419e8f91c00000000065ed1841000000000000803f000000000000000052ab72411ef59dc000000000ad8b0d41000000000000803f000000000000003f52ab72419e5aaac000000000f5290241000000000000803f000000000000803f52ab724188a48cc00000000094761741000000000000803f00000000000000005d9a734185bf9ac0000000001b970c41000000000000803f000000000000003f5d9a734182daa8c000000000a2b70141000000000000803f000000000000803f5d9a7341310288c000000000d8d41541000000000000803f00000000000000007e86744146bb97c00000000031870b41000000000000803f000000000000003f7e8674415b74a7c0000000008a390141000000000000803f000000000000803f7e86744168ac83c000000000190b1441000000000000803f0000000000000000127075418aea94c000000000ec5d0a41000000000000803f000000000000003f12707541ac28a6c000000000bfb00041000000000000803f000000000000803f127075414b4d7fc0000000001f1c1241000000000000803f0000000000000000645776417c4f92c0000000004d1d0941000000000000803f000000000000003f6457764153f8a4c0000000007b1e0041000000000000803f000000000000803f645776415ce877c0000000008c0a1041000000000000803f0000000000000000b43c774147ec8fc00000000054c70741000000000000803f000000000000003fb43c774160e4a3c0000000003808ff40000000000000803f000000000000803fb43c7741773071c000000000d2d80d41000000000000803f00000000000000003c20784112c38dc000000000fd5d0641000000000000803f000000000000003f3c207841e8eda2c00000000050c6fd40000000000000803f000000000000803f3c207841592c6bc0000000004c890b41000000000000803f00000000000000002b02794109d68bc0000000004ae30441000000000000803f000000000000003f2b027941e515a2c000000000907afc40000000000000803f000000000000803f2b0279413ee365c000000000391e0941000000000000803f0000000000000000b5e2794155278ac00000000037590341000000000000803f000000000000003fb5e279410b5da1c0000000006a28fb40000000000000803f000000000000803fb5e27941195d61c000000000de990641000000000000803f00000000000000000fc27a411eb988c000000000c4c10141000000000000803f000000000000003f0fc27a41b0c3a0c00000000053d3f940000000000000803f000000000000803f0fc27a41bea25dc00000000098fe0341000000000000803f000000000000000075a07b41908d87c000000000f11e0041000000000000803f000000000000003f75a07b41c149a0c000000000957ef840000000000000803f000000000000803f75a07b41d6bd5ac000000000f34e0141000000000000803f0000000000000000327e7c41d3a686c00000000078e5fc40000000000000803f000000000000003f327e7c41bbee9fc0000000000a2df740000000000000803f000000000000803f327e7c41c8b858c000000000a41bfd40000000000000803f0000000000000000a05b7d41120786c000000000487ef940000000000000803f000000000000003fa05b7d41c0b19fc000000000ece0f540000000000000803f000000000000803fa05b7d41649e57c000000000157df740000000000000803f00000000000000002e397e4176b085c0000000004e0cf640000000000000803f000000000000003f2e397e41ba919fc000000000879bf440000000000000803f000000000000803f2e397e41657957c00000000002caf140000000000000803f000000000000000063177f4128a585c0000000008c93f240000000000000803f000000000000003f63177f419e8d9fc000000000165df340000000000000803f000000000000803f63177f41bd5358c0000000006a0bec40000000000000803f0000000000000000e4f67f4152e785c000000000fc17ef40000000000000803f000000000000003fe4f67f41c5a49fc0000000008e24f240000000000000803f000000000000803fe4f67f41c8355ac000000000934be640000000000000803f0000000000000000396c80411e7986c0000000009e9deb40000000000000803f000000000000003f396c804158d79fc000000000a9eff040000000000000803f000000000000803f396c804160255dc000000000d695e040000000000000803f000000000000000078de8041b55c87c0000000006f28e840000000000000803f000000000000003f78de8041ba26a0c00000000008bbef40000000000000803f000000000000803f78de8041282561c00000000046f6da40000000000000803f0000000000000000b0528141429488c0000000006dbce440000000000000803f000000000000003fb0528141f095a0c0000000009482ee40000000000000803f000000000000803fb05281410a3466c0000000002d79d540000000000000803f000000000000000073c98141ed218ac000000000955de140000000000000803f000000000000003f73c98141d529a1c000000000fd41ed40000000000000803f000000000000803f73c98141264d6cc000000000702ad040000000000000803f00000000000000005e438241df078cc000000000e90fde40000000000000803f000000000000003f5e4382412be9a1c00000000062f5eb40000000000000803f000000000000803f5e438241
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -4.8949666, y: 0, z: 8.176058}
+    m_Extent: {x: 1.5281821, y: 0, z: 1.670877}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &540795372
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -10134,8 +1441,8 @@ Mesh:
     firstVertex: 0
     vertexCount: 124
     localAABB:
-      m_Center: {x: -7.429123, y: 0.095, z: 5.593294}
-      m_Extent: {x: 1.4274957, y: 0.105000004, z: 2.603608}
+      m_Center: {x: -5.8255835, y: 0.095, z: 2.8565073}
+      m_Extent: {x: 0.22314286, y: 0.105000004, z: 0.18401957}
   m_Shapes:
     vertices: []
     shapes: []
@@ -10214,7 +1521,7 @@ Mesh:
       format: 0
       dimension: 0
     m_DataSize: 3968
-    _typelessdata: b6b40dc10ad723bceb583f40a1fb7fbf000000008c443d3c00000000eaf82d41b6b40dc1cdcc4c3eeb583f40a1fb7fbf000000008c443d3c0000003feaf82d41c18b0dc1cdcc4c3e06573f40a1fb7f3f000000008c443dbc0000003feaf82d41c18b0dc10ad723bc06573f40a1fb7f3f000000008c443dbc0000803feaf82d415e910dc10ad723bc97565040e1a27fbf0000000010475a3d00000000555d30415e910dc1cdcc4c3e97565040e1a27fbf0000000010475a3d0000003f555d304177680dc1cdcc4c3edc4d5040e1a27f3f0000000010475abd0000003f555d304177680dc10ad723bcdc4d5040e1a27f3f0000000010475abd0000803f555d3041be410dc10ad723bc162c6140e9dd7ebf00000000827bc03d0000000058bc3241be410dc1cdcc4c3e162c6140e9dd7ebf00000000827bc03d0000003f58bc3241f7180dc1cdcc4c3eb01c6140e9dd7e3f00000000827bc0bd0000003f58bc3241f7180dc10ad723bcb01c6140e9dd7e3f00000000827bc0bd0000803f58bc324193c70cc10ad723bca5d371408fb47dbf0000000083cc083e000000001816354193c70cc1cdcc4c3ea5d371408fb47dbf0000000083cc083e0000003f18163541fc9e0cc1cdcc4c3ec2bd71408fb47d3f0000000083cc08be0000003f18163541fc9e0cc10ad723bcc2bd71408fb47d3f0000000083cc08be0000803f18163541a8240cc10ad723bca32381404a2e7cbf000000004238303e00000000a36a3741a8240cc1cdcc4c3ea32381404a2e7cbf000000004238303e0000003fa36a37414ffc0bc1cdcc4c3e8a1581404a2e7c3f00000000423830be0000003fa36a37414ffc0bc10ad723bc8a1581404a2e7c3f00000000423830be0000803fa36a3741c35a0bc10ad723bc4b408940fc517abf000000003c81563e00000000edb93941c35a0bc1cdcc4c3e4b408940fc517abf000000003c81563e0000003fedb93941b5320bc1cdcc4c3e222f8940fc517a3f000000003c8156be0000003fedb93941b5320bc10ad723bc222f8940fc517a3f000000003c8156be0000803fedb93941bd6b0ac10ad723bc8c3c9140d42578bf000000001eac7b3e00000000d9033c41bd6b0ac1cdcc4c3e8c3c9140d42578bf000000001eac7b3e0000003fd9033c4109440ac1cdcc4c3e6a289140d425783f000000001eac7bbe0000003fd9033c4109440ac10ad723bc6a289140d425783f000000001eac7bbe0000803fd9033c41785909c10ad723bcf81499401caf75bf0000000049e18f3e0000000033483e41785909c1cdcc4c3ef81499401caf75bf0000000049e18f3e0000003f33483e41283209c1cdcc4c3ef3fd98401caf753f0000000049e18fbe0000003f33483e41283209c10ad723bcf3fd98401caf753f0000000049e18fbe0000803f33483e41e02508c10ad723bc1dc6a04036f272bf000000009568a13e00000000b7864041e02508c1cdcc4c3e1dc6a04036f272bf000000009568a13e0000003fb786404101ff07c1cdcc4c3e49aca04036f2723f000000009568a1be0000003fb786404101ff07c10ad723bc49aca04036f2723f000000009568a1be0000803fb7864041edd206c10ad723bc634ca84078f26fbf00000000fa73b23e000000000ebf4241edd206c1cdcc4c3e634ca84078f26fbf00000000fa73b23e0000003f0ebf424189ac06c1cdcc4c3ed62fa84078f26f3f00000000fa73b2be0000003f0ebf424189ac06c10ad723bcd62fa84078f26f3f00000000fa73b2be0000803f0ebf4241aa6205c10ad723bc32a4af401eb26cbf00000000c60cc33e00000000d5f04441aa6205c1cdcc4c3e32a4af401eb26cbf00000000c60cc33e0000003fd5f04441cb3c05c1cdcc4c3efc84af401eb26c3f00000000c60cc3be0000003fd5f04441cb3c05c10ad723bcfc84af401eb26c3f00000000c60cc3be0000803fd5f044412ed703c10ad723bcdac9b6403e3269bf000000003e3dd33e00000000991b47412ed703c1cdcc4c3edac9b6403e3269bf000000003e3dd33e0000003f991b4741dfb103c1cdcc4c3e0ea8b6403e32693f000000003e3dd3be0000003f991b4741dfb103c10ad723bc0ea8b6403e32693f000000003e3dd3be0000803f991b4741a03202c10ad723bca2b9bd40ac7265bf00000000ad10e33e00000000dd3e4941a03202c1cdcc4c3ea2b9bd40ac7265bf00000000ad10e33e0000003fdd3e4941ea0d02c1cdcc4c3e4d95bd40ac72653f00000000ad10e3be0000003fdd3e4941ea0d02c10ad723bc4d95bd40ac72653f00000000ad10e3be0000803fdd3e4941377700c10ad723bcca6fc440ee7161bf00000000f092f23e00000000185a4b41377700c1cdcc4c3eca6fc440ee7161bf00000000f092f23e0000003f185a4b41245300c1cdcc4c3efa48c440ee71613f00000000f092f2be0000003f185a4b41245300c10ad723bcfa48c440ee71613f00000000f092f2be0000803f185a4b41764efdc00ad723bc86e8ca40162d5dbf000000004ee8003f00000000ba6c4d41764efdc0cdcc4c3e86e8ca40162d5dbf000000004ee8003f0000003fba6c4d41b007fdc0cdcc4c3e46bfca40162d5d3f000000004ee800bf0000003fba6c4d41b007fdc00ad723bc46bfca40162d5d3f000000004ee800bf0000803fba6c4d411e8af9c00ad723bc0a20d1409d9f58bf00000000606b083f000000002a764f411e8af9c0cdcc4c3e0a20d1409d9f58bf00000000606b083f0000003f2a764f41cc44f9c0cdcc4c3e62f4d0409d9f583f00000000606b08bf0000003f2a764f41cc44f9c00ad723bc62f4d0409d9f583f00000000606b08bf0000803f2a764f414ca6f5c00ad723bc8112d74040c353bf000000005ed90f3f00000000ca7551414ca6f5c0cdcc4c3e8112d74040c353bf000000005ed90f3f0000003fca7551418862f5c0cdcc4c3e78e4d64040c3533f000000005ed90fbf0000003fca7551418862f5c00ad723bc78e4d64040c3533f000000005ed90fbf0000803fca7551411ea8f1c00ad723bc10bcdc40b58f4ebf000000001939173f00000000f96a53411ea8f1c0cdcc4c3e10bcdc40b58f4ebf000000001939173f0000003ff96a53410466f1c0cdcc4c3eac8bdc40b58f4e3f00000000193917bf0000003ff96a53410466f1c00ad723bcac8bdc40b58f4e3f00000000193917bf0000803ff96a5341ec94edc00ad723bce318e24063fa48bf000000006a911e3f0000000012555541ec94edc0cdcc4c3ee318e24063fa48bf000000006a911e3f0000003f125555419c54edc0cdcc4c3e25e6e14063fa483f000000006a911ebf0000003f125555419c54edc00ad723bc25e6e14063fa483f000000006a911ebf0000803f125555415772e9c00ad723bc2125e740f2f542bf000000001ae9253f00000000723357415772e9c0cdcc4c3e2125e740f2f542bf000000001ae9253f0000003f72335741f433e9c0cdcc4c3e09f0e640f2f5423f000000001ae925bf0000003f72335741f433e9c00ad723bc09f0e640f2f5423f000000001ae925bf0000803f723357415046e5c00ad723bcfcdceb40e0713cbf00000000a4462d3f00000000770559415046e5c0cdcc4c3efcdceb40e0713cbf00000000a4462d3f0000003f77055941030ae5c0cdcc4c3e89a5eb40e0713c3f00000000a4462dbf0000003f77055941030ae5c00ad723bc89a5eb40e0713c3f00000000a4462dbf0000803f770559412b17e1c00ad723bcb33cf040c85935bf00000000f6af343f0000000084ca5a412b17e1c0cdcc4c3eb33cf040c85935bf00000000f6af343f0000003f84ca5a4123dde0c0cdcc4c3ee202f040c859353f00000000f6af34bf0000003f84ca5a4123dde0c00ad723bce202f040c859353f00000000f6af34bf0000803f84ca5a41adebdcc00ad723bca640f440c0942dbf00000000f0293c3f0000000004825c41adebdcc0cdcc4c3ea640f440c0942dbf00000000f0293c3f0000003f04825c4122b4dcc0cdcc4c3e6f04f440c0942d3f00000000f0293cbf0000003f04825c4122b4dcc00ad723bc6f04f440c0942d3f00000000f0293cbf0000803f04825c412ccbd8c00ad723bc51e5f740570425bf00000000b9b7433f000000006b2b5e412ccbd8c0cdcc4c3e51e5f740570425bf00000000b9b7433f0000003f6b2b5e415e96d8c0cdcc4c3eb0a6f7405704253f00000000b9b743bf0000003f6b2b5e415e96d8c00ad723bcb0a6f7405704253f00000000b9b743bf0000803f6b2b5e41a6bdd4c00ad723bc8827fb408c831bbf00000000be594b3f0000000041c65f41a6bdd4c0cdcc4c3e8827fb408c831bbf00000000be594b3f0000003f41c65f41e38bd4c0cdcc4c3e75e6fa408c831b3f00000000be594bbf0000003f41c65f41e38bd4c00ad723bc75e6fa408c831b3f00000000be594bbf0000803f41c65f41dccbd0c00ad723bc8604fe40bce510bf00000000fa0b533f000000001e526141dccbd0c0cdcc4c3e8604fe40bce510bf00000000fa0b533f0000003f1e5261417e9dd0c0cdcc4c3efdc0fd40bce5103f00000000fa0b53bf0000003f1e5261417e9dd0c00ad723bcfdc0fd40bce5103f00000000fa0b53bf0000803f1e5261416bffccc00ad723bc1c3d004188f504bf00000000b2c35a3f00000000bace62416bffccc0cdcc4c3e1c3d004188f504bf00000000b2c35a3f0000003fbace6241dfd4ccc0cdcc4c3e1b1a004188f5043f00000000b2c35abf0000003fbace6241dfd4ccc00ad723bc1b1a004188f5043f00000000b2c35abf0000803fbace6241e862c9c00ad723bcc44301414ee8eebe00000000f86b623f00000000ec3b6441e862c9c0cdcc4c3ec44301414ee8eebe00000000f86b623f0000003fec3b6441ae3cc9c0cdcc4c3e8a1f01414ee8ee3e00000000f86b62bf0000003fec3b6441ae3cc9c00ad723bc8a1f01414ee8ee3e00000000f86b62bf0000803fec3b6441cf01c6c00ad723bc741602410833d0be00000000f5e0693f00000000bb996541cf01c6c0cdcc4c3e741602410833d0be00000000f5e0693f0000003fbb99654180e0c5c0cdcc4c3e08f101410833d03e00000000f5e069bf0000003fbb99654180e0c5c00ad723bc08f101410833d03e00000000f5e069bf0000803fbb9965414be8c2c00ad723bc74b60241a42dadbe0000000055e9703f0000000067e866414be8c2c0cdcc4c3e74b60241a42dadbe0000000055e9703f0000003f67e8664196ccc2c0cdcc4c3ee98f0241a42dad3e0000000055e970bf0000003f67e8664196ccc2c00ad723bce98f0241a42dad3e0000000055e970bf0000803f67e86641a622c0c00ad723bc83260341b03885be00000000a12e773f0000000076286841a622c0c0cdcc4c3e83260341b03885be00000000a12e773f0000003f76286841550dc0c0cdcc4c3ef6fe0241b038853e00000000a12e77bf0000003f76286841550dc0c00ad723bcf6fe0241b038853e00000000a12e77bf0000803f76286841
+    _typelessdata: dbbbbec00ad723bc663c42403642543f00000000c91d0fbf0000000005c29241dbbbbec0cdcc4c3e663c42403642543f00000000c91d0fbf0000003f05c29241c7ffbec0cdcc4c3efe974240364254bf00000000c91d0f3f0000003f05c29241c7ffbec00ad723bcfe974240364254bf00000000c91d0f3f0000803f05c292413d8bbfc00ad723bc5e9b3f40c2815f3f0000000033a5f9be00000000033993413d8bbfc0cdcc4c3e5e9b3f40c2815f3f0000000033a5f9be0000003f03399341c2d2bfc0cdcc4c3e40eb3f40c2815fbf0000000033a5f93e0000003f03399341c2d2bfc00ad723bc40eb3f40c2815fbf0000000033a5f93e0000803f03399341c428c0c00ad723bc552b3d40865c693f000000002c82d2be00000000b0ab9341c428c0c0cdcc4c3e552b3d40865c693f000000002c82d2be0000003fb0ab93417173c0c0cdcc4c3eb26e3d40865c69bf000000002c82d23e0000003fb0ab93417173c0c00ad723bcb26e3d40865c69bf000000002c82d23e0000803fb0ab9341149cc0c00ad723bcd7eb3a40629f713f000000004c2ba9be000000008f1a9441149cc0c0cdcc4c3ed7eb3a40629f713f000000004c2ba9be0000003f8f1a944166e9c0c0cdcc4c3ef9213b40629f71bf000000004c2ba93e0000003f8f1a944166e9c0c00ad723bcf9213b40629f71bf000000004c2ba93e0000803f8f1a944103ecc0c00ad723bc3edb3840cc1f783f000000002c0b7cbe000000001486944103ecc0c0cdcc4c3e3edb3840cc1f783f000000002c0b7cbe0000003f14869441693bc1c0cdcc4c3e91033940cc1f78bf000000002c0b7c3e0000003f14869441693bc1c00ad723bc91033940cc1f78bf000000002c0b7c3e0000803f14869441561ec1c00ad723bc55f73640cabc7c3f0000000042f622be00000000a8ee9441561ec1c0cdcc4c3e55f73640cabc7c3f0000000042f622be0000003fa8ee9441376fc1c0cdcc4c3e68113740cabc7cbf0000000042f6223e0000003fa8ee9441376fc1c00ad723bc68113740cabc7cbf0000000042f6223e0000803fa8ee94410a38c1c00ad723bce23d3540205e7f3f00000000c5db8fbd00000000a95495410a38c1c0cdcc4c3ee23d3540205e7f3f00000000c5db8fbd0000003fa9549541c189c1c0cdcc4c3e64493540205e7fbf00000000c5db8f3d0000003fa9549541c189c1c00ad723bc64493540205e7fbf00000000c5db8f3d0000803fa9549541433dc1c00ad723bc1cad33402cf37f3f00000000fa13a23c000000006ab89541433dc1c0cdcc4c3e1cad33402cf37f3f00000000fa13a23c0000003f6ab895412b8fc1c0cdcc4c3edea933402cf37fbf00000000fa13a2bc0000003f6ab895412b8fc1c00ad723bcdea933402cf37fbf00000000fa13a2bc0000803f6ab89541a331c1c00ad723bcea433240c2707e3f0000000010b7e13d00000000331a9641a331c1c0cdcc4c3eea433240c2707e3f0000000010b7e13d0000003f331a96410f83c1c0cdcc4c3edc313240c2707ebf0000000010b7e1bd0000003f331a96410f83c1c00ad723bcdc313240c2707ebf0000000010b7e1bd0000803f331a96417218c1c00ad723bcf5013140f6ce7a3f00000000b12d4d3e00000000447a96417218c1c0cdcc4c3ef5013140f6ce7a3f00000000b12d4d3e0000003f447a9641b468c1c0cdcc4c3e21e13040f6ce7abf00000000b12d4dbe0000003f447a9641b468c1c00ad723bc21e13040f6ce7abf00000000b12d4dbe0000803f447a9641daf4c0c00ad723bc75e72f401a07753f00000000054a943e00000000d7d89641daf4c0c0cdcc4c3e75e72f401a07753f00000000054a943e0000003fd7d896414343c1c0cdcc4c3e01b82f401a0775bf00000000054a94be0000003fd7d896414343c1c00ad723bc01b82f401a0775bf00000000054a94be0000803fd7d896410bcac0c00ad723bcd0f42e4072126d3f00000000a236c13e00000000213697410bcac0c0cdcc4c3ed0f42e4072126d3f00000000a236c13e0000003f21369741e815c1c0cdcc4c3efbb62e4072126dbf00000000a236c1be0000003f21369741e815c1c00ad723bcfbb62e4072126dbf00000000a236c1be0000803f21369741389bc0c00ad723bc232a2e40b4e9623f000000004709ed3e0000000056929741389bc0c0cdcc4c3e232a2e40b4e9623f000000004709ed3e0000003f56929741d5e3c0c0cdcc4c3e49de2d40b4e962bf000000004709edbe0000003f56929741d5e3c0c00ad723bc49de2d40b4e962bf000000004709edbe0000803f56929741966bc0c00ad723bcac862d40e885563f0000000000b30b3f00000000abed9741966bc0c0cdcc4c3eac862d40e885563f0000000000b30b3f0000003fabed97413cb0c0c0cdcc4c3e442d2d40e88556bf0000000000b30bbf0000003fabed97413cb0c0c00ad723bc442d2d40e88556bf0000000000b30bbf0000803fabed9741103ec0c00ad723bc49082d409ce2473f000000008bf11f3f0000000058489841103ec0c0cdcc4c3e49082d409ce2473f000000008bf11f3f0000003f58489841067ec0c0cdcc4c3eeca12c409ce247bf000000008bf11fbf0000003f58489841067ec0c00ad723bceca12c409ce247bf000000008bf11fbf0000803f58489841fe14c0c00ad723bc16ab2c407e01373f00000000c502333f000000009ea29841fe14c0c0cdcc4c3e16ab2c407e01373f00000000c502333f0000003f9ea298418e4fc0c0cdcc4c3e85382c407e0137bf00000000c50233bf0000003f9ea298418e4fc0c00ad723bc85382c407e0137bf00000000c50233bf0000803f9ea298418af1bfc00ad723bc4a692c4076ef233f00000000e09f443f00000000c6fc98418af1bfc0cdcc4c3e4a692c4076ef233f00000000e09f443f0000003fc6fc98410026c0c0cdcc4c3e73eb2b4076ef23bf00000000e09f44bf0000003fc6fc98410026c0c00ad723bc73eb2b4076ef23bf00000000e09f44bf0000803fc6fc984137d3bfc00ad723bca13b2c40f6c90e3f00000000a27a543f000000002657994137d3bfc0cdcc4c3ea13b2c40f6c90e3f00000000a27a543f0000003f26579941e900c0c0cdcc4c3ea4b32b40f6c90ebf00000000a27a54bf0000003f26579941e900c0c00ad723bca4b32b40f6c90ebf00000000a27a54bf0000803f2657994149b7bfc00ad723bc231a2c401089ef3e000000007e41623f0000000025b2994149b7bfc0cdcc4c3e231a2c401089ef3e000000007e41623f0000003f25b299419cddbfc0cdcc4c3e56892b401089efbe000000007e4162bf0000003f25b299419cddbfc00ad723bc56892b401089efbe000000007e4162bf0000803f25b299416f98bfc00ad723bca8fd2b405458be3e00000000c3a66d3f00000000380e9a416f98bfc0cdcc4c3ea8fd2b405458be3e00000000c3a66d3f0000003f380e9a41e3b6bfc0cdcc4c3e8f652b405458bebe00000000c3a66dbf0000003f380e9a41e3b6bfc00ad723bc8f652b405458bebe00000000c3a66dbf0000803f380e9a41c46ebfc00ad723bc98e12b4024cf8a3e000000008c69763f00000000e56b9a41c46ebfc0cdcc4c3e98e12b4024cf8a3e000000008c69763f0000003fe56b9a41f984bfc0cdcc4c3ee4432b4024cf8abe000000008c6976bf0000003fe56b9a41f984bfc00ad723bce4432b4024cf8abe000000008c6976bf0000803fe56b9a412930bfc00ad723bcddc52b4078cc2b3e00000000155f7c3f00000000c6cb9a412930bfc0cdcc4c3eddc52b4078cc2b3e00000000155f7c3f0000003fc6cb9a41e73dbfc0cdcc4c3e59242b4078cc2bbe00000000155f7cbf0000003fc6cb9a41e73dbfc00ad723bc59242b4078cc2bbe00000000155f7cbf0000803fc6cb9a4132d1bec00ad723bc5fb02b4000c2823d000000004a7a7f3f00000000812e9b4132d1bec0cdcc4c3e5fb02b4000c2823d000000004a7a7f3f0000003f812e9b416dd6bec0cdcc4c3ede0c2b4000c282bd000000004a7a7fbf0000003f812e9b416dd6bec00ad723bcde0c2b4000c282bd000000004a7a7fbf0000803f812e9b414a46bec00ad723bcc2ad2b4050e21dbd000000004ccf7f3f00000000ce949b414a46bec0cdcc4c3ec2ad2b4050e21dbd000000004ccf7f3f0000003fce949b412143bec0cdcc4c3e0a0a2b4050e21d3d000000004ccf7fbf0000003fce949b412143bec00ad723bc0a0a2b4050e21d3d000000004ccf7fbf0000803fce949b41f884bdc00ad723bc15d12b40e0bf0cbe00000000f9917d3f000000006dff9b41f884bdc0cdcc4c3e15d12b40e0bf0cbe00000000f9917d3f0000003f6dff9b41b579bdc0cdcc4c3ecc2e2b40e0bf0c3e00000000f9917dbf0000003f6dff9b41b579bdc00ad723bccc2e2b40e0bf0c3e00000000f9917dbf0000803f6dff9b41e484bcc00ad723bc9b322c4088c96cbe00000000cd0f793f00000000296f9c41e484bcc0cdcc4c3e9b322c4088c96cbe00000000cd0f793f0000003f296f9c41f271bcc0cdcc4c3e35932b4088c96c3e00000000cd0f79bf0000003f296f9c41f271bcc00ad723bc35932b4088c96c3e00000000cd0f79bf0000803f296f9c418740bbc00ad723bce8ed2c40462ca3be00000000bba6723f00000000d2e49c418740bbc0cdcc4c3ee8ed2c40462ca3be00000000bba6723f0000003fd2e49c416b26bbc0cdcc4c3e9c522c40462ca33e00000000bba672bf0000003fd2e49c416b26bbc00ad723bc9c522c40462ca33e00000000bba672bf0000803fd2e49c4154b5b9c00ad723bce91f2e40ee52ccbe000000004cbb6a3f0000000039619d4154b5b9c0cdcc4c3ee91f2e40ee52ccbe000000004cbb6a3f0000003f39619d41a394b9c0cdcc4c3eae892d40ee52cc3e000000004cbb6abf0000003f39619d41a394b9c00ad723bcae892d40ee52cc3e000000004cbb6abf0000803f39619d4184e3b7c00ad723bc17e52f403aacf1be00000000d8af613f0000000034e59d4184e3b7c0cdcc4c3e17e52f403aacf1be00000000d8af613f0000003f34e59d41d9bcb7c0cdcc4c3ea6542f403aacf13e00000000d8af61bf0000003f34e59d41d9bcb7c00ad723bca6542f403aacf13e00000000d8af61bf0000803f34e59d41a6cdb5c00ad723bc30583240ad9c09bf000000002cde573f0000000093719e41a6cdb5c0cdcc4c3e30583240ad9c09bf000000002cde573f0000003f93719e419da1b5c0cdcc4c3e08ce3140ad9c093f000000002cde57bf0000003f93719e419da1b5c00ad723bc08ce3140ad9c093f000000002cde57bf0000803f93719e410378b3c00ad723bc76913540d48e18bf00000000d4934d3f0000000026079f410378b3c0cdcc4c3e76913540d48e18bf00000000d4934d3f0000003f26079f413247b3c0cdcc4c3ee40d3540d48e183f00000000d4934dbf0000003f26079f413247b3c00ad723bce40d3540d48e183f00000000d4934dbf0000803f26079f41
   m_CompressedMesh:
     m_Vertices:
       m_NumItems: 0
@@ -10268,8 +1575,8 @@ Mesh:
       m_BitSize: 0
     m_UVInfo: 0
   m_LocalAABB:
-    m_Center: {x: -7.429123, y: 0.095, z: 5.593294}
-    m_Extent: {x: 1.4274957, y: 0.105000004, z: 2.603608}
+    m_Center: {x: -5.8255835, y: 0.095, z: 2.8565073}
+    m_Extent: {x: 0.22314286, y: 0.105000004, z: 0.18401957}
   m_MeshUsageFlags: 0
   m_BakedConvexCollisionMesh: 
   m_BakedTriangleCollisionMesh: 
@@ -10280,217 +1587,7 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1 &1904266820
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1904266821}
-  - component: {fileID: 1904266825}
-  - component: {fileID: 1904266824}
-  - component: {fileID: 1904266823}
-  - component: {fileID: 1904266822}
-  m_Layer: 0
-  m_Name: segment 3
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1904266821
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1904266820}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1236410749}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1904266822
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1904266820}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 7416093}
---- !u!114 &1904266823
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1904266820}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &1904266824
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1904266820}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: b9e571a0d937247d08bd00d852cb7425, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1904266825
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1904266820}
-  m_Mesh: {fileID: 7416093}
---- !u!1 &1926398520
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1926398521}
-  - component: {fileID: 1926398525}
-  - component: {fileID: 1926398524}
-  - component: {fileID: 1926398523}
-  - component: {fileID: 1926398522}
-  m_Layer: 0
-  m_Name: segment 8
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1926398521
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1926398520}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1272024235}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1926398522
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1926398520}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 2096413040}
---- !u!114 &1926398523
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1926398520}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &1926398524
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1926398520}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1926398525
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1926398520}
-  m_Mesh: {fileID: 2096413040}
---- !u!43 &1974503200
+--- !u!43 &594260057
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -10507,8 +1604,8 @@ Mesh:
     firstVertex: 0
     vertexCount: 124
     localAABB:
-      m_Center: {x: -2.9276567, y: 0.095, z: 4.9479437}
-      m_Extent: {x: 2.6807432, y: 0.105000004, z: 2.118971}
+      m_Center: {x: -8.678727, y: 0.095, z: 0.4487927}
+      m_Extent: {x: 1.7886868, y: 0.105000004, z: 2.5596082}
   m_Shapes:
     vertices: []
     shapes: []
@@ -10587,7 +1684,7 @@ Mesh:
       format: 0
       dimension: 0
     m_DataSize: 3968
-    _typelessdata: 0378b3c00ad723bc76913540d48e18bf00000000d4934d3f0000000026079f410378b3c0cdcc4c3e76913540d48e18bf00000000d4934d3f0000003f26079f413247b3c0cdcc4c3ee40d3540d48e183f00000000d4934dbf0000003f26079f413247b3c00ad723bce40d3540d48e183f00000000d4934dbf0000803f26079f411769afc00ad723bcb09b3b400a1319bf0000000074314d3f000000001cab9f411769afc0cdcc4c3eb09b3b400a1319bf0000000074314d3f0000003f1cab9f411b38afc0cdcc4c3e5d183b400a13193f0000000074314dbf0000003f1cab9f411b38afc00ad723bc5d183b400a13193f0000000074314dbf0000803f1cab9f410be6aac00ad723bcf25a42407e8019bf00000000a0df4c3f000000001e61a0410be6aac0cdcc4c3ef25a42407e8019bf00000000a0df4c3f0000003f1e61a041ecb4aac0cdcc4c3ed4d741407e80193f00000000a0df4cbf0000003f1e61a041ecb4aac00ad723bcd4d741407e80193f00000000a0df4cbf0000803f1e61a041a9f8a5c00ad723bccec0494022df19bf0000000095984c3f00000000c627a141a9f8a5c0cdcc4c3ecec0494022df19bf0000000095984c3f0000003fc627a1416cc7a5c0cdcc4c3edd3d494022df193f0000000095984cbf0000003fc627a1416cc7a5c00ad723bcdd3d494022df193f0000000095984cbf0000803fc627a14178aaa0c00ad723bc4abf514007341abf000000009f584c3f00000000affda14178aaa0c0cdcc4c3e4abf514007341abf000000009f584c3f0000003faffda1411f79a0c0cdcc4c3e823c514007341a3f000000009f584cbf0000003faffda1411f79a0c00ad723bc823c514007341a3f000000009f584cbf0000803faffda141c2049bc00ad723bca9485a4074821abf000000005a1d4c3f0000000073e1a241c2049bc0cdcc4c3ea9485a4074821abf000000005a1d4c3f0000003f73e1a24151d39ac0cdcc4c3e07c6594074821a3f000000005a1d4cbf0000003f73e1a24151d39ac00ad723bc07c6594074821a3f000000005a1d4cbf0000803f73e1a241ce1095c00ad723bc544f6340d7cc1abf00000000f6e44b3f00000000aed1a341ce1095c0cdcc4c3e544f6340d7cc1abf00000000f6e44b3f0000003faed1a34144df94c0cdcc4c3ed6cc6240d7cc1a3f00000000f6e44bbf0000003faed1a34144df94c00ad723bcd6cc6240d7cc1a3f00000000f6e44bbf0000803faed1a341c1d78ec00ad723bcc7c56c40e6141bbf000000002cae4b3f00000000facca441c1d78ec0cdcc4c3ec7c56c40e6141bbf000000002cae4b3f0000003ffacca44121a68ec0cdcc4c3e6c436c40e6141b3f000000002cae4bbf0000003ffacca44121a68ec00ad723bc6c436c40e6141b3f000000002cae4bbf0000803ffacca441c26288c00ad723bc8c9e7640165c1bbf00000000e4774b3f00000000f3d1a541c26288c0cdcc4c3e8c9e7640165c1bbf00000000e4774b3f0000003ff3d1a5410b3188c0cdcc4c3e541c7640165c1b3f00000000e4774bbf0000003ff3d1a5410b3188c00ad723bc541c7640165c1b3f00000000e4774bbf0000803ff3d1a541ebba81c00ad723bc1c6680408fa31bbf000000003f414b3f0000000032dfa641ebba81c0cdcc4c3e1c6680408fa31bbf000000003f414b3f0000003f32dfa6411d8981c0cdcc4c3e112580408fa31b3f000000003f414bbf0000003f32dfa6411d8981c00ad723bc112580408fa31b3f000000003f414bbf0000803f32dfa641aed275c00ad723bcb0a085405aec1bbf000000006c094b3f0000000052f3a741aed275c0cdcc4c3eb0a085405aec1bbf000000006c094b3f0000003f52f3a741e36e75c0cdcc4c3eb75f85405aec1b3f000000006c094bbf0000003f52f3a741e36e75c00ad723bcb75f85405aec1b3f000000006c094bbf0000803f52f3a7413dee67c00ad723bc52f88a4072371cbf00000000aacf4a3f00000000f00ca9413dee67c0cdcc4c3e52f88a4072371cbf00000000aacf4a3f0000003ff00ca941438a67c0cdcc4c3e6cb78a4072371c3f00000000aacf4abf0000003ff00ca941438a67c00ad723bc6cb78a4072371c3f00000000aacf4abf0000803ff00ca941b2da59c00ad723bc4f669040ce851cbf0000000037934a3f00000000a42aaa41b2da59c0cdcc4c3e4f669040ce851cbf0000000037934a3f0000003fa42aaa41857659c0cdcc4c3e7c259040ce851c3f0000000037934abf0000003fa42aaa41857659c00ad723bc7c259040ce851c3f0000000037934abf0000803fa42aaa4136aa4bc00ad723bcf3e395406ad81cbf0000000048534a3f000000000b4bab4136aa4bc0cdcc4c3ef3e395406ad81cbf0000000048534a3f0000003f0b4bab41d5454bc0cdcc4c3e34a395406ad81c3f0000000048534abf0000003f0b4bab41d5454bc00ad723bc34a395406ad81c3f0000000048534abf0000803f0b4bab41066f3dc00ad723bc856a9b4064301dbf00000000f50e4a3f00000000bf6cac41066f3dc0cdcc4c3e856a9b4064301dbf00000000f50e4a3f0000003fbf6cac416c0a3dc0cdcc4c3edc299b4064301d3f00000000f50e4abf0000003fbf6cac416c0a3dc00ad723bcdc299b4064301d3f00000000f50e4abf0000803fbf6cac415c3b2fc00ad723bc51f3a040ea8e1dbf0000000049c5493f000000005b8ead415c3b2fc0cdcc4c3e51f3a040ea8e1dbf0000000049c5493f0000003f5b8ead4186d62ec0cdcc4c3ec0b2a040ea8e1d3f0000000049c549bf0000003f5b8ead4186d62ec00ad723bcc0b2a040ea8e1d3f0000000049c549bf0000803f5b8ead417c2121c00ad723bc9877a6406cf51dbf000000001375493f000000007aaeae417c2121c0cdcc4c3e9877a6406cf51dbf000000001375493f0000003f7aaeae4164bc20c0cdcc4c3e2137a6406cf51d3f00000000137549bf0000003f7aaeae4164bc20c00ad723bc2137a6406cf51d3f00000000137549bf0000803f7aaeae41ba3313c00ad723bc97f0ab408c651ebf00000000f71c493f00000000b8cbaf41ba3313c0cdcc4c3e97f0ab408c651ebf00000000f71c493f0000003fb8cbaf415ace12c0cdcc4c3e3cb0ab408c651e3f00000000f71c49bf0000003fb8cbaf415ace12c00ad723bc3cb0ab408c651e3f00000000f71c49bf0000803fb8cbaf417a8405c00ad723bc8557b1404de11ebf0000000042bb483f00000000aee4b0417a8405c0cdcc4c3e8557b1404de11ebf0000000042bb483f0000003faee4b041cc1e05c0cdcc4c3e4917b1404de11e3f0000000042bb48bf0000003faee4b041cc1e05c00ad723bc4917b1404de11e3f0000000042bb48bf0000803faee4b041764cf0bf0ad723bc8aa5b6402a6b1fbf00000000d64d483f00000000f9f7b141764cf0bfcdcc4c3e8aa5b6402a6b1fbf00000000d64d483f0000003ff9f7b1416880efbfcdcc4c3e7165b6402a6b1f3f00000000d64d48bf0000003ff9f7b1416880efbf0ad723bc7165b6402a6b1f3f00000000d64d48bf0000803ff9f7b1413457d6bf0ad723bcc1d3bb403f0620bf0000000006d2473f000000003404b3413457d6bfcdcc4c3ec1d3bb403f0620bf0000000006d2473f0000003f3404b341608ad5bfcdcc4c3ed093bb403f06203f0000000006d247bf0000003f3404b341608ad5bf0ad723bcd093bb403f06203f0000000006d247bf0000803f3404b341c74ebdbf0ad723bc34dbc0408cb620bf000000005644473f00000000fb07b441c74ebdbfcdcc4c3e34dbc0408cb620bf000000005644473f0000003ffb07b4411081bcbfcdcc4c3e709bc0408cb6203f00000000564447bf0000003ffb07b4411081bcbf0ad723bc709bc0408cb6203f00000000564447bf0000803ffb07b4414a59a5bf0ad723bcc9b4c5404f8121bf0000000023a0463f00000000e801b5414a59a5bfcdcc4c3ec9b4c5404f8121bf0000000023a0463f0000003fe801b541908aa4bfcdcc4c3e3975c5404f81213f0000000023a046bf0000003fe801b541908aa4bf0ad723bc3975c5404f81213f0000000023a046bf0000803fe801b5418a9d8ebf0ad723bc3d59ca408a6d22bf0000000023df453f0000000099f0b5418a9d8ebfcdcc4c3e3d59ca408a6d22bf0000000023df453f0000003f99f0b541a2cd8dbfcdcc4c3eec19ca408a6d223f0000000023df45bf0000003f99f0b541a2cd8dbf0ad723bcec19ca408a6d223f0000000023df45bf0000803f99f0b541c88672bf0ad723bc13c1ce40d18423bf0000000097f8443f00000000a9d2b641c88672bfcdcc4c3e13c1ce40d18423bf0000000097f8443f0000003fa9d2b6412ce470bfcdcc4c3e0c82ce40d184233f0000000097f844bf0000003fa9d2b6412ce470bf0ad723bc0c82ce40d184233f0000000097f844bf0000803fa9d2b641a8e84abf0ad723bc60e4d240c0d424bf00000000cfdf433f00000000b6a6b741a8e84abfcdcc4c3e60e4d240c0d424bf00000000cfdf433f0000003fb6a6b741b14249bfcdcc4c3eb2a5d240c0d4243f00000000cfdf43bf0000003fb6a6b741b14249bf0ad723bcb2a5d240c0d4243f00000000cfdf43bf0000803fb6a6b741b0b826bf0ad723bc9abad640207126bf00000000e081423f000000005d6bb841b0b826bfcdcc4c3e9abad640207126bf00000000e081423f0000003f5d6bb841980e25bfcdcc4c3e5c7cd6402071263f00000000e08142bf0000003f5d6bb841980e25bf0ad723bc5c7cd6402071263f00000000e08142bf0000803f5d6bb841395706bf0ad723bc223ada40117828bf0000000015c1403f000000003e1fb941395706bfcdcc4c3e223ada40117828bf0000000015c1403f0000003f3e1fb941f1a704bfcdcc4c3e73fcd9401178283f0000000015c140bf0000003f3e1fb941f1a704bf0ad723bc73fcd9401178283f0000000015c140bf0000803f3e1fb9412a66d4be0ad723bc5c57dd4092192bbf000000003b6c3e3f00000000f8c0b9412a66d4becdcc4c3e5c57dd4092192bbf000000003b6c3e3f0000003ff8c0b94122fad0becdcc4c3e6d1add4092192b3f000000003b6c3ebf0000003ff8c0b94122fad0be0ad723bc6d1add4092192b3f000000003b6c3ebf0000803ff8c0b94182aca5be0ad723bcc302e04024a72ebf000000005c2b3b3f00000000304fba4182aca5becdcc4c3ec302e04024a72ebf000000005c2b3b3f0000003f304fba41482ea2becdcc4c3edec6df4024a72e3f000000005c2b3bbf0000003f304fba41482ea2be0ad723bcdec6df4024a72e3f000000005c2b3bbf0000803f304fba41980382be0ad723bc2b24e2403ab633bf000000004651363f0000000090c8ba41980382becdcc4c3e2b24e2403ab633bf000000004651363f0000003f90c8ba41f0d67cbecdcc4c3ed4e9e1403ab6333f00000000465136bf0000003f90c8ba41f0d67cbe0ad723bcd4e9e1403ab6333f00000000465136bf0000803f90c8ba41
+    _typelessdata: 367bdcc00ad723bce463f9bff4eca43e00000000d95a72bf000000005ad1fe40367bdcc0cdcc4c3ee463f9bff4eca43e00000000d95a72bf0000003f5ad1fe409a95dcc0cdcc4c3eae2df8bff4eca4be00000000d95a723f0000003f5ad1fe409a95dcc00ad723bcae2df8bff4eca4be00000000d95a723f0000803f5ad1fe40b0e4e3c00ad723bc792a01c0acd2813e0000000044a277bf0000000062e10041b0e4e3c0cdcc4c3e792a01c0acd2813e0000000044a277bf0000003f62e1004175f9e3c0cdcc4c3efc8b00c0acd281be0000000044a2773f0000003f62e1004175f9e3c00ad723bcfc8b00c0acd281be0000000044a2773f0000803f62e100411250ebc00ad723bcdb7104c0105d343e0000000067ff7bbf000000002b4402411250ebc0cdcc4c3edb7104c0105d343e0000000067ff7bbf0000003f2b4402417f5eebc0cdcc4c3e94d003c0105d34be0000000067ff7b3f0000003f2b4402417f5eebc00ad723bc94d003c0105d34be0000000067ff7b3f0000803f2b4402417ebef2c00ad723bc8a7306c060cdb73d0000000089f77ebf000000007f9303417ebef2c0cdcc4c3e8a7306c060cdb73d0000000089f77ebf0000003f7f930341d8c5f2c0cdcc4c3e5dd005c060cdb7bd0000000089f77e3f0000003f7f930341d8c5f2c00ad723bc5dd005c060cdb7bd0000000089f77e3f0000803f7f930341712cfac00ad723bc9a1707c000bfa3bb000000002fff7fbf000000001dd20441712cfac0cdcc4c3e9a1707c000bfa3bb000000002fff7fbf0000003f1dd20441082cfac0cdcc4c3ec37306c000bfa33b000000002fff7f3f0000003f1dd20441082cfac00ad723bcc37306c000bfa33b000000002fff7f3f0000803f1dd2044108c800c10ad723bc184606c00834dabd00000000f88a7ebf000000000603064108c800c1cdcc4c3e184606c00834dabd00000000f88a7ebf0000003f06030641abc300c1cdcc4c3e30a305c00834da3d00000000f88a7e3f0000003f06030641abc300c10ad723bc30a305c00834da3d00000000f88a7e3f0000803f060306415a6c04c10ad723bc82ec03c0b06559be000000000d2a7abf000000007e2907415a6c04c1cdcc4c3e82ec03c0b06559be000000000d2a7abf0000003f7e290741a86304c1cdcc4c3e664c03c0b065593e000000000d2a7a3f0000003f7e290741a86304c10ad723bc664c03c0b065593e000000000d2a7a3f0000803f7e290741e6f707c10ad723bcc80300c0f439a3be000000006fa472bf00000000ec480841e6f707c1cdcc4c3ec80300c0f439a3be000000006fa472bf0000003fec480841d7ea07c1cdcc4c3efad0febff439a33e000000006fa4723f0000003fec480841d7ea07c10ad723bcfad0febff439a33e000000006fa4723f0000803fec480841125e0bc10ad723bc012af5bfd025d8be00000000ad1168bf00000000cf640941125e0bc1cdcc4c3e012af5bfd025d8be00000000ad1168bf0000003fcf640941c74c0bc1cdcc4c3ef500f4bfd025d83e00000000ad11683f0000003fcf640941c74c0bc10ad723bcf500f4bfd025d83e00000000ad11683f0000803fcf6409410b930ec10ad723bc0f74e7bf2ccd04bf0000000034dc5abf0000000093800a410b930ec1cdcc4c3e0f74e7bf2ccd04bf0000000034dc5abf0000003f93800a41cc7d0ec1cdcc4c3eeb5be6bf2ccd043f0000000034dc5a3f0000003f93800a41cc7d0ec10ad723bceb5be6bf2ccd043f0000000034dc5a3f0000803f93800a41e08d11c10ad723bced32d7bfee151bbf0000000063ad4bbf000000007c9f0b41e08d11c1cdcc4c3eed32d7bfee151bbf0000000063ad4bbf0000003f7c9f0b41107511c1cdcc4c3e382ed6bfee151b3f0000000063ad4b3f0000003f7c9f0b41107511c10ad723bc382ed6bfee151b3f0000000063ad4b3f0000803f7c9f0b41914914c10ad723bc2cbfc4bfa2852ebf000000009a4a3bbf0000000086c40c41914914c1cdcc4c3e2cbfc4bfa2852ebf000000009a4a3bbf0000003f86c40c41a52d14c1cdcc4c3e70cfc3bfa2852e3f000000009a4a3b3f0000003f86c40c41a52d14c10ad723bc70cfc3bfa2852e3f000000009a4a3b3f0000803f86c40c4113c516c10ad723bc2a6eb0bfcc023fbf000000006b712abf0000000055f20d4113c516c1cdcc4c3e2a6eb0bfcc023fbf000000006b712abf0000003f55f20d4184a616c1cdcc4c3efe93afbfcc023f3f000000006b712a3f0000003f55f20d4184a616c10ad723bcfe93afbfcc023f3f000000006b712a3f0000803f55f20d416e0219c10ad723bc2a889abfbcb04cbf00000000ffbe19bf000000002b2b0f416e0219c1cdcc4c3e2a889abfbcb04cbf00000000ffbe19bf0000003f2b2b0f41aee118c1cdcc4c3e5ec399bfbcb04c3f00000000ffbe193f0000003f2b2b0f41aee118c10ad723bc5ec399bfbcb04c3f00000000ffbe193f0000803f2b2b0f4196051bc10ad723bc124483bf7ad857bf000000009ca509bf00000000ee70104196051bc1cdcc4c3e124483bf7ad857bf000000009ca509bf0000003fee7010410de31ac1cdcc4c3ee29382bf7ad8573f000000009ca5093f0000003fee7010410de31ac10ad723bce29382bf7ad8573f000000009ca5093f0000803fee70104154d31cc10ad723bcd68f55bfa7d360bf00000000c7dbf4be0000000028c5114154d31cc1cdcc4c3ed68f55bfa7d360bf00000000c7dbf4be0000003f28c511415baf1cc1cdcc4c3e6c5654bfa7d3603f00000000c7dbf43e0000003f28c511415baf1cc10ad723bc6c5654bfa7d3603f00000000c7dbf43e0000803f28c5114183701ec10ad723bcca5722bf70fd67bf00000000a57cd8be000000001029134183701ec1cdcc4c3eca5722bf70fd67bf00000000a57cd8be0000003f10291341654b1ec1cdcc4c3eb04221bf70fd673f00000000a57cd83e0000003f10291341654b1ec10ad723bcb04221bf70fd673f00000000a57cd83e0000803f10291341a5e11fc10ad723bc23f8d9beeaa96dbf000000009748bebe000000009b9d1441a5e11fc1cdcc4c3e23f8d9beeaa96dbf000000009748bebe0000003f9b9d14419ebb1fc1cdcc4c3e0311d8beeaa96d3f000000009748be3e0000003f9b9d14419ebb1fc10ad723bc0311d8beeaa96d3f000000009748be3e0000803f9b9d1441ae2a21c10ad723bc2e2d56be142272bf000000003039a6be000000007f231641ae2a21c1cdcc4c3e2e2d56be142272bf000000003039a6be0000003f7f231641f00321c1cdcc4c3e1eda52be1422723f000000003039a63e0000003f7f231641f00321c10ad723bc1eda52be1422723f000000003039a63e0000803f7f231641f14e22c10ad723bc60047d3c00a375bf00000000df3390be0000000042bb1741f14e22c1cdcc4c3e60047d3c00a375bf00000000df3390be0000003f42bb1741a32722c1cdcc4c3eb894953c00a3753f00000000df33903e0000003f42bb1741a32722c10ad723bcb894953c00a3753f00000000df33903e0000803f42bb1741355123c10ad723bc66ff7d3e895e78bf00000000d82678be000000003f651941355123c1cdcc4c3e66ff7d3e895e78bf00000000d82678be0000003f3f651941772923c1cdcc4c3e553d803e895e783f00000000d826783e0000003f3f651941772923c10ad723bc553d803e895e783f00000000d826783e0000803f3f651941c33324c10ad723bc8a2ffa3ec67c7abf00000000285c53be00000000af211b41c33324c1cdcc4c3e8a2ffa3ec67c7abf00000000285c53be0000003faf211b41af0b24c1cdcc4c3e143efb3ec67c7a3f00000000285c533e0000003faf211b41af0b24c10ad723bc143efb3ec67c7a3f00000000285c533e0000803faf211b4176f824c10ad723bcb0bb3c3fab1d7cbf0000000028b331be00000000aef01c4176f824c1cdcc4c3eb0bb3c3fab1d7cbf0000000028b331be0000003faef01c411fd024c1cdcc4c3e6b2d3d3fab1d7c3f0000000028b3313e0000003faef01c411fd024c10ad723bc6b2d3d3fab1d7c3f0000000028b3313e0000803faef01c41d5a025c10ad723bce16a7e3f905a7dbf0000000081da12be000000003ed21e41d5a025c1cdcc4c3ee16a7e3f905a7dbf0000000081da12be0000003f3ed21e414c7825c1cdcc4c3eddc87e3f905a7d3f0000000081da123e0000003f3ed21e414c7825c10ad723bcddc87e3f905a7d3f0000000081da123e0000803f3ed21e41282e26c10ad723bcbc11a13f84477ebf00000000b10cedbd0000000052c62041282e26c1cdcc4c3ebc11a13f84477ebf00000000b10cedbd0000003f52c62041790526c1cdcc4c3eaa37a13f84477e3f00000000b10ced3d0000003f52c62041790526c10ad723bcaa37a13f84477e3f00000000b10ced3d0000803f52c6204178a126c10ad723bc12f1c33f63f47ebf000000001de4b8bd00000000c6cc224178a126c1cdcc4c3e12f1c33f63f47ebf000000001de4b8bd0000003fc6cc2241ad7826c1cdcc4c3ea70ec43f63f47e3f000000001de4b83d0000003fc6cc2241ad7826c10ad723bca70ec43f63f47e3f000000001de4b83d0000803fc6cc2241a8fb26c10ad723bc25d1e73fc06d7fbf0000000075be88bd000000006de52441a8fb26c1cdcc4c3e25d1e73fc06d7fbf0000000075be88bd0000003f6de52441cad226c1cdcc4c3e06e7e73fc06d7f3f0000000075be883d0000003f6de52441cad226c10ad723bc06e7e73fc06d7f3f0000000075be883d0000803f6de524417b3d27c10ad723bc7657064096bd7fbf000000005d5b38bd000000000d1027417b3d27c1cdcc4c3e7657064096bd7fbf000000005d5b38bd0000003f0d102741901427c1cdcc4c3ed65e064096bd7f3f000000005d5b383d0000003f0d102741901427c10ad723bcd65e064096bd7f3f000000005d5b383d0000803f0d102741946727c10ad723bc66431940d4eb7fbf00000000fa3bcbbc00000000614c2941946727c1cdcc4c3e66431940d4eb7fbf00000000fa3bcbbc0000003f614c2941a23e27c1cdcc4c3e76471940d4eb7f3f00000000fa3bcb3c0000003f614c2941a23e27c10ad723bc76471940d4eb7f3f00000000fa3bcb3c0000803f614c2941877a27c10ad723bc42aa2c40d2fe7fbf00000000aebfc4bb000000001c9a2b41877a27c1cdcc4c3e42aa2c40d2fe7fbf00000000aebfc4bb0000003f1c9a2b41925127c1cdcc4c3e3eab2c40d2fe7f3f00000000aebfc43b0000003f1c9a2b41925127c10ad723bc3eab2c40d2fe7f3f00000000aebfc43b0000803f1c9a2b41d57627c10ad723bca4894040a1fb7fbf000000008c443d3c00000000eaf82d41d57627c1cdcc4c3ea4894040a1fb7fbf000000008c443d3c0000003feaf82d41e04d27c1cdcc4c3ebf874040a1fb7f3f000000008c443dbc0000003feaf82d41e04d27c10ad723bcbf874040a1fb7f3f000000008c443dbc0000803feaf82d41
   m_CompressedMesh:
     m_Vertices:
       m_NumItems: 0
@@ -10641,8 +1738,8 @@ Mesh:
       m_BitSize: 0
     m_UVInfo: 0
   m_LocalAABB:
-    m_Center: {x: -2.9276567, y: 0.095, z: 4.9479437}
-    m_Extent: {x: 2.6807432, y: 0.105000004, z: 2.118971}
+    m_Center: {x: -8.678727, y: 0.095, z: 0.4487927}
+    m_Extent: {x: 1.7886868, y: 0.105000004, z: 2.5596082}
   m_MeshUsageFlags: 0
   m_BakedConvexCollisionMesh: 
   m_BakedTriangleCollisionMesh: 
@@ -10653,217 +1750,7 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1 &2074913391
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2074913392}
-  - component: {fileID: 2074913396}
-  - component: {fileID: 2074913395}
-  - component: {fileID: 2074913394}
-  - component: {fileID: 2074913393}
-  m_Layer: 0
-  m_Name: segment 2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2074913392
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2074913391}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1272024235}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &2074913393
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2074913391}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 2137921210}
---- !u!114 &2074913394
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2074913391}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &2074913395
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2074913391}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &2074913396
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2074913391}
-  m_Mesh: {fileID: 2137921210}
---- !u!1 &2079892564
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2079892565}
-  - component: {fileID: 2079892569}
-  - component: {fileID: 2079892568}
-  - component: {fileID: 2079892567}
-  - component: {fileID: 2079892566}
-  m_Layer: 0
-  m_Name: segment 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2079892565
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2079892564}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1272024235}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &2079892566
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2079892564}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 663229291}
---- !u!114 &2079892567
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2079892564}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &2079892568
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2079892564}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &2079892569
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2079892564}
-  m_Mesh: {fileID: 663229291}
---- !u!43 &2096413040
+--- !u!43 &661021024
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -10880,8 +1767,8 @@ Mesh:
     firstVertex: 0
     vertexCount: 124
     localAABB:
-      m_Center: {x: 0.391029, y: 0.095, z: 7.457205}
-      m_Extent: {x: 1.0821339, y: 0.105000004, z: 1.5440176}
+      m_Center: {x: -1.428297, y: 0.095, z: 9.055265}
+      m_Extent: {x: 1.0324535, y: 0.105000004, z: 1.71176}
   m_Shapes:
     vertices: []
     shapes: []
@@ -10960,7 +1847,7 @@ Mesh:
       format: 0
       dimension: 0
     m_DataSize: 3968
-    _typelessdata: 3c54603f0ad723bc2c73bd403ab633bf000000004651363f0000000090c8ba413c54603fcdcc4c3e2c73bd403ab633bf000000004651363f0000003f90c8ba414c20623fcdcc4c3ed538bd403ab6333f00000000465136bf0000003f90c8ba414c20623f0ad723bcd538bd403ab6333f00000000465136bf0000803f90c8ba4113867d3f0ad723bc3d54c1405c0c41bf00000000ca21283f00000000b034bb4113867d3fcdcc4c3e3d54c1405c0c41bf00000000ca21283f0000003fb034bb4147747f3fcdcc4c3e701ec1405c0c413f00000000ca2128bf0000003fb034bb4147747f3f0ad723bc701ec1405c0c413f00000000ca2128bf0000803fb034bb41faef8b3f0ad723bc6c6cc540eeaa4dbf00000000ad6f183f00000000669cbb41faef8b3fcdcc4c3e6c6cc540eeaa4dbf00000000ad6f183f0000003f669cbb413bf78c3fcdcc4c3ea43bc540eeaa4d3f00000000ad6f18bf0000003f669cbb413bf78c3f0ad723bca43bc540eeaa4d3f00000000ad6f18bf0000803f669cbb41d69e973f0ad723bc08b7c940fa5359bf00000000514b073f000000002c00bc41d69e973fcdcc4c3e08b7c940fa5359bf00000000514b073f0000003f2c00bc4104b5983fcdcc4c3ebd8bc940fa53593f00000000514b07bf0000003f2c00bc4104b5983f0ad723bcbd8bc940fa53593f00000000514b07bf0000803f2c00bc4126bea13f0ad723bc3d2ece4024cb63bf0000000018a2e93e000000007860bc4126bea13fcdcc4c3e3d2ece4024cb63bf0000000018a2e93e0000003f7860bc41bae1a23fcdcc4c3edb08ce4024cb633f0000000018a2e9be0000003f7860bc41bae1a23f0ad723bcdb08ce4024cb633f0000000018a2e9be0000803f7860bc41523eaa3f0ad723bc03cbd240bad86cbf00000000f150c23e00000000b8bdbc41523eaa3fcdcc4c3e03cbd240bad86cbf00000000f150c23e0000003fb8bdbc417c6dab3fcdcc4c3eecabd240bad86c3f00000000f150c2be0000003fb8bdbc417c6dab3f0ad723bcecabd240bad86c3f00000000f150c2be0000803fb8bdbc41d512b13f0ad723bc7e85d740b64c74bf00000000cc04993e000000005918bd41d512b13fcdcc4c3e7e85d740b64c74bf00000000cc04993e0000003f5918bd41894bb23fcdcc4c3e036dd740b64c743f00000000cc0499be0000003f5918bd41894bb23f0ad723bc036dd740b64c743f00000000cc0499be0000803f5918bd41ff32b63f0ad723bc0d55dc40af007abf00000000e2595c3e00000000b970bd41ff32b63fcdcc4c3e0d55dc40af007abf00000000e2595c3e0000003fb970bd410073b73fcdcc4c3e6c43dc40af007a3f00000000e2595cbe0000003fb970bd410073b73f0ad723bc6c43dc40af007a3f00000000e2595cbe0000803fb970bd41789ab93f0ad723bcc530e14011d97dbf00000000857f043e0000000034c7bd41789ab93fcdcc4c3ec530e14011d97dbf00000000857f043e0000003f34c7bd4166dfba3fcdcc4c3e2c26e14011d97d3f00000000857f04be0000003f34c7bd4166dfba3f0ad723bc2c26e14011d97d3f00000000857f04be0000803f34c7bd413849bb3f0ad723bca20fe64015c57fbf00000000bba52d3d000000001b1cbe413849bb3fcdcc4c3ea20fe64015c57fbf00000000bba52d3d0000003f1b1cbe419a90bc3fcdcc4c3e290ce64015c57f3f00000000bba52dbd0000003f1b1cbe419a90bc3f0ad723bc290ce64015c57f3f00000000bba52dbd0000803f1b1cbe412a43bb3f0ad723bcdce8ea40d1bd7fbf00000000260938bd00000000b96fbe412a43bb3fcdcc4c3edce8ea40d1bd7fbf00000000260938bd0000003fb96fbe41838abc3fcdcc4c3e8aecea40d1bd7f3f000000002609383d0000003fb96fbe41838abc3f0ad723bc8aecea40d1bd7f3f000000002609383d0000803fb96fbe41848fb93f0ad723bc19b4ef4094c47dbf00000000c6ed06be0000000051c2be41848fb93fcdcc4c3e19b4ef4094c47dbf00000000c6ed06be0000003f51c2be4157d4ba3fcdcc4c3ee5beef4094c47d3f00000000c6ed063e0000003f51c2be4157d4ba3f0ad723bce5beef4094c47d3f00000000c6ed063e0000803f51c2be41f637b63f0ad723bc7b69f440e3e079bf0000000007985ebe000000001d14bf41f637b63fcdcc4c3e7b69f440e3e079bf0000000007985ebe0000003f1d14bf41ce77b73fcdcc4c3e4a7bf440e3e0793f0000000007985e3e0000003f1d14bf41ce77b73f0ad723bc4a7bf440e3e0793f0000000007985e3e0000803f1d14bf41e447b13f0ad723bcaf01f940821e74bf00000000a42a9abe000000005465bf41e447b13fcdcc4c3eaf01f940821e74bf00000000a42a9abe0000003f5465bf415c80b23fcdcc4c3e5a1af940821e743f00000000a42a9a3e0000003f5465bf415c80b23f0ad723bc5a1af940821e743f00000000a42a9a3e0000803f5465bf41b8cbaa3f0ad723bcdf75fd40c88b6cbf0000000070c6c3be0000000027b6bf41b8cbaa3fcdcc4c3edf75fd40c88b6cbf0000000070c6c3be0000003f27b6bf4180faab3fcdcc4c3e3295fd40c88b6c3f0000000070c6c33e0000003f27b6bf4180faab3f0ad723bc3295fd40c88b6c3f0000000070c6c33e0000803f27b6bf4173d0a23f0ad723bccbdf00417b3863bf00000000a6daebbe00000000c506c04173d0a23fcdcc4c3ecbdf00417b3863bf00000000a6daebbe0000003fc506c0414af3a33fcdcc4c3ea9f200417b38633f00000000a6daeb3e0000003fc506c0414af3a33f0ad723bca9f200417b38633f00000000a6daeb3e0000803fc506c0416f63993f0ad723bc4bec02414e3558bf000000009e1309bf000000005757c0416f63993fcdcc4c3e4bec02414e3558bf000000009e1309bf0000003f5757c0412e789a3fcdcc4c3e390203414e35583f000000009e13093f0000003f5757c0412e789a3f0ad723bc390203414e35583f000000009e13093f0000803f5757c04177928e3f0ad723bc61dd044104944bbf000000003a371bbf000000000aa8c04177928e3fcdcc4c3e61dd044104944bbf000000003a371bbf0000003f0aa8c0410c978f3fcdcc4c3e37f6044104944b3f000000003a371b3f0000003f0aa8c0410c978f3f0ad723bc37f6044104944b3f000000003a371b3f0000803f0aa8c041066c823f0ad723bc01b006411c683dbf0000000059392cbf000000000bf9c041066c823fcdcc4c3e01b006411c683dbf0000000059392cbf0000003f0bf9c041775e833fcdcc4c3e8fcb06411c683d3f0000000059392c3f0000003f0bf9c041775e833f0ad723bc8fcb06411c683d3f0000000059392c3f0000803f0bf9c0418aff693f0ad723bc1461084106c82dbf0000000095fa3bbf00000000874ac1418aff693fcdcc4c3e1461084106c82dbf0000000095fa3bbf0000003f874ac1416abc6b3fcdcc4c3e287f084106c82d3f0000000095fa3b3f0000003f874ac1416abc6b3f0ad723bc287f084106c82d3f0000000095fa3b3f0000803f874ac14138be4c3f0ad723bc7eed094192ce1cbf00000000e85a4abf00000000b19cc14138be4c3fcdcc4c3e7eed094192ce1cbf00000000e85a4abf0000003fb19cc141a54f4e3fcdcc4c3edf0d0a4192ce1c3f00000000e85a4a3f0000003fb19cc141a54f4e3f0ad723bcdf0d0a4192ce1c3f00000000e85a4a3f0000803fb19cc1417a3b2d3f0ad723bc24520b41489c0abf00000000663a57bf00000000c1efc1417a3b2d3fcdcc4c3e24520b41489c0abf00000000663a57bf0000003fc1efc141529e2e3fcdcc4c3e93740b41489c0a3f00000000663a573f0000003fc1efc141529e2e3f0ad723bc93740b41489c0a3f00000000663a573f0000803fc1efc14164a40b3f0ad723bcf68b0c4192b1eebe00000000667a62bf00000000f643c24164a40b3fcdcc4c3ef68b0c4192b1eebe00000000667a62bf0000003ff643c241ead50c3fcdcc4c3e33b00c4192b1ee3e00000000667a623f0000003ff643c241ead50c3f0ad723bc33b00c4192b1ee3e00000000667a623f0000803ff643c2415458d03e0ad723bc16980d41c666c6be0000000094ff6bbf000000009299c2415458d03ecdcc4c3e16980d41c666c6be0000000094ff6bbf0000003f9299c2413c54d23ecdcc4c3ed9bd0d41c666c63e0000000094ff6b3f0000003f9299c2413c54d23e0ad723bcd9bd0d41c666c63e0000000094ff6b3f0000803f9299c2419817863e0ad723bced730e4146c59cbe0000000048b473bf00000000e5f0c2419817863ecdcc4c3eed730e4146c59cbe0000000048b473bf0000003fe5f0c241eea8873ecdcc4c3eeb9a0e4146c59c3e0000000048b4733f0000003fe5f0c241eea8873e0ad723bceb9a0e4146c59c3e0000000048b4733f0000803fe5f0c2418c0de43d0ad723bc421d0f413c8f64be00000000aa8a79bf00000000414ac3418c0de43dcdcc4c3e421d0f413c8f64be00000000aa8a79bf0000003f414ac341c69fe83dcdcc4c3e2f450f413c8f643e00000000aa8a793f0000003f414ac341c69fe83d0ad723bc2f450f413c8f643e00000000aa8a793f0000803f414ac341ca0833bd0ad723bc65920f41d4e00ebe00000000ec7e7dbf0000000004a6c341ca0833bdcdcc4c3e65920f41d4e00ebe00000000ec7e7dbf0000003f04a6c341b8512dbdcdcc4c3ef4ba0f41d4e00e3e00000000ec7e7d3f0000003f04a6c341b8512dbd0ad723bcf4ba0f41d4e00e3e00000000ec7e7d3f0000803f04a6c341ce1f4fbe0ad723bc2ed20f41802d66bd0000000070987fbf000000009004c441ce1f4fbecdcc4c3e2ed20f41802d66bd0000000070987fbf0000003f9004c4417e8c4ebecdcc4c3e13fb0f41802d663d0000000070987f3f0000003f9004c4417e8c4ebe0ad723bc13fb0f41802d663d0000000070987f3f0000803f9004c4414306babe0ad723bc0fdc0f414068d33c000000002dea7fbf000000005366c4414306babecdcc4c3e0fdc0f414068d33c000000002dea7fbf0000003f5366c4411628babecdcc4c3e020510414068d3bc000000002dea7f3f0000003f5366c4411628babe0ad723bc020510414068d3bc000000002dea7f3f0000803f5366c44180a406bf0ad723bc00b00f41a02ed83d00000000dc917ebf00000000bccbc44180a406bfcdcc4c3e00b00f41a02ed83d00000000dc917ebf0000003fbccbc441aee906bfcdcc4c3ebbd80f41a02ed8bd00000000dc917e3f0000003fbccbc441aee906bf0ad723bcbbd80f41a02ed8bd00000000dc917e3f0000803fbccbc441ce7430bf0ad723bc6e4e0f4168a23a3e000000004cb67bbf000000004335c541ce7430bfcdcc4c3e6e4e0f4168a23a3e000000004cb67bbf0000003f4335c54140ec30bfcdcc4c3eb4760f4168a23abe000000004cb67b3f0000003f4335c54140ec30bf0ad723bcb4760f4168a23abe000000004cb67b3f0000803f4335c541
+    _typelessdata: fdabcabe0ad723bca7f4eb4068a23a3e000000004cb67bbf000000004335c541fdabcabecdcc4c3ea7f4eb4068a23a3e000000004cb67bbf0000003f4335c541e19acbbecdcc4c3e3445ec4068a23abe000000004cb67b3f0000003f4335c541e19acbbe0ad723bc3445ec4068a23abe000000004cb67b3f0000803f4335c5412f4a14bf0ad723bcbe2beb4090a5a73d000000000f247fbf00000000bc9ec5412f4a14bfcdcc4c3ebe2beb4090a5a73d000000000f247fbf0000003fbc9ec541d47f14bfcdcc4c3e637deb4090a5a7bd000000000f247f3f0000003fbc9ec541d47f14bf0ad723bc637deb4090a5a7bd000000000f247f3f0000803fbc9ec541480843bf0ad723bcfefdea40e001aebc0000000038f17fbf000000003d04c641480843bfcdcc4c3efefdea40e001aebc0000000038f17fbf0000003f3d04c6415dfa42bfcdcc4c3ee54feb40e001ae3c0000000038f17f3f0000003f3d04c6415dfa42bf0ad723bce54feb40e001ae3c0000000038f17f3f0000803f3d04c641c50871bf0ad723bcc669eb40a0c8ffbd00000000dbfe7dbf000000008866c641c50871bfcdcc4c3ec669eb40a0c8ffbd00000000dbfe7dbf0000003f8866c641ebb670bfcdcc4c3e0dbbeb40a0c8ff3d00000000dbfe7d3f0000003f8866c641ebb670bf0ad723bc0dbbeb40a0c8ff3d00000000dbfe7d3f0000803f8866c641cae28ebf0ad723bce569ec40306e68be000000006e5179bf000000004dc6c641cae28ebfcdcc4c3ee569ec40306e68be000000006e5179bf0000003f4dc6c6416a988ebfcdcc4c3eadb9ec40306e683e000000006e51793f0000003f4dc6c6416a988ebf0ad723bcadb9ec40306e683e000000006e51793f0000803f4dc6c6413262a4bf0ad723bcf7f5ed406cb6a6be000000008d0c72bf000000002424c7413262a4bfcdcc4c3ef7f5ed406cb6a6be000000008d0c72bf0000003f2424c7417ff7a3bfcdcc4c3e6c43ee406cb6a63e000000008d0c723f0000003f2424c7417ff7a3bf0ad723bc6c43ee406cb6a63e000000008d0c723f0000803f2424c7417acfb8bf0ad723bc6c03f04004a9d6be00000000fb6968bf000000008c80c7417acfb8bfcdcc4c3e6c03f04004a9d6be00000000fb6968bf0000003f8c80c7411846b8bfcdcc4c3ecc4df04004a9d63e00000000fb69683f0000003f8c80c7411846b8bf0ad723bccc4df04004a9d63e00000000fb69683f0000803f8c80c741c402ccbf0ad723bc7886f240bcbf01bf00000000faae5cbf00000000eedbc741c402ccbfcdcc4c3e7886f240bcbf01bf00000000faae5cbf0000003feedbc741b05ccbbfcdcc4c3e17cdf240bcbf013f00000000faae5c3f0000003feedbc741b05ccbbf0ad723bc17cdf240bcbf013f00000000faae5c3f0000803feedbc74159dfddbf0ad723bc4873f540b07016bf00000000d9214fbf000000009d36c84159dfddbfcdcc4c3e4873f540b07016bf00000000d9214fbf0000003f9d36c841c91eddbfcdcc4c3e90b5f540b070163f00000000d9214f3f0000003f9d36c841c91eddbf0ad723bc90b5f540b070163f00000000d9214f3f0000803f9d36c8418451eebf0ad723bc9cbef840775129bf000000003a0240bf00000000d590c8418451eebfcdcc4c3e9cbef840775129bf000000003a0240bf0000003fd590c841ca78edbfcdcc4c3e0efcf8407751293f000000003a02403f0000003fd590c841ca78edbf0ad723bc0efcf8407751293f000000003a02403f0000803fd590c841004cfdbf0ad723bc725efc40fb5b3abf0000000059842fbf00000000c2eac841004cfdbfcdcc4c3e725efc40fb5b3abf0000000059842fbf0000003fc2eac841765dfcbfcdcc4c3e9c96fc40fb5b3a3f0000000059842f3f0000003fc2eac841765dfcbf0ad723bc9c96fc40fb5b3a3f0000000059842f3f0000803fc2eac841966205c00ad723bc0d2500412f9349bf00000000ffce1dbf000000008444c941966205c0cdcc4c3e0d2500412f9349bf00000000ffce1dbf0000003f8444c94194e104c0cdcc4c3e4d3e00412f93493f00000000ffce1d3f0000003f8444c94194e104c00ad723bc4d3e00412f93493f00000000ffce1d3f0000803f8444c941355a0bc00ad723bc1a3d024180fc56bf0000000035fc0abf000000002d9ec941355a0bc0cdcc4c3e1a3d024180fc56bf0000000035fc0abf0000003f2d9ec9419ed00ac0cdcc4c3e5753024180fc563f0000000035fc0a3f0000003f2d9ec9419ed00ac00ad723bc5753024180fc563f0000000035fc0a3f0000803f2d9ec941068810c00ad723bc37740441c29a62bf000000009736eebe00000000cbf7c941068810c0cdcc4c3e37740441c29a62bf000000009736eebe0000003fcbf7c941fff60fc0cdcc4c3e45870441c29a623f000000009736ee3e0000003fcbf7c941fff60fc00ad723bc45870441c29a623f000000009736ee3e0000803fcbf7c941d9e514c00ad723bc9bc70641246a6cbf00000000b868c4be000000006951ca41d9e514c0cdcc4c3e9bc70641246a6cbf00000000b868c4be0000003f6951ca418b4e14c0cdcc4c3e51d70641246a6c3f00000000b868c43e0000003f6951ca418b4e14c00ad723bc51d70641246a6c3f00000000b868c43e0000803f6951ca41a06b18c00ad723bca6340941915d74bf00000000fa9898be0000000014abca41a06b18c0cdcc4c3ea6340941915d74bf00000000fa9898be0000003f14abca413bcf17c0cdcc4c3edb400941915d743f00000000fa98983e0000003f14abca413bcf17c00ad723bcdb400941915d743f00000000fa98983e0000803f14abca412a0f1bc00ad723bc99b80b416e5d7abf0000000017ab55be00000000de04cb412a0f1bc0cdcc4c3e99b80b416e5d7abf0000000017ab55be0000003fde04cb41ef6e1ac0cdcc4c3e25c10b416e5d7a3f0000000017ab553e0000003fde04cb41ef6e1ac00ad723bc25c10b416e5d7a3f0000000017ab553e0000803fde04cb4138c41cc00ad723bc57500e41f0477ebf00000000caefecbd00000000e35ecb4138c41cc0cdcc4c3e57500e41f0477ebf00000000caefecbd0000003fe35ecb417a211cc0cdcc4c3e14550e41f0477e3f00000000caefec3d0000003fe35ecb417a211cc00ad723bc14550e41f0477e3f00000000caefec3d0000803fe35ecb41f07c1dc00ad723bc11f8104174f37fbf00000000c547a0bc000000004cb9cb41f07c1dc0cdcc4c3e11f8104174f37fbf00000000c547a0bc0000003f4cb9cb4121d91cc0cdcc4c3edef8104174f37f3f00000000c547a03c0000003f4cb9cb4121d91cc00ad723bcdef8104174f37f3f00000000c547a03c0000803f4cb9cb41d82a1dc00ad723bc07ab13412a337fbf00000000ffcba13d000000005314cc41d82a1dc0cdcc4c3e07ab13412a337fbf00000000ffcba13d0000003f5314cc4184871cc0cdcc4c3ecba713412a337f3f00000000ffcba1bd0000003f5314cc4184871cc00ad723bccba713412a337f3f00000000ffcba1bd0000803f5314cc413ac01bc00ad723bc556316411ede7bbf00000000ef3e373e000000004470cc413ac01bc0cdcc4c3e556316411ede7bbf00000000ef3e373e0000003f4470cc41081f1bc0cdcc4c3e015c16411ede7b3f00000000ef3e37be0000003f4470cc41081f1bc00ad723bc015c16411ede7b3f00000000ef3e37be0000803f4470cc41023219c00ad723bce41919414cd875bf00000000c4c68e3e0000000085cdcc41023219c0cdcc4c3ee41919414cd875bf00000000c4c68e3e0000003f85cdcc41aa9418c0cdcc4c3e780e19414cd8753f00000000c4c68ebe0000003f85cdcc41aa9418c00ad723bc780e19414cd8753f00000000c4c68ebe0000803f85cdcc41ae7915c00ad723bc96c61b414c1c6dbf000000003b06c13e00000000912ccd41ae7915c0cdcc4c3e96c61b414c1c6dbf000000003b06c13e0000003f912ccd41eee114c0cdcc4c3e25b71b414c1c6d3f000000003b06c1be0000003f912ccd41eee114c00ad723bc25b71b414c1c6d3f000000003b06c1be0000803f912ccd41f69610c00ad723bcb2601e416fc361bf00000000fd62f13e00000000fc8dcd41f69610c0cdcc4c3eb2601e416fc361bf00000000fd62f13e0000003ffc8dcd41790610c0cdcc4c3e624d1e416fc3613f00000000fd62f1be0000003ffc8dcd41790610c00ad723bc624d1e416fc3613f00000000fd62f1be0000803ffc8dcd419d900ac00ad723bc80df2041cb0954bf000000004e710f3f0000000070f2cd419d900ac0cdcc4c3e80df2041cb0954bf000000004e710f3f0000003f70f2cd41e9080ac0cdcc4c3e8dc82041cb09543f000000004e710fbf0000003f70f2cd41e9080ac00ad723bc8dc82041cb09543f000000004e710fbf0000803f70f2cd41167403c00ad723bcff3a23418a4c44bf000000003553243f00000000af5ace41167403c0cdcc4c3eff3a23418a4c44bf000000003553243f0000003faf5ace4174f602c0cdcc4c3eb42023418a4c443f00000000355324bf0000003faf5ace4174f602c00ad723bcb42023418a4c443f00000000355324bf0000803faf5ace41cca7f6bf0ad723bc816c2541d40133bf000000006902373f0000000089c7ce41cca7f6bfcdcc4c3e816c2541d40133bf000000006902373f0000003f89c7ce41aac2f5bfcdcc4c3e394f2541d401333f00000000690237bf0000003f89c7ce41aac2f5bf0ad723bc394f2541d401333f00000000690237bf0000803f89c7ce415f8ae4bf0ad723bc176f2741c2ac20bf000000003a4c473f00000000dc39cf415f8ae4bfcdcc4c3e176f2741c2ac20bf000000003a4c473f0000003fdc39cf41b6bce3bfcdcc4c3e344f2741c2ac203f000000003a4c47bf0000003fdc39cf41b6bce3bf0ad723bc344f2741c2ac203f000000003a4c47bf0000803fdc39cf41f9b9d0bf0ad723bca03f2941eccf0dbf00000000d321553f0000000093b2cf41f9b9d0bfcdcc4c3ea03f2941eccf0dbf00000000d321553f0000003f93b2cf417404d0bfcdcc4c3e861d2941eccf0d3f00000000d32155bf0000003f93b2cf417404d0bf0ad723bc861d2941eccf0d3f00000000d32155bf0000803f93b2cf41d25bbbbf0ad723bc98dc2a41eac3f5be000000004b94603f000000009a32d041d25bbbbfcdcc4c3e98dc2a41eac3f5be000000004b94603f0000003f9a32d04188bebabfcdcc4c3ea9b82a41eac3f53e000000004b9460bf0000003f9a32d04188bebabf0ad723bca9b82a41eac3f53e000000004b9460bf0000803f9a32d041368da4bf0ad723bcbc452c418a8bd0be000000003dcd693f00000000e1bad041368da4bfcdcc4c3ebc452c418a8bd0be000000003dcd693f0000003fe1bad041be07a4bfcdcc4c3e53202c418a8bd03e000000003dcd69bf0000003fe1bad041be07a4bf0ad723bc53202c418a8bd03e000000003dcd69bf0000803fe1bad041
   m_CompressedMesh:
     m_Vertices:
       m_NumItems: 0
@@ -11014,8 +1901,8 @@ Mesh:
       m_BitSize: 0
     m_UVInfo: 0
   m_LocalAABB:
-    m_Center: {x: 0.391029, y: 0.095, z: 7.457205}
-    m_Extent: {x: 1.0821339, y: 0.105000004, z: 1.5440176}
+    m_Center: {x: -1.428297, y: 0.095, z: 9.055265}
+    m_Extent: {x: 1.0324535, y: 0.105000004, z: 1.71176}
   m_MeshUsageFlags: 0
   m_BakedConvexCollisionMesh: 
   m_BakedTriangleCollisionMesh: 
@@ -11026,84 +1913,170 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1 &2103067470
-GameObject:
+--- !u!43 &676533774
+Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2103067471}
-  - component: {fileID: 2103067473}
-  - component: {fileID: 2103067472}
-  m_Layer: 0
-  m_Name: Tire
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2103067471
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2103067470}
-  m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.07000003, y: 0.020000014, z: 0.07000003}
-  m_Children: []
-  m_Father: {fileID: 501547373}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
---- !u!23 &2103067472
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2103067470}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: c05de7c865075334786e6a47a543af72, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &2103067473
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2103067470}
-  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
---- !u!43 &2137921210
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 360
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 93
+    localAABB:
+      m_Center: {x: -8.678727, y: 0, z: 0.4487927}
+      m_Extent: {x: 1.7886868, y: 0, z: 2.5596082}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000030003000400010002000100040004000500020004000300060006000700040005000400070007000800050007000600090009000a000700080007000a000a000b0008000a0009000c000c000d000a000b000a000d000d000e000b000d000c000f000f0010000d000e000d001000100011000e0010000f00120012001300100011001000130013001400110013001200150015001600130014001300160016001700140016001500180018001900160017001600190019001a001700190018001b001b001c0019001a0019001c001c001d001a001c001b001e001e001f001c001d001c001f001f0020001d001f001e002100210022001f0020001f002200220023002000220021002400240025002200230022002500250026002300250024002700270028002500260025002800280029002600280027002a002a002b002800290028002b002b002c0029002b002a002d002d002e002b002c002b002e002e002f002c002e002d003000300031002e002f002e003100310032002f0031003000330033003400310032003100340034003500320034003300360036003700340035003400370037003800350037003600390039003a003700380037003a003a003b0038003a0039003c003c003d003a003b003a003d003d003e003b003d003c003f003f0040003d003e003d004000400041003e0040003f00420042004300400041004000430043004400410043004200450045004600430044004300460046004700440046004500480048004900460047004600490049004a004700490048004b004b004c0049004a0049004c004c004d004a004c004b004e004e004f004c004d004c004f004f0050004d004f004e005100510052004f0050004f005200520053005000520051005400540055005200530052005500550056005300550054005700570058005500560055005800580059005600580057005a005a005b005800590058005b005b005c005900
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 93
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 2976
+    _typelessdata: 367bdcc000000000e463f9bf000000800000803f00000000000000005ad1fe40a6d4e4c0000000008a3c97bf000000800000803f000000000000003f5ad1fe40162eedc000000000be54d4be000000800000803f000000000000803f5ad1fe40b0e4e3c000000000792a01c0000000800000803f000000000000000062e100413177eac000000000440a9ebf000000800000803f000000000000003f62e10041b209f1c0000000005afee6be000000800000803f000000000000803f62e100411250ebc000000000db7104c0000000800000803f00000000000000002b440241d3e0efc00000000098d4a2bf000000800000803f000000000000003f2b4402419471f4c000000000e815f3be000000800000803f000000000000803f2b4402417ebef2c0000000008a7306c0000000800000803f00000000000000007f9303410312f5c0000000001ca4a5bf000000800000803f000000000000003f7f9303418865f7c0000000008c84f9be000000800000803f000000000000803f7f930341712cfac0000000009a1707c0000000000000803f00000000000000001dd20441480bfac0000000007381a6bf000000000000803f000000000000003f1dd204411feaf9c000000000cc4efbbe000000000000803f000000000000803f1dd2044108c800c100000000184606c0000000000000803f00000000000000000603064116cdfec0000000003075a5bf000000000000803f000000000000003f060306411c0afcc000000000be78f9be000000000000803f000000000000803f060306415a6c04c10000000082ec03c0000000000000803f00000000000000007e290741fcab01c100000000fb87a2bf000000000000803f000000000000003f7e2907413cd7fdc000000000ccdbf4be000000000000803f000000000000803f7e290741e6f707c100000000c80300c0000000000000803f0000000000000000ec48084131d603c10000000067c29dbf000000000000803f000000000000003fec480841f868ffc000000000fcf4edbe000000000000803f000000000000803fec480841125e0bc100000000012af5bf000000000000803f0000000000000000cf6409416fe505c100000000162d97bf000000000000803f000000000000003fcf640941cc6c00c100000000acc0e4be000000000000803f000000000000803fcf6409410b930ec1000000000f74e7bf000000000000803f000000000000000093800a41f0d907c100000000a3d08ebf000000000000803f000000000000003f93800a41d52001c100000000dcb4d8be000000000000803f000000000000803f93800a41e08d11c100000000ed32d7bf000000000000803f00000000000000007c9f0b41f7b309c100000000aab584bf000000000000803f000000000000003f7c9f0b410eda01c1000000009ce1c8be000000000000803f000000000000803f7c9f0b41914914c1000000002cbfc4bf000000000000803f000000000000000086c40c41c3730bc10000000099c971bf000000000000803f000000000000003f86c40c41f59d02c100000000b429b4be000000000000803f000000000000803f86c40c4113c516c1000000002a6eb0bf000000000000803f000000000000000055f20d4193190dc10000000041cd56bf000000000000803f000000000000003f55f20d41136e03c1000000005e7c99be000000000000803f000000000000803f55f20d416e0219c1000000002a889abf000000000000803f00000000000000002b2b0f41a5a50ec1000000008a8738bf000000000000803f000000000000003f2b2b0f41dc4804c10000000002fb6fbe000000000000803f000000000000803f2b2b0f4196051bc100000000124483bf000000000000803f0000000000000000ee7010413a1810c100000000ae0917bf000000000000803f000000000000003fee701041de2a05c100000000de2c1ebe000000000000803f000000000000803fee70104154d31cc100000000d68f55bf000000000000803f000000000000000028c51141937111c100000000d1c9e4be000000000000803f000000000000003f28c51141d20f06c100000000a89f73bd000000000000803f000000000000803f28c5114183701ec100000000ca5722bf000000000000803f000000000000000010291341ecb112c100000000dc5495be000000000000803f000000000000003f1029134155f306c100000000e82e503d000000000000803f000000000000803f10291341a5e11fc10000000023f8d9be000000000000803f00000000000000009b9d144186d913c100000000c05bffbd000000000000803f000000000000003f9b9d144167d107c1000000008694343e000000000000803f000000000000803f9b9d1441ae2a21c1000000002e2d56be000000000000803f00000000000000007f231641a2e814c100000000f06b5c3d000000000000803f000000000000003f7f23164196a608c1000000009331a23e000000000000803f000000000000803f7f231641f14e22c10000000060047d3c000000000000803f000000000000000042bb17417ddf15c100000000fc6b793e000000000000803f000000000000003f42bb1741097009c100000000d983f13e000000000000803f000000000000803f42bb1741355123c10000000066ff7d3e000000000000803f00000000000000003f65194157be16c1000000001280e33e000000000000803f000000000000003f3f651941792b0ac1000000003800243f000000000000803f000000000000803f3f651941c33324c1000000008a2ffa3e000000000000803f0000000000000000af211b41728517c100000000ace4273f000000000000803f000000000000003faf211b4121d70ac10000000093b1523f000000000000803f000000000000803faf211b4176f824c100000000b0bb3c3f000000000000803f0000000000000000aef01c410a3518c100000000a6b7603f000000000000803f000000000000003faef01c419e710bc100000000ce59823f000000000000803f000000000000803faef01c41d5a025c100000000e16a7e3f000000000000803f00000000000000003ed21e415ecd18c100000000e2138e3f000000000000803f000000000000003f3ed21e41e7f90bc10000000054f29c3f000000000000803f000000000000803f3ed21e41282e26c100000000bc11a13f000000000000803f000000000000000052c62041b24e19c100000000e611ad3f000000000000803f000000000000003f52c620413c6f0cc1000000001012b93f000000000000803f000000000000803f52c6204178a126c10000000012f1c33f000000000000803f0000000000000000c6cc224142b919c100000000424dcd3f000000000000803f000000000000003fc6cc22410cd10cc10000000072a9d63f000000000000803f000000000000803fc6cc2241a8fb26c10000000025d1e73f000000000000803f00000000000000006de524414d0d1ac10000000059bdee3f000000000000803f000000000000003f6de52441f21e0dc1000000008da9f53f000000000000803f000000000000803f6de524417b3d27c10000000076570640000000000000803f00000000000000000d102741154b1ac100000000c7ac0840000000000000803f000000000000003f0d102741af580dc10000000018020b40000000000000803f000000000000803f0d102741946727c10000000066431940000000000000803f0000000000000000614c2941d7721ac100000000a38c1a40000000000000803f000000000000003f614c29411a7e0dc100000000e0d51b40000000000000803f000000000000803f614c2941877a27c10000000042aa2c40000000000000803f00000000000000001c9a2b41d4841ac100000000f1f92c40000000000000803f000000000000003f1c9a2b41218f0dc100000000a0492d40000000000000803f000000000000803f1c9a2b41d57627c100000000a4894040000000000000803f0000000000000000eaf82d414b811ac10000000055f03f40000000000000803f000000000000003feaf82d41c18b0dc10000000006573f40000000000000803f000000000000803feaf82d41
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -8.678727, y: 0, z: 0.4487927}
+    m_Extent: {x: 1.7886868, y: 0, z: 2.5596082}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &686140020
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -11266,199 +2239,4013 @@ Mesh:
     offset: 0
     size: 0
     path: 
---- !u!1 &2138677391
-GameObject:
+--- !u!43 &720844179
+Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2138677393}
-  - component: {fileID: 2138677392}
-  m_Layer: 0
-  m_Name: Directional Light
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!108 &2138677392
-Light:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2138677391}
-  m_Enabled: 1
-  serializedVersion: 9
-  m_Type: 1
-  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
-  m_Intensity: 1
-  m_Range: 10
-  m_SpotAngle: 30
-  m_InnerSpotAngle: 21.802082
-  m_CookieSize: 10
-  m_Shadows:
-    m_Type: 2
-    m_Resolution: -1
-    m_CustomResolution: -1
-    m_Strength: 1
-    m_Bias: 0.02
-    m_NormalBias: 0.1
-    m_NearPlane: 0.1
-    m_CullingMatrixOverride:
-      e00: 1
-      e01: 0
-      e02: 0
-      e03: 0
-      e10: 0
-      e11: 1
-      e12: 0
-      e13: 0
-      e20: 0
-      e21: 0
-      e22: 1
-      e23: 0
-      e30: 0
-      e31: 0
-      e32: 0
-      e33: 1
-    m_UseCullingMatrixOverride: 0
-  m_Cookie: {fileID: 0}
-  m_DrawHalo: 0
-  m_Flare: {fileID: 0}
-  m_RenderMode: 0
-  m_CullingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_RenderingLayerMask: 1
-  m_Lightmapping: 1
-  m_LightShadowCasterMode: 0
-  m_AreaSize: {x: 1, y: 1}
-  m_BounceIntensity: 1
-  m_ColorTemperature: 6570
-  m_UseColorTemperature: 0
-  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
-  m_UseBoundingSphereOverride: 0
-  m_ShadowRadius: 0
-  m_ShadowAngle: 51
---- !u!4 &2138677393
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2138677391}
-  m_LocalRotation: {x: 0.7388608, y: 0.5997209, z: -0.2709314, w: 0.14496852}
-  m_LocalPosition: {x: 0.24, y: 3, z: 4.18}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 32.629, y: 195.59999, z: 106.461006}
---- !u!1 &2146937494
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2146937495}
-  - component: {fileID: 2146937499}
-  - component: {fileID: 2146937498}
-  - component: {fileID: 2146937497}
-  - component: {fileID: 2146937496}
-  m_Layer: 0
-  m_Name: segment 1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2146937495
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2146937494}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 539737851}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &2146937496
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2146937494}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 0
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1390907342}
---- !u!114 &2146937497
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2146937494}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67dc87f5a664ca14d9492006284bbca2, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: 
---- !u!23 &2146937498
-MeshRenderer:
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 360
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 93
+    localAABB:
+      m_Center: {x: -8.23407, y: 0, z: 6.3705664}
+      m_Extent: {x: 2.2324421, y: 0, z: 3.3808796}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000030003000400010002000100040004000500020004000300060006000700040005000400070007000800050007000600090009000a000700080007000a000a000b0008000a0009000c000c000d000a000b000a000d000d000e000b000d000c000f000f0010000d000e000d001000100011000e0010000f00120012001300100011001000130013001400110013001200150015001600130014001300160016001700140016001500180018001900160017001600190019001a001700190018001b001b001c0019001a0019001c001c001d001a001c001b001e001e001f001c001d001c001f001f0020001d001f001e002100210022001f0020001f002200220023002000220021002400240025002200230022002500250026002300250024002700270028002500260025002800280029002600280027002a002a002b002800290028002b002b002c0029002b002a002d002d002e002b002c002b002e002e002f002c002e002d003000300031002e002f002e003100310032002f0031003000330033003400310032003100340034003500320034003300360036003700340035003400370037003800350037003600390039003a003700380037003a003a003b0038003a0039003c003c003d003a003b003a003d003d003e003b003d003c003f003f0040003d003e003d004000400041003e0040003f00420042004300400041004000430043004400410043004200450045004600430044004300460046004700440046004500480048004900460047004600490049004a004700490048004b004b004c0049004a0049004c004c004d004a004c004b004e004e004f004c004d004c004f004f0050004d004f004e005100510052004f0050004f005200520053005000520051005400540055005200530052005500550056005300550054005700570058005500560055005800580059005600580057005a005a005b005800590058005b005b005c005900
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 93
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 2976
+    _typelessdata: d57627c100000000a4894040000000000000803f0000000000000000eaf82d414b811ac10000000055f03f40000000000000803f000000000000003feaf82d41c18b0dc10000000006573f40000000000000803f000000000000803feaf82d418f4a27c1000000004cd45540000000000000803f0000000000000000555d304183591ac10000000014115340000000000000803f000000000000003f555d304177680dc100000000dc4d5040000000000000803f000000000000803f555d30411de726c10000000042db6a40000000000000803f000000000000000058bc32410a001ac100000000f9fb6540000000000000803f000000000000003f58bc3241f7180dc100000000b01c6140000000000000803f000000000000803f58bc3241064f26c10000000096977f40000000000000803f000000000000000018163541017719c100000000acaa7840000000000000803f000000000000003f18163541fc9e0cc100000000c2bd7140000000000000803f000000000000803f18163541d58425c10000000058018a40000000000000803f0000000000000000a36a374192c018c100000000718b8540000000000000803f000000000000003fa36a37414ffc0bc1000000008a158140000000000000803f000000000000803fa36a3741038b24c1000000001e0b9440000000000000803f0000000000000000edb93941dcde17c100000000209d8e40000000000000803f000000000000003fedb93941b5320bc100000000222f8940000000000000803f000000000000803fedb93941076423c10000000016e69d40000000000000803f0000000000000000d9033c4108d416c10000000040879740000000000000803f000000000000003fd9033c4109440ac1000000006a289140000000000000803f000000000000803fd9033c414a1222c100000000518fa740000000000000803f000000000000000033483e4139a215c100000000a246a040000000000000803f000000000000003f33483e41283209c100000000f3fd9840000000000000803f000000000000803f33483e412b9820c100000000ff03b140000000000000803f0000000000000000b7864041964b14c10000000024d8a840000000000000803f000000000000003fb786404101ff07c10000000049aca040000000000000803f000000000000803fb7864041f7f71ec1000000005641ba40000000000000803f00000000000000000ebf424140d212c1000000009638b140000000000000803f000000000000003f0ebf424189ac06c100000000d62fa840000000000000803f000000000000803f0ebf4241f3331dc100000000ae44c340000000000000803f0000000000000000d5f044415f3811c100000000d564b940000000000000803f000000000000003fd5f04441cb3c05c100000000fc84af40000000000000803f000000000000803fd5f04441514e1bc100000000600bcc40000000000000803f0000000000000000991b474118800fc100000000b759c140000000000000803f000000000000003f991b4741dfb103c1000000000ea8b640000000000000803f000000000000803f991b4741344919c100000000d592d440000000000000803f0000000000000000dd3e49418fab0dc1000000001114c940000000000000803f000000000000003fdd3e4941ea0d02c1000000004d95bd40000000000000803f000000000000803fdd3e4941ae2617c1000000007ed8dc40000000000000803f0000000000000000185a4b41e9bc0bc100000000bc90d040000000000000803f000000000000003f185a4b41245300c100000000fa48c440000000000000803f000000000000803f185a4b41bae814c100000000d6d9e440000000000000803f0000000000000000ba6c4d4149b609c1000000008eccd740000000000000803f000000000000003fba6c4d41b007fdc00000000046bfca40000000000000803f000000000000803fba6c4d41489112c1000000005e94ec40000000000000803f00000000000000002a764f41d79907c10000000060c4de40000000000000803f000000000000003f2a764f41cc44f9c00000000062f4d040000000000000803f000000000000803f2a764f41282210c1000000009c05f440000000000000803f0000000000000000ca755141b66905c1000000000a75e540000000000000803f000000000000003fca7551418862f5c00000000078e4d640000000000000803f000000000000803fca755141149d0dc100000000122bfb40000000000000803f0000000000000000f96a53410b2803c1000000005fdbeb40000000000000803f000000000000003ff96a53410466f1c000000000ac8bdc40000000000000803f000000000000803ff96a5341a8030bc10000000028010141000000000000803f000000000000000012555541fbd600c1000000003af4f140000000000000803f000000000000003f125555419c54edc00000000025e6e140000000000000803f000000000000803f125555415c5708c1000000006b440441000000000000803f00000000000000007233574156f1fcc00000000070bcf740000000000000803f000000000000003f72335741f433e9c00000000009f0e640000000000000803f000000000000803f723357417f9905c100000000145e0741000000000000803f000000000000000077055941801ef8c000000000d930fd40000000000000803f000000000000003f77055941030ae5c00000000089a5eb40000000000000803f000000000000803f770559412ecb02c100000000db4c0a41000000000000803f000000000000000084ca5a41bf39f3c00000000026270141000000000000803f000000000000003f84ca5a4123dde0c000000000e202f040000000000000803f000000000000803f84ca5a4192daffc0000000006c0f0d41000000000000803f000000000000000004825c415a47eec000000000d2880341000000000000803f000000000000003f04825c4122b4dcc0000000006f04f440000000000000803f000000000000803f04825c41d800fac00000000058a40f41000000000000803f00000000000000006b2b5e419b4be9c000000000d8bb0541000000000000803f000000000000003f6b2b5e415e96d8c000000000b0a6f740000000000000803f000000000000803f6b2b5e41b909f4c000000000130a1241000000000000803f000000000000000041c65f41ce4ae4c000000000a7be0741000000000000803f000000000000003f41c65f41e38bd4c00000000075e6fa40000000000000803f000000000000803f41c65f41faf4edc000000000d43e1441000000000000803f00000000000000001e5261413c49dfc000000000a98f0941000000000000803f000000000000003f1e5261417e9dd0c000000000fdc0fd40000000000000803f000000000000803f1e52614179c1e7c0000000007b401641000000000000803f0000000000000000bace62412c4bdac0000000004b2d0b41000000000000803f000000000000003fbace6241dfd4ccc0000000001b1a0041000000000000803f000000000000803fbace62412a6de1c000000000640c1841000000000000803f0000000000000000ec3b6441ec54d5c000000000f7950c41000000000000803f000000000000003fec3b6441ae3cc9c0000000008a1f0141000000000000803f000000000000803fec3b644106f5dac0000000002c9f1941000000000000803f0000000000000000bb996541c36ad0c0000000001ac80d41000000000000803f000000000000003fbb99654180e0c5c00000000008f10141000000000000803f000000000000803fbb9965415e55d4c00000000055f41a41000000000000803f000000000000000067e86641fa90cbc0000000001fc20e41000000000000803f000000000000003f67e8664196ccc2c000000000e98f0241000000000000803f000000000000803f67e866416f8acdc000000000ec051c41000000000000803f000000000000000076286841e2cbc6c00000000071820f41000000000000803f000000000000003f76286841550dc0c000000000f6fe0241000000000000803f000000000000803f76286841
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -8.23407, y: 0, z: 6.3705664}
+    m_Extent: {x: 2.2324421, y: 0, z: 3.3808796}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &736362454
+Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2146937494}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: e745492728544aa488aa0429b6068e71, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &2146937499
-MeshFilter:
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 540
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 124
+    localAABB:
+      m_Center: {x: -6.150703, y: 0.095, z: 2.5021393}
+      m_Extent: {x: 1.5077085, y: 0.105000004, z: 1.4384553}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 124
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 3968
+    _typelessdata: 6b73e9c00ad723bc1cd77b403642543f00000000c91d0fbf0000000005c292416b73e9c0cdcc4c3e1cd77b403642543f00000000c91d0fbf0000003f05c2924157b7e9c0cdcc4c3eb4327c40364254bf00000000c91d0f3f0000003f05c2924157b7e9c00ad723bcb4327c40364254bf00000000c91d0f3f0000803f05c292415086ecc00ad723bc18d97140c2815f3f0000000033a5f9be00000000033993415086ecc0cdcc4c3e18d97140c2815f3f0000000033a5f9be0000003f03399341d5cdecc0cdcc4c3efa287240c2815fbf0000000033a5f93e0000003f03399341d5cdecc00ad723bcfa287240c2815fbf0000000033a5f93e0000803f033993418b1fefc00ad723bcba886740865c693f000000002c82d2be00000000b0ab93418b1fefc0cdcc4c3eba886740865c693f000000002c82d2be0000003fb0ab9341386aefc0cdcc4c3e17cc6740865c69bf000000002c82d23e0000003fb0ab9341386aefc00ad723bc17cc6740865c69bf000000002c82d23e0000803fb0ab93417a3cf1c00ad723bc6ff75c40629f713f000000004c2ba9be000000008f1a94417a3cf1c0cdcc4c3e6ff75c40629f713f000000004c2ba9be0000003f8f1a9441cc89f1c0cdcc4c3e912d5d40629f71bf000000004c2ba93e0000003f8f1a9441cc89f1c00ad723bc912d5d40629f71bf000000004c2ba93e0000803f8f1a94415fdbf2c00ad723bce3375240cc1f783f000000002c0b7cbe00000000148694415fdbf2c0cdcc4c3ee3375240cc1f783f000000002c0b7cbe0000003f14869441c52af3c0cdcc4c3e36605240cc1f78bf000000002c0b7c3e0000003f14869441c52af3c00ad723bc36605240cc1f78bf000000002c0b7c3e0000803f148694415ffbf3c00ad723bc3c5d4740cabc7c3f0000000042f622be00000000a8ee94415ffbf3c0cdcc4c3e3c5d4740cabc7c3f0000000042f622be0000003fa8ee9441404cf4c0cdcc4c3e4f774740cabc7cbf0000000042f6223e0000003fa8ee9441404cf4c00ad723bc4f774740cabc7cbf0000000042f6223e0000803fa8ee9441959cf4c00ad723bcc87a3c40205e7f3f00000000c5db8fbd00000000a9549541959cf4c0cdcc4c3ec87a3c40205e7f3f00000000c5db8fbd0000003fa95495414ceef4c0cdcc4c3e4a863c40205e7fbf00000000c5db8f3d0000003fa95495414ceef4c00ad723bc4a863c40205e7fbf00000000c5db8f3d0000803fa9549541cdbff4c00ad723bc38a331402cf37f3f00000000fa13a23c000000006ab89541cdbff4c0cdcc4c3e38a331402cf37f3f00000000fa13a23c0000003f6ab89541b511f5c0cdcc4c3efa9f31402cf37fbf00000000fa13a2bc0000003f6ab89541b511f5c00ad723bcfa9f31402cf37fbf00000000fa13a2bc0000803f6ab895416966f4c00ad723bcb4e82640c2707e3f0000000010b7e13d00000000331a96416966f4c0cdcc4c3eb4e82640c2707e3f0000000010b7e13d0000003f331a9641d5b7f4c0cdcc4c3ea6d62640c2707ebf0000000010b7e1bd0000003f331a9641d5b7f4c00ad723bca6d62640c2707ebf0000000010b7e1bd0000803f331a96411892f3c00ad723bc8f5c1c40f6ce7a3f00000000b12d4d3e00000000447a96411892f3c0cdcc4c3e8f5c1c40f6ce7a3f00000000b12d4d3e0000003f447a96415ae2f3c0cdcc4c3ebb3b1c40f6ce7abf00000000b12d4dbe0000003f447a96415ae2f3c00ad723bcbb3b1c40f6ce7abf00000000b12d4dbe0000803f447a9641af44f2c00ad723bc990f12401a07753f00000000054a943e00000000d7d89641af44f2c0cdcc4c3e990f12401a07753f00000000054a943e0000003fd7d896411893f2c0cdcc4c3e25e011401a0775bf00000000054a94be0000003fd7d896411893f2c00ad723bc25e011401a0775bf00000000054a94be0000803fd7d89641fe7ff0c00ad723bc7512084072126d3f00000000a236c13e0000000021369741fe7ff0c0cdcc4c3e7512084072126d3f00000000a236c13e0000003f21369741dbcbf0c0cdcc4c3ea0d4074072126dbf00000000a236c1be0000003f21369741dbcbf0c00ad723bca0d4074072126dbf00000000a236c1be0000803f21369741c545eec00ad723bc0eecfc3fb4e9623f000000004709ed3e0000000056929741c545eec0cdcc4c3e0eecfc3fb4e9623f000000004709ed3e0000003f56929741628eeec0cdcc4c3e5a54fc3fb4e962bf000000004709edbe0000003f56929741628eeec00ad723bc5a54fc3fb4e962bf000000004709edbe0000803f56929741d097ebc00ad723bc2198ea3fe885563f0000000000b30b3f00000000abed9741d097ebc0cdcc4c3e2198ea3fe885563f0000000000b30b3f0000003fabed974176dcebc0cdcc4c3e50e5e93fe88556bf0000000000b30bbf0000003fabed974176dcebc00ad723bc50e5e93fe88556bf0000000000b30bbf0000803fabed97412678e8c00ad723bc684fd93f9ce2473f000000008bf11f3f00000000584898412678e8c0cdcc4c3e684fd93f9ce2473f000000008bf11f3f0000003f584898411cb8e8c0cdcc4c3eae82d83f9ce247bf000000008bf11fbf0000003f584898411cb8e8c00ad723bcae82d83f9ce247bf000000008bf11fbf0000803f5848984174e9e4c00ad723bc9e3bc93f7e01373f00000000c502333f000000009ea2984174e9e4c0cdcc4c3e9e3bc93f7e01373f00000000c502333f0000003f9ea298410424e5c0cdcc4c3e7c56c83f7e0137bf00000000c50233bf0000003f9ea298410424e5c00ad723bc7c56c83f7e0137bf00000000c50233bf0000803f9ea298417eefe0c00ad723bc328aba3f76ef233f00000000e09f443f00000000c6fc98417eefe0c0cdcc4c3e328aba3f76ef233f00000000e09f443f0000003fc6fc9841f423e1c0cdcc4c3e848eb93f76ef23bf00000000e09f44bf0000003fc6fc9841f423e1c00ad723bc848eb93f76ef23bf00000000e09f44bf0000803fc6fc9841b38fdcc00ad723bc946bad3ff6c90e3f00000000a27a543f0000000026579941b38fdcc0cdcc4c3e946bad3ff6c90e3f00000000a27a543f0000003f2657994165bddcc0cdcc4c3e9a5bac3ff6c90ebf00000000a27a54bf0000003f2657994165bddcc00ad723bc9a5bac3ff6c90ebf00000000a27a54bf0000803f26579941b8d1d7c00ad723bc7911a23f1089ef3e000000007e41623f0000000025b29941b8d1d7c0cdcc4c3e7911a23f1089ef3e000000007e41623f0000003f25b299410bf8d7c0cdcc4c3edeefa03f1089efbe000000007e4162bf0000003f25b299410bf8d7c00ad723bcdeefa03f1089efbe000000007e4162bf0000803f25b29941b9bfd2c00ad723bc1aac983f5458be3e00000000c3a66d3f00000000380e9a41b9bfd2c0cdcc4c3e1aac983f5458be3e00000000c3a66d3f0000003f380e9a412dded2c0cdcc4c3ee97b973f5458bebe00000000c3a66dbf0000003f380e9a412dded2c00ad723bce97b973f5458bebe00000000c3a66dbf0000803f380e9a417d66cdc00ad723bc8a66913f24cf8a3e000000008c69763f00000000e56b9a417d66cdc0cdcc4c3e8a66913f24cf8a3e000000008c69763f0000003fe56b9a41b27ccdc0cdcc4c3e222b903f24cf8abe000000008c6976bf0000003fe56b9a41b27ccdc00ad723bc222b903f24cf8abe000000008c6976bf0000803fe56b9a41edd4c7c00ad723bc06638c3f78cc2b3e00000000155f7c3f00000000c6cb9a41edd4c7c0cdcc4c3e06638c3f78cc2b3e00000000155f7c3f0000003fc6cb9a41abe2c7c0cdcc4c3efe1f8b3f78cc2bbe00000000155f7cbf0000003fc6cb9a41abe2c7c00ad723bcfe1f8b3f78cc2bbe00000000155f7cbf0000803fc6cb9a41471bc2c00ad723bce6b7893f00c2823d000000004a7a7f3f00000000812e9b41471bc2c0cdcc4c3ee6b7893f00c2823d000000004a7a7f3f0000003f812e9b418220c2c0cdcc4c3ee470883f00c282bd000000004a7a7fbf0000003f812e9b418220c2c00ad723bce470883f00c282bd000000004a7a7fbf0000803f812e9b41e749bcc00ad723bc3c6e893f50e21dbd000000004ccf7f3f00000000ce949b41e749bcc0cdcc4c3e3c6e893f50e21dbd000000004ccf7f3f0000003fce949b41be46bcc0cdcc4c3ecd26883f50e21d3d000000004ccf7fbf0000003fce949b41be46bcc00ad723bccd26883f50e21d3d000000004ccf7fbf0000803fce949b411d70b6c00ad723bc6b828b3fe0bf0cbe00000000f9917d3f000000006dff9b411d70b6c0cdcc4c3e6b828b3fe0bf0cbe00000000f9917d3f0000003f6dff9b41da64b6c0cdcc4c3eda3d8a3fe0bf0c3e00000000f9917dbf0000003f6dff9b41da64b6c00ad723bcda3d8a3fe0bf0c3e00000000f9917dbf0000803f6dff9b41129bb0c00ad723bc92e68f3f88c96cbe00000000cd0f793f00000000296f9c41129bb0c0cdcc4c3e92e68f3f88c96cbe00000000cd0f793f0000003f296f9c412088b0c0cdcc4c3ec6a78e3f88c96c3e00000000cd0f79bf0000003f296f9c412088b0c00ad723bcc6a78e3f88c96c3e00000000cd0f79bf0000803f296f9c4131d5aac00ad723bc3d86963f462ca3be00000000bba6723f00000000d2e49c4131d5aac0cdcc4c3e3d86963f462ca3be00000000bba6723f0000003fd2e49c4115bbaac0cdcc4c3ea54f953f462ca33e00000000bba672bf0000003fd2e49c4115bbaac00ad723bca54f953f462ca33e00000000bba672bf0000803fd2e49c41f125a5c00ad723bc534a9f3fee52ccbe000000004cbb6a3f0000000039619d41f125a5c0cdcc4c3e534a9f3fee52ccbe000000004cbb6a3f0000003f39619d414005a5c0cdcc4c3ede1d9e3fee52cc3e000000004cbb6abf0000003f39619d414005a5c00ad723bcde1d9e3fee52cc3e000000004cbb6abf0000803f39619d4107929fc00ad723bca01caa3f3aacf1be00000000d8af613f0000000034e59d4107929fc0cdcc4c3ea01caa3f3aacf1be00000000d8af613f0000003f34e59d415c6b9fc0cdcc4c3ebefba83f3aacf13e00000000d8af61bf0000003f34e59d415c6b9fc00ad723bcbefba83f3aacf13e00000000d8af61bf0000803f34e59d41e11b9ac00ad723bc54eab63fad9c09bf000000002cde573f0000000093719e41e11b9ac0cdcc4c3e54eab63fad9c09bf000000002cde573f0000003f93719e41d8ef99c0cdcc4c3e04d6b53fad9c093f000000002cde57bf0000003f93719e41d8ef99c00ad723bc04d6b53fad9c093f000000002cde57bf0000803f93719e413ac494c00ad723bc84a5c53fd48e18bf00000000d4934d3f0000000026079f413ac494c0cdcc4c3e84a5c53fd48e18bf00000000d4934d3f0000003f26079f41699394c0cdcc4c3e619ec43fd48e183f00000000d4934dbf0000003f26079f41699394c00ad723bc619ec43fd48e183f00000000d4934dbf0000803f26079f41
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -6.150703, y: 0.095, z: 2.5021393}
+    m_Extent: {x: 1.5077085, y: 0.105000004, z: 1.4384553}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1062378135
+Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2146937494}
-  m_Mesh: {fileID: 1390907342}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 540
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 124
+    localAABB:
+      m_Center: {x: -2.7720082, y: 0.095, z: 1.4293681}
+      m_Extent: {x: 4.6398673, y: 0.105000004, z: 1.8535441}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 124
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 3968
+    _typelessdata: 0316ef3f0ad723bc50895140fccfe83e00000000e60064bf00000000e34d3a400316ef3fcdcc4c3e50895140fccfe83e00000000e60064bf0000003fe34d3a400381ee3fcdcc4c3e3c1b5240fccfe8be00000000e600643f0000003fe34d3a400381ee3f0ad723bc3c1b5240fccfe8be00000000e600643f0000803fe34d3a409f79e03f0ad723bc57f14d402cf2dc3e00000000c5ef66bf000000006f093f409f79e03fcdcc4c3e57f14d402cf2dc3e00000000c5ef66bf0000003f6f093f4037ecdf3fcdcc4c3e24854e402cf2dcbe00000000c5ef663f0000003f6f093f4037ecdf3f0ad723bc24854e402cf2dcbe00000000c5ef663f0000803f6f093f4016bfcc3f0ad723bca1544940b88fd53e00000000bbaa68bf00000000a7e3444016bfcc3fcdcc4c3ea1544940b88fd53e00000000bbaa68bf0000003fa7e344406836cc3fcdcc4c3e89e94940b88fd5be00000000bbaa683f0000003fa7e344406836cc3f0ad723bc89e94940b88fd5be00000000bbaa683f0000803fa7e34440ed9cb43f0ad723bcdce04340dc80d03e00000000a1cf69bf000000009ac94b40ed9cb43fcdcc4c3edce04340dc80d03e00000000a1cf69bf0000003f9ac94b407c17b43fcdcc4c3e80764440dc80d0be00000000a1cf693f0000003f9ac94b407c17b43f0ad723bc80764440dc80d0be00000000a1cf693f0000803f9ac94b40ea8c983f0ad723bc69b13d40d8cdcc3e0000000083a06abf000000001fa85340ea8c983fcdcc4c3e69b13d40d8cdcc3e0000000083a06abf0000003f1fa85340d709983fcdcc4c3e92473e40d8cdccbe0000000083a06a3f0000003f1fa85340d709983f0ad723bc92473e40d8cdccbe0000000083a06a3f0000803f1fa853407be1713f0ad723bce5da3640f0f6c93e00000000d63d6bbf00000000fd6b5c407be1713fcdcc4c3ee5da3640f0f6c93e00000000d63d6bbf0000003ffd6b5c40f8de703fcdcc4c3e73713740f0f6c9be00000000d63d6b3f0000003ffd6b5c40f8de703f0ad723bc73713740f0f6c9be00000000d63d6b3f0000803ffd6b5c40563e2c3f0ad723bc066f2f4088b3c73e000000005fb96bbf00000000e7016640563e2c3fcdcc4c3e066f2f4088b3c73e000000005fb96bbf0000003fe7016640b83e2b3fcdcc4c3ee305304088b3c7be000000005fb96b3f0000003fe7016640b83e2b3f0ad723bce305304088b3c7be000000005fb96b3f0000803fe7016640aba4c13e0ad723bc087e274074d7c53e00000000a71d6cbf000000008f567040aba4c13ecdcc4c3e087e274074d7c53e00000000a71d6cbf0000003f8f56704032aabf3ecdcc4c3e2515284074d7c5be00000000a71d6c3f0000003f8f56704032aabf3e0ad723bc2515284074d7c5be00000000a71d6c3f0000803f8f5670407ccb813d0ad723bc6b171f40ec45c43e000000005e716cbf000000009c567b407ccb813dcdcc4c3e6b171f40ec45c43e000000005e716cbf0000003f9c567b4050e3733dcdcc4c3ebeae1f40ec45c4be000000005e716c3f0000003f9c567b4050e3733d0ad723bcbeae1f40ec45c4be000000005e716c3f0000803f9c567b4084e889be0ad723bc334a164098ebc23e00000000f6b86cbf000000005b77834084e889becdcc4c3e334a164098ebc23e00000000f6b86cbf0000003f5b77834084db8bbecdcc4c3eb3e1164098ebc2be00000000f6b86c3f0000003f5b77834084db8bbe0ad723bcb3e1164098ebc2be00000000f6b86c3f0000803f5b778340e3201ebf0ad723bc22250d40b0bac13e0000000080f76cbf00000000c2858940e3201ebfcdcc4c3e22250d40b0bac13e0000000080f76cbf0000003fc2858940dc181fbfcdcc4c3ecabc0d40b0bac1be0000000080f76c3f0000003fc2858940dc181fbf0ad723bccabc0d40b0bac1be0000000080f76c3f0000803fc285894004b87abf0ad723bcd1b6034038a9c03e00000000342f6dbf00000000d2cc8f4004b87abfcdcc4c3ed1b6034038a9c03e00000000342f6dbf0000003fd2cc8f409fae7bbfcdcc4c3e9e4e044038a9c0be00000000342f6d3f0000003fd2cc8f409fae7bbf0ad723bc9e4e044038a9c0be00000000342f6d3f0000803fd2cc8f402813adbf0ad723bc701bf43f98afbf3e00000000c0616dbf00000000e04296402813adbfcdcc4c3e701bf43f98afbf3e00000000c0616dbf0000003fe0429640d68dadbfcdcc4c3e4a4bf53f98afbfbe00000000c0616d3f0000003fe0429640d68dadbf0ad723bc4a4bf53f98afbfbe00000000c0616d3f0000803fe042964076ecddbf0ad723bc7a70e03fc4c7be3e000000006c906dbf000000003bde9c4076ecddbfcdcc4c3e7a70e03fc4c7be3e000000006c906dbf0000003f3bde9c409066debfcdcc4c3e90a0e13fc4c7bebe000000006c906d3f0000003f3bde9c409066debf0ad723bc90a0e13fc4c7bebe000000006c906d3f0000803f3bde9c4062cf07c00ad723bc7389cc3fe4ecbd3e0000000040bc6dbf000000003495a34062cf07c0cdcc4c3e7389cc3fe4ecbd3e0000000040bc6dbf0000003f3495a340280c08c0cdcc4c3ec0b9cd3fe4ecbdbe0000000040bc6d3f0000003f3495a340280c08c00ad723bcc0b9cd3fe4ecbdbe0000000040bc6d3f0000803f3495a34089f020c00ad723bc0083b83fd01abd3e0000000018e66dbf000000001a5eaa4089f020c0cdcc4c3e0083b83fd01abd3e0000000018e66dbf0000003f1a5eaa400c2d21c0cdcc4c3e83b3b93fd01abdbe0000000018e66d3f0000003f1a5eaa400c2d21c00ad723bc83b3b93fd01abdbe0000000018e66d3f0000803f1a5eaa403a353ac00ad723bcb579a43fec4dbc3e00000000ba0e6ebf00000000402fb1403a353ac0cdcc4c3eb579a43fec4dbc3e00000000ba0e6ebf0000003f402fb1407c713ac0cdcc4c3e6caaa53fec4dbcbe00000000ba0e6e3f0000003f402fb1407c713ac00ad723bc6caaa53fec4dbcbe00000000ba0e6e3f0000803f402fb140027953c00ad723bc1e8a903fb882bb3e00000000d0366ebf00000000f4feb740027953c0cdcc4c3e1e8a903fb882bb3e00000000d0366ebf0000003ff4feb74002b553c0cdcc4c3e08bb913fb882bbbe00000000d0366e3f0000003ff4feb74002b553c00ad723bc08bb913fb882bbbe00000000d0366e3f0000803ff4feb74074976cc00ad723bc9ba1793fc0b5ba3e000000000b5f6ebf0000000088c3be4074976cc0cdcc4c3e9ba1793fc0b5ba3e000000000b5f6ebf0000003f88c3be4034d36cc0cdcc4c3ed6037c3fc0b5babe000000000b5f6e3f0000003f88c3be4034d36cc00ad723bcd6037c3fc0b5babe000000000b5f6e3f0000803f88c3be400db682c00ad723bca5d4523f84e3b93e000000001a886ebf000000004c73c5400db682c0cdcc4c3ea5d4523f84e3b93e000000001a886ebf0000003f4c73c540cbd382c0cdcc4c3e4937553f84e3b9be000000001a886e3f0000003f4c73c540cbd382c00ad723bc4937553f84e3b9be000000001a886e3f0000803f4c73c5403de98ec00ad723bc86e62c3f1008b93e00000000bdb26ebf000000008e04cc403de98ec0cdcc4c3e86e62c3f1008b93e00000000bdb26ebf0000003f8e04cc40d8068fc0cdcc4c3e96492f3f1008b9be00000000bdb26e3f0000003f8e04cc40d8068fc00ad723bc96492f3f1008b9be00000000bdb26e3f0000803f8e04cc4003d39ac00ad723bc7e10083fe81eb83e00000000d0df6ebf00000000a06dd24003d39ac0cdcc4c3e7e10083fe81eb83e00000000d0df6ebf0000003fa06dd24078f09ac0cdcc4c3e03740a3fe81eb8be00000000d0df6e3f0000003fa06dd24078f09ac00ad723bc03740a3fe81eb8be00000000d0df6e3f0000803fa06dd2400c61a6c00ad723bcd417c93e6c22b73e000000004f106fbf00000000d4a4d8400c61a6c0cdcc4c3ed417c93e6c22b73e000000004f106fbf0000003fd4a4d840597ea6c0cdcc4c3ed6dfcd3e6c22b7be000000004f106f3f0000003fd4a4d840597ea6c00ad723bcd6dfcd3e6c22b7be000000004f106f3f0000803fd4a4d840ef80b1c00ad723bcce24853e8c0bb63e0000000088456fbf0000000076a0de40ef80b1c0cdcc4c3ece24853e8c0bb63e0000000088456fbf0000003f76a0de40109eb1c0cdcc4c3ee0ed893e8c0bb6be0000000088456f3f0000003f76a0de40109eb1c00ad723bce0ed893e8c0bb6be0000000088456f3f0000803f76a0de402e20bcc00ad723bc6077093e00d1b43e0000000020816fbf00000000de56e4402e20bcc0cdcc4c3e6077093e00d1b43e0000000020816fbf0000003fde56e4401c3dbcc0cdcc4c3ee80b133e00d1b4be0000000020816f3f0000003fde56e4401c3dbcc00ad723bce80b133e00d1b4be0000000020816f3f0000803fde56e440152cc6c00ad723bc8013853c0066b33e0000000057c56fbf0000000058bee940152cc6c0cdcc4c3e8013853c0066b33e0000000057c56fbf0000003f58bee940c948c6c0cdcc4c3e80cdd13c0066b3be0000000057c56f3f0000003f58bee940c948c6c00ad723bc80cdd13c0066b3be0000000057c56f3f0000803f58bee940af91cfc00ad723bcd891bebd34b8b13e000000004e1570bf0000000038cdee40af91cfc0cdcc4c3ed891bebd34b8b13e000000004e1570bf0000003f38cdee401faecfc0cdcc4c3ef05cabbd34b8b1be000000004e15703f0000003f38cdee401faecfc00ad723bcf05cabbd34b8b1be000000004e15703f0000803f38cdee408e3dd8c00ad723bc885945be10acaf3e00000000aa7570bf00000000d279f3408e3dd8c0cdcc4c3e885945be10acaf3e00000000aa7570bf0000003fd279f340aa59d8c0cdcc4c3e3cbb3bbe10acafbe00000000aa75703f0000003fd279f340aa59d8c00ad723bc3cbb3bbe10acafbe00000000aa75703f0000803fd279f3407e1be0c00ad723bc2e4b90be4416ad3e0000000088ed70bf000000007abaf7407e1be0c0cdcc4c3e2e4b90be4416ad3e0000000088ed70bf0000003f7abaf7403037e0c0cdcc4c3ea2798bbe4416adbe0000000088ed703f0000003f7abaf7403037e0c00ad723bca2798bbe4416adbe0000000088ed703f0000803f7abaf740c915e7c00ad723bcfefbb7bebcada93e00000000838871bf000000008a85fb40c915e7c0cdcc4c3efefbb7bebcada93e00000000838871bf0000003f8a85fb40ef30e7c0cdcc4c3e5827b3bebcada9be000000008388713f0000003f8a85fb40ef30e7c00ad723bc5827b3bebcada9be000000008388713f0000803f8a85fb40b213edc00ad723bc9a2dd9bef4eca43e00000000d95a72bf000000005ad1fe40b213edc0cdcc4c3e9a2dd9bef4eca43e00000000d95a72bf0000003f5ad1fe40162eedc0cdcc4c3ebe54d4bef4eca4be00000000d95a723f0000003f5ad1fe40162eedc00ad723bcbe54d4bef4eca4be00000000d95a723f0000803f5ad1fe40
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -2.7720082, y: 0.095, z: 1.4293681}
+    m_Extent: {x: 4.6398673, y: 0.105000004, z: 1.8535441}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1068218713
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 540
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 124
+    localAABB:
+      m_Center: {x: 1.9517306, y: 0.095, z: 9.363232}
+      m_Extent: {x: 3.23729, y: 0.105000004, z: 1.7006259}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 124
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 3968
+    _typelessdata: 368da4bf0ad723bcbc452c418a8bd0be000000003dcd693f00000000e1bad041368da4bfcdcc4c3ebc452c418a8bd0be000000003dcd693f0000003fe1bad041be07a4bfcdcc4c3e53202c418a8bd03e000000003dcd69bf0000003fe1bad041be07a4bf0ad723bc53202c418a8bd03e000000003dcd69bf0000803fe1bad0417f258cbf0ad723bc937d2d41eaeaabbe000000001723713f00000000314dd1417f258cbfcdcc4c3e937d2d41eaeaabbe000000001723713f0000003f314dd14178b78bbfcdcc4c3efe562d41eaeaab3e00000000172371bf0000003f314dd14178b78bbf0ad723bcfe562d41eaeaab3e00000000172371bf0000803f314dd141c7ba65bf0ad723bc517f2e41c2918bbe000000000e4e763f0000000072ead141c7ba65bfcdcc4c3e517f2e41c2918bbe000000000e4e763f0000003f72ead141210865bfcdcc4c3ee8572e41c2918b3e000000000e4e76bf0000003f72ead141210865bf0ad723bce8572e41c2918b3e000000000e4e76bf0000803f72ead141fa5131bf0ad723bc0b522f411c205dbe00000000bef5793f000000002492d241fa5131bfcdcc4c3e0b522f411c205dbe00000000bef5793f0000003f2492d24175c430bfcdcc4c3e0d2a2f411c205d3e00000000bef579bf0000003f2492d24175c430bf0ad723bc0d2a2f411c205d3e00000000bef579bf0000803f2492d2419211f6be0ad723bcd8f92f41343a28be0000000090857c3f00000000a843d3419211f6becdcc4c3ed8f92f41343a28be0000000090857c3f0000003fa843d3413e3af5becdcc4c3e70d12f41343a283e0000000090857cbf0000003fa843d3413e3af5be0ad723bc70d12f41343a283e0000000090857cbf0000803fa843d341a2cc85be0ad723bcce7830419854eebd00000000bb427e3f000000004afed341a2cc85becdcc4c3ece7830419854eebd00000000bb427e3f0000003f4afed3411a3485becdcc4c3e1f5030419854ee3d00000000bb427ebf0000003f4afed3411a3485be0ad723bc1f5030419854ee3d00000000bb427ebf0000803f4afed3414eec0fbd0ad723bcd3cf3041b8d291bd00000000aa597f3f000000004cc1d4414eec0fbdcdcc4c3ed3cf3041b8d291bd00000000aa597f3f0000003f4cc1d441b1010dbdcdcc4c3ef8a63041b8d2913d00000000aa597fbf0000003f4cc1d441b1010dbd0ad723bcf8a63041b8d2913d00000000aa597fbf0000803f4cc1d441933f4a3e0ad723bcebfe3041a005e5bc0000000064e67f3f00000000e78bd541933f4a3ecdcc4c3eebfe3041a005e5bc0000000064e67f3f0000003fe78bd541dd884a3ecdcc4c3ef9d53041a005e53c0000000064e67fbf0000003fe78bd541dd884a3e0ad723bcf9d53041a005e53c0000000064e67fbf0000803fe78bd541923fdf3e0ad723bc9005314180f4653c000000008df97f3f00000000535dd641923fdf3ecdcc4c3e9005314180f4653c000000008df97f3f0000003f535dd6412c2ddf3ecdcc4c3e9bdc304180f465bc000000008df97fbf0000003f535dd6412c2ddf3e0ad723bc9bdc304180f465bc000000008df97fbf0000803f535dd6413b052e3f0ad723bccde2304100a7623d00000000979b7f3f00000000c934d7413b052e3fcdcc4c3ecde2304100a7623d00000000979b7f3f0000003fc934d741f7e02d3fcdcc4c3ee8b9304100a762bd00000000979b7fbf0000003fc934d741f7e02d3f0ad723bce8b9304100a762bd00000000979b7fbf0000803fc934d74107906d3f0ad723bc5b9530418076c53d00000000abce7e3f000000008411d84107906d3fcdcc4c3e5b9530418076c53d00000000abce7e3f0000003f8411d841d7506d3fcdcc4c3e976c30418076c5bd00000000abce7ebf0000003f8411d841d7506d3f0ad723bc976c30418076c5bd00000000abce7ebf0000803f8411d8411f06973f0ad723bcb71b304128fe0c3e00000000d08f7d3f00000000c6f2d8411f06973fcdcc4c3eb71b304128fe0c3e00000000d08f7d3f0000003fc6f2d84100d9963fcdcc4c3e25f32f4128fe0cbe00000000d08f7dbf0000003fc6f2d84100d9963f0ad723bc25f32f4128fe0cbe00000000d08f7dbf0000803fc6f2d8418fa1b73f0ad723bc1b742f4198ce373e0000000093d77b3f00000000dad7d9418fa1b73fcdcc4c3e1b742f4198ce373e0000000093d77b3f0000003fdad7d941be66b73fcdcc4c3ecf4b2f4198ce37be0000000093d77bbf0000003fdad7d941be66b73f0ad723bccf4b2f4198ce37be0000000093d77bbf0000803fdad7d9418e7dd83f0ad723bc8f9c2e41507b633e000000006d9a793f0000000014c0da418e7dd83fcdcc4c3e8f9c2e41507b633e000000006d9a793f0000003f14c0da41c334d83fcdcc4c3e9f742e41507b63be000000006d9a79bf0000003f14c0da41c334d83f0ad723bc9f742e41507b63be000000006d9a79bf0000803f14c0da41177cf93f0ad723bcea922d414423883e00000000ddc8763f00000000d8aadb41177cf93fcdcc4c3eea922d414423883e00000000ddc8763f0000003fd8aadb41f624f93fcdcc4c3e6e6b2d41442388be00000000ddc876bf0000003fd8aadb41f624f93f0ad723bc6e6b2d41442388be00000000ddc876bf0000803fd8aadb41e43e0d400ad723bcd3542c4164329f3e000000008c4f733f000000009997dc41e43e0d40cdcc4c3ed3542c4164329f3e000000008c4f733f0000003f9997dc41f20b0d40cdcc4c3ee52d2c4164329fbe000000008c4f73bf0000003f9997dc41f20b0d400ad723bce52d2c4164329fbe000000008c4f73bf0000803f9997dc41cab01d400ad723bcbadf2a414cfdb63e0000000069176f3f00000000dd85dd41cab01d40cdcc4c3ebadf2a414cfdb63e0000000069176f3f0000003fdd85dd413c761d40cdcc4c3e79b92a414cfdb6be0000000069176fbf0000003fdd85dd413c761d400ad723bc79b92a414cfdb6be0000000069176fbf0000803fdd85dd4147022e400ad723bce5302941cc8ccf3e00000000e3056a3f000000004275de4147022e40cdcc4c3ee5302941cc8ccf3e00000000e3056a3f0000003f4275de41ddbf2d40cdcc4c3e740b2941cc8ccfbe00000000e3056abf0000003f4275de41ddbf2d400ad723bc740b2941cc8ccfbe00000000e3056abf0000803f4275de41a7203e400ad723bc7745274188dde83e0000000071fd633f000000007e65df41a7203e40cdcc4c3e7745274188dde83e0000000071fd633f0000003f7e65df4122d63d40cdcc4c3efd20274188dde8be0000000071fd63bf0000003f7e65df4122d63d400ad723bcfd20274188dde8be0000000071fd63bf0000803f7e65df41b9f74d400ad723bc731a2541bc6e013f0000000086de5c3f000000006856e041b9f74d40cdcc4c3e731a2541bc6e013f0000000086de5c3f0000003f6856e041e2a44d40cdcc4c3e1cf72441bc6e01bf0000000086de5cbf0000003f6856e041e2a44d400ad723bc1cf72441bc6e01bf0000000086de5cbf0000803f6856e0417e715d400ad723bcdaac22415cb40e3f000000002489543f00000000f847e1417e715d40cdcc4c3edaac22415cb40e3f000000002489543f0000003ff847e14129165d40cdcc4c3ed98a22415cb40ebf00000000248954bf0000003ff847e14129165d400ad723bcd98a22415cb40ebf00000000248954bf0000803ff847e141db756c400ad723bcc5f91f414c231c3f000000002ddf4a3f000000004a3ae241db756c40cdcc4c3ec5f91f414c231c3f000000002ddf4a3f0000003f4a3ae241ed116c40cdcc4c3e4fd91f414c231cbf000000002ddf4abf0000003f4a3ae241ed116c400ad723bc4fd91f414c231cbf000000002ddf4abf0000803f4a3ae2416cea7a400ad723bc8cfe1c41e293293f0000000096c73f3f00000000aa2de3416cea7a40cdcc4c3e8cfe1c41e293293f0000000096c73f3f0000003faa2de341e47d7a40cdcc4c3edcdf1c41e29329bf0000000096c73fbf0000003faa2de341e47d7a400ad723bcdcdf1c41e29329bf0000000096c73fbf0000803faa2de3413e5984400ad723bcfdb819410ed3363f000000003332333f000000008c22e4413e598440cdcc4c3efdb819410ed3363f000000003332333f0000003f8c22e441bd1e8440cdcc4c3e519c19410ed336bf00000000333233bf0000003f8c22e441bd1e84400ad723bc519c19410ed336bf00000000333233bf0000803f8c22e441acd78a400ad723bc8f271641daa3433f00000000e51b253f000000009a19e541acd78a40cdcc4c3e8f271641daa3433f00000000e51b253f0000003f9a19e54112998a40cdcc4c3e240d1641daa343bf00000000e51b25bf0000003f9a19e54112998a400ad723bc240d1641daa343bf00000000e51b25bf0000803f9a19e54172e090400ad723bc964912415ec24f3f00000000b592153f00000000ab13e64172e09040cdcc4c3e964912415ec24f3f00000000b592153f0000003fab13e641f69d9040cdcc4c3ea73112415ec24fbf00000000b59215bf0000003fab13e641f69d90400ad723bca73112415ec24fbf00000000b59215bf0000803fab13e641506396400ad723bc621f0e41e4e85a3f0000000044b8043f00000000ce11e74150639640cdcc4c3e621f0e41e4e85a3f0000000044b8043f0000003fce11e741431d9640cdcc4c3e260a0e41e4e85abf0000000044b804bf0000003fce11e741431d96400ad723bc260a0e41e4e85abf0000000044b804bf0000803fce11e74180509b400ad723bc50aa094136d6643f00000000de84e53e000000003f15e84180509b40cdcc4c3e50aa094136d6643f00000000de84e53e0000003f3f15e84146079b40cdcc4c3ef497094136d664bf00000000de84e5be0000003f3f15e84146079b400ad723bcf497094136d664bf00000000de84e5be0000803f3f15e8415c999f400ad723bc9dec04415e546d3f00000000cbf1bf3e00000000691fe9415c999f40cdcc4c3e9dec04415e546d3f00000000cbf1bf3e0000003f691fe9416a4d9f40cdcc4c3e42dd04415e546dbf00000000cbf1bfbe0000003f691fe9416a4d9f400ad723bc42dd04415e546dbf00000000cbf1bfbe0000803f691fe941f630a3400ad723bc5bd2ff40663e743f000000002060993e00000000dd31ea41f630a340cdcc4c3e5bd2ff40663e743f000000002060993e0000003fdd31ea41cee2a240cdcc4c3ed1b9ff40663e74bf00000000206099be0000003fdd31ea41cee2a2400ad723bcd1b9ff40663e74bf00000000206099be0000803fdd31ea41750ca6400ad723bc6546f540c683793f000000006907653e000000004c4eeb41750ca640cdcc4c3e6546f540c683793f000000006907653e0000003f4c4eeb419dbca540cdcc4c3e1234f540c68379bf00000000690765be0000003f4c4eeb419dbca5400ad723bc1234f540c68379bf00000000690765be0000803f4c4eeb41
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 1.9517306, y: 0.095, z: 9.363232}
+    m_Extent: {x: 3.23729, y: 0.105000004, z: 1.7006259}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1155560283
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 540
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 124
+    localAABB:
+      m_Center: {x: 3.9721823, y: 0.095, z: 4.7524605}
+      m_Extent: {x: 1.3767842, y: 0.105000004, z: 2.9123828}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 124
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 3968
+    _typelessdata: 750ca6400ad723bc6546f540c683793f000000006907653e0000000000000000750ca640cdcc4c3e6546f540c683793f000000006907653e0000003f000000009dbca540cdcc4c3e1234f540c68379bf00000000690765be0000003f000000009dbca5400ad723bc1234f540c68379bf00000000690765be0000803f000000006c14a8400ad723bcb660eb4082eb7b3f000000007417363e000000001e400e3e6c14a840cdcc4c3eb660eb4082eb7b3f000000007417363e0000003f1e400e3ecfc3a740cdcc4c3e2552eb4082eb7bbf00000000741736be0000003f1e400e3ecfc3a7400ad723bc2552eb4082eb7bbf00000000741736be0000803f1e400e3ed597a9400ad723bcc2afe1402cd27d3f000000004552053e000000006a998b3ed597a940cdcc4c3ec2afe1402cd27d3f000000004552053e0000003f6a998b3e9c46a940cdcc4c3e18a5e1402cd27dbf00000000455205be0000003f6a998b3e9c46a9400ad723bc18a5e1402cd27dbf00000000455205be0000803f6a998b3e2d9aaa400ad723bca534d8409e287f3f000000003ae7a53d00000000289ecd3e2d9aaa40cdcc4c3ea534d8409e287f3f000000003ae7a53d0000003f289ecd3e8748aa40cdcc4c3e022ed8409e287fbf000000003ae7a5bd0000003f289ecd3e8748aa400ad723bc022ed8409e287fbf000000003ae7a5bd0000803f289ecd3e2c1fab400ad723bce0f0ce4070e17f3f000000009927fa3c000000005caf063f2c1fab40cdcc4c3ee0f0ce4070e17f3f000000009927fa3c0000003f5caf063f4acdaa40cdcc4c3e60eece4070e17fbf000000009927fabc0000003f5caf063f4acdaa400ad723bc60eece4070e17fbf000000009927fabc0000803f5caf063fbc2aab400ad723bc34e6c540b4f17f3f00000000ff22abbc000000002a85253fbc2aab40cdcc4c3e34e6c540b4f17f3f00000000ff22abbc0000003f2a85253fd5d8aa40cdcc4c3eeae7c540b4f17fbf00000000ff22ab3c0000003f2a85253fd5d8aa400ad723bceae7c540b4f17fbf00000000ff22ab3c0000803f2a85253f24c1aa400ad723bcb116bd4096517f3f00000000e05195bd00000000de66433f24c1aa40cdcc4c3eb116bd4096517f3f00000000e05195bd0000003fde66433f716faa40cdcc4c3eaa1cbd4096517fbf00000000e051953d0000003fde66433f716faa400ad723bcaa1cbd4096517fbf00000000e051953d0000803fde66433fffe6a9400ad723bc8584b440e6fc7d3f00000000002300be00000000dd69603fffe6a940cdcc4c3e8584b440e6fc7d3f00000000002300be0000003fdd69603fb895a940cdcc4c3ec58eb440e6fc7dbf000000000023003e0000003fdd69603fb895a9400ad723bcc58eb440e6fc7dbf000000000023003e0000803fdd69603f55a1a8400ad723bcfc31ac405af37b3f00000000836935be0000000005a27c3f55a1a840cdcc4c3efc31ac405af37b3f00000000836935be0000003f05a27c3fb550a840cdcc4c3e7f40ac405af37bbf000000008369353e0000003f05a27c3fb550a8400ad723bc7f40ac405af37bbf000000008369353e0000803f05a27c3f92f5a6400ad723bc5421a440b838793f00000000c2146abe00000000ed108c3f92f5a640cdcc4c3e5421a440b838793f00000000c2146abe0000003fed108c3fd1a5a640cdcc4c3e0e34a440b83879bf00000000c2146a3e0000003fed108c3fd1a5a6400ad723bc0e34a440b83879bf00000000c2146a3e0000803fed108c3f84e9a4400ad723bca8549c407cd4753f0000000000e18ebe00000000197d993f84e9a440cdcc4c3ea8549c407cd4753f0000000000e18ebe0000003f197d993fda9aa440cdcc4c3e846b9c407cd475bf0000000000e18e3e0000003f197d993fda9aa4400ad723bc846b9c407cd475bf0000000000e18e3e0000803f197d993f5583a2400ad723bce6cd94408ad1713f000000009e0ba8be00000000009da63f5583a240cdcc4c3ee6cd94408ad1713f000000009e0ba8be0000003f009da63ff335a240cdcc4c3ec9e894408ad171bf000000009e0ba83e0000003f009da63ff335a2400ad723bcc9e894408ad171bf000000009e0ba83e0000803f009da63f6dc99f400ad723bca48e8d40763d6d3f000000000b63c0be000000004577b33f6dc99f40cdcc4c3ea48e8d40763d6d3f000000000b63c0be0000003f4577b33f837d9f40cdcc4c3e6cad8d40763d6dbf000000000b63c03e0000003f4577b33f837d9f400ad723bc6cad8d40763d6dbf000000000b63c03e0000803f4577b33f6cc29c400ad723bc25988640c227683f00000000dfc6d7be000000008c11c03f6cc29c40cdcc4c3e25988640c227683f00000000dfc6d7be0000003f8c11c03f22789c40cdcc4c3eabba8640c22768bf00000000dfc6d73e0000003f8c11c03f22789c400ad723bcabba8640c22768bf00000000dfc6d73e0000803f8c11c03f107599400ad723bc9bd67f4034a1623f00000000111eeebe000000008670cc3f10759940cdcc4c3e9bd67f4034a1623f00000000111eeebe0000003f8670cc3f8a2c9940cdcc4c3e6711804034a162bf00000000111eee3e0000003f8670cc3f8a2c99400ad723bc6711804034a162bf00000000111eee3e0000803f8670cc3f21e895400ad723bc44117340dcba5c3f0000000086ab01bf00000000e197d83f21e89540cdcc4c3e44117340dcba5c3f0000000086ab01bf0000003fe197d83f7fa19540cdcc4c3e41647340dcba5cbf0000000086ab013f0000003fe197d83f7fa195400ad723bc41647340dcba5cbf0000000086ab013f0000803fe197d83f5b2292400ad723bc93e066407685563f00000000adb30bbf00000000628ae43f5b229240cdcc4c3e93e066407685563f00000000adb30bbf0000003f628ae43fb5dd9140cdcc4c3efc396740768556bf00000000adb30b3f0000003f628ae43fb5dd91400ad723bcfc396740768556bf00000000adb30b3f0000803f628ae43f662a8e400ad723bc29445b40d410503f000000007f2515bf00000000df49f03f662a8e40cdcc4c3e29445b40d410503f000000007f2515bf0000003fdf49f03fd1e78d40cdcc4c3e9da35b40d41050bf000000007f25153f0000003fdf49f03fd1e78d400ad723bc9da35b40d41050bf000000007f25153f0000803fdf49f03fc2068a400ad723bc1b3b5040566b493f00000000df011ebf0000000047d7fb3fc2068a40cdcc4c3e1b3b5040566b493f00000000df011ebf0000003f47d7fb3f4ec68940cdcc4c3e3ba05040566b49bf00000000df011e3f0000003f47d7fb3f4ec689400ad723bc3ba05040566b49bf00000000df011e3f0000803f47d7fb3fc2bd85400ad723bcfdc345409ea1423f00000000034c26bf0000000059990340c2bd8540cdcc4c3efdc345409ea1423f00000000034c26bf0000003f599903407a7f8540cdcc4c3e6b2e46409ea142bf00000000034c263f0000003f599903407a7f85400ad723bc6b2e46409ea142bf00000000034c263f0000803f59990340895581400ad723bc05dd3b405ebe3b3f0000000017092ebf00000000b42d094089558140cdcc4c3e05dd3b405ebe3b3f0000000017092ebf0000003fb42d094075198140cdcc4c3e674c3c405ebe3bbf0000000017092e3f0000003fb42d0940751981400ad723bc674c3c405ebe3bbf0000000017092e3f0000803fb42d094000a879400ad723bc1a8432401cca343f00000000b93f35bf00000000f8a70e4000a87940cdcc4c3e1a8432401cca343f00000000b93f35bf0000003ff8a70e404b347940cdcc4c3e1af832401cca34bf00000000b93f353f0000003ff8a70e404b3479400ad723bc1af832401cca34bf00000000b93f353f0000803ff8a70e40ae7d70400ad723bceab6294040cb2d3f0000000099f73bbf0000000012071440ae7d7040cdcc4c3eeab6294040cb2d3f0000000099f73bbf0000003f12071440740e7040cdcc4c3e362f2a4040cb2dbf0000000099f73b3f0000003f12071440740e70400ad723bc362f2a4040cb2dbf0000000099f73b3f0000803f12071440123767400ad723bc0173214004c6263f000000001b3942bf000000009c49194012376740cdcc4c3e0173214004c6263f000000001b3942bf0000003f9c49194056cc6640cdcc4c3e4eef214004c626bf000000001b39423f0000003f9c49194056cc66400ad723bc4eef214004c626bf000000001b39423f0000803f9c491940aede5d400ad723bcd6b5194064bc1f3f00000000170d48bf00000000df6d1e40aede5d40cdcc4c3ed6b5194064bc1f3f00000000170d48bf0000003fdf6d1e4072785d40cdcc4c3ede351a4064bc1fbf00000000170d483f0000003fdf6d1e4072785d400ad723bcde351a4064bc1fbf00000000170d483f0000803fdf6d1e40887e54400ad723bccd7c12401aae183f000000009b7c4dbf00000000e7712340887e5440cdcc4c3ecd7c12401aae183f000000009b7c4dbf0000003fe7712340d11c5440cdcc4c3e500013401aae18bf000000009b7c4d3f0000003fe7712340d11c54400ad723bc500013401aae18bf000000009b7c4d3f0000803fe771234038204b400ad723bc53c50b40a098113f00000000b89052bf000000007c53284038204b40cdcc4c3e53c50b40a098113f00000000b89052bf0000003f7c53284009c34a40cdcc4c3e164c0c40a09811bf00000000b890523f0000003f7c53284009c34a400ad723bc164c0c40a09811bf00000000b890523f0000803f7c532840cfcc41400ad723bcce8c0540de760a3f000000007b5257bf0000000030102d40cfcc4140cdcc4c3ece8c0540de760a3f000000007b5257bf0000003f30102d4031744140cdcc4c3e9d160640de760abf000000007b52573f0000003f30102d40317441400ad723bc9d160640de760abf000000007b52573f0000803f30102d40cc8c38400ad723bc6fa1ff3ffa40033f00000000b7ca5bbf0000000062a53140cc8c3840cdcc4c3e6fa1ff3ffa40033f00000000b7ca5bbf0000003f62a53140cb383840cdcc4c3e625d0040fa4003bf00000000b7ca5b3f0000003f62a53140cb3838400ad723bc625d0040fa4003bf00000000b7ca5b3f0000803f62a5314004682f400ad723bc101df53f8cd7f73e00000000110260bf000000004610364004682f40cdcc4c3e101df53f8cd7f73e00000000110260bf0000003f46103640b5182f40cdcc4c3eca3bf63f8cd7f7be000000001102603f0000003f46103640b5182f400ad723bcca3bf63f8cd7f7be000000001102603f0000803f46103640816526400ad723bca887eb3ffccfe83e00000000e60064bf00000000e34d3a4081652640cdcc4c3ea887eb3ffccfe83e00000000e60064bf0000003fe34d3a40011b2640cdcc4c3e80abec3ffccfe8be00000000e600643f0000003fe34d3a40011b26400ad723bc80abec3ffccfe8be00000000e600643f0000803fe34d3a40
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 3.9721823, y: 0.095, z: 4.7524605}
+    m_Extent: {x: 1.3767842, y: 0.105000004, z: 2.9123828}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1242041360
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 360
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 93
+    localAABB:
+      m_Center: {x: -1.428297, y: 0, z: 9.055265}
+      m_Extent: {x: 1.0324535, y: 0, z: 1.71176}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000030003000400010002000100040004000500020004000300060006000700040005000400070007000800050007000600090009000a000700080007000a000a000b0008000a0009000c000c000d000a000b000a000d000d000e000b000d000c000f000f0010000d000e000d001000100011000e0010000f00120012001300100011001000130013001400110013001200150015001600130014001300160016001700140016001500180018001900160017001600190019001a001700190018001b001b001c0019001a0019001c001c001d001a001c001b001e001e001f001c001d001c001f001f0020001d001f001e002100210022001f0020001f002200220023002000220021002400240025002200230022002500250026002300250024002700270028002500260025002800280029002600280027002a002a002b002800290028002b002b002c0029002b002a002d002d002e002b002c002b002e002e002f002c002e002d003000300031002e002f002e003100310032002f0031003000330033003400310032003100340034003500320034003300360036003700340035003400370037003800350037003600390039003a003700380037003a003a003b0038003a0039003c003c003d003a003b003a003d003d003e003b003d003c003f003f0040003d003e003d004000400041003e0040003f00420042004300400041004000430043004400410043004200450045004600430044004300460046004700440046004500480048004900460047004600490049004a004700490048004b004b004c0049004a0049004c004c004d004a004c004b004e004e004f004c004d004c004f004f0050004d004f004e005100510052004f0050004f005200520053005000520051005400540055005200530052005500550056005300550054005700570058005500560055005800580059005600580057005a005a005b005800590058005b005b005c005900
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 93
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 2976
+    _typelessdata: fdabcabe00000000a7f4eb40000000800000803f00000000000000004335c5411f210bbf0000000084b80241000000800000803f000000000000003f4335c54140ec30bf00000000b4760f41000000800000803f000000000000803f4335c5412f4a14bf00000000be2beb40000000800000803f0000000000000000bc9ec541964325bf000000007f800241000000800000803f000000000000003fbc9ec541fd3c36bf000000001f6b0f41000000800000803f000000000000803fbc9ec541480843bf00000000fefdea40000000000000803f00000000000000003d04c641b7a03ebf0000000002740241000000000000803f000000000000003f3d04c64126393abf0000000005690f41000000000000803f000000000000803f3d04c641c50871bf00000000c669eb40000000000000803f00000000000000008866c641db2257bf00000000ab900241000000000000803f000000000000003f8866c641f13c3dbf00000000736c0f41000000000000803f000000000000803f8866c641cae28ebf00000000e569ec40000000000000803f00000000000000004dc6c64163b46ebf000000001cd40241000000000000803f000000000000003f4dc6c64132a33fbf0000000046730f41000000000000803f000000000000803f4dc6c6413262a4bf00000000f7f5ed40000000000000803f00000000000000002424c741d09f82bf00000000f03b0341000000000000803f000000000000003f2424c741ddba41bf00000000e57c0f41000000000000803f000000000000803f2424c7417acfb8bf000000006c03f040000000000000803f00000000000000008c80c7417e578dbf00000000ccc50341000000000000803f000000000000003f8c80c74104bf43bf00000000e2890f41000000000000803f000000000000803f8c80c741c402ccbf000000007886f240000000000000803f0000000000000000eedbc741657697bf000000004b6f0441000000000000803f000000000000003feedbc7410cd445bf000000005a9b0f41000000000000803f000000000000803feedbc74159dfddbf000000004873f540000000000000803f00000000000000009d36c841b6f1a0bf0000000013360541000000000000803f000000000000003f9d36c841260848bf0000000082b20f41000000000000803f000000000000803f9d36c8418451eebf000000009cbef840000000000000803f0000000000000000d590c8419abea9bf00000000bd170641000000000000803f000000000000003fd590c84160574abf000000002cd00f41000000000000803f000000000000803fd590c841004cfdbf00000000725efc40000000000000803f0000000000000000c2eac84144d2b1bf00000000ec110741000000000000803f000000000000003fc2eac84111b14cbf000000009ff40f41000000000000803f000000000000803fc2eac841966205c0000000000d250041000000000000803f00000000000000008444c941e321b9bf0000000040220841000000000000803f000000000000003f8444c94132fd4ebf00000000731f1041000000000000803f000000000000803f8444c941355a0bc0000000001a3d0241000000000000803f00000000000000002d9ec941a2a2bfbf000000005a460941000000000000803f000000000000003f2d9ec941b42151bf000000009a4f1041000000000000803f000000000000803f2d9ec941068810c00000000037740441000000000000803f0000000000000000cbf7c941b049c5bf00000000d67b0a41000000000000803f000000000000003fcbf7c941a90653bf0000000075831041000000000000803f000000000000803fcbf7c941d9e514c0000000009bc70641000000000000803f00000000000000006951ca413a0ccabf0000000056c00b41000000000000803f000000000000003f6951ca41859954bf0000000011b91041000000000000803f000000000000803f6951ca41a06b18c000000000a6340941000000000000803f000000000000000014abca416fdfcdbf000000007b110d41000000000000803f000000000000003f14abca413dcf55bf0000000050ee1041000000000000803f000000000000803f14abca412a0f1bc00000000099b80b41000000000000803f0000000000000000de04cb417eb8d0bf00000000e26c0e41000000000000803f000000000000003fde04cb414ea556bf000000002b211141000000000000803f000000000000803fde04cb4138c41cc00000000057500e41000000000000803f0000000000000000e35ecb41958cd2bf000000002dd00f41000000000000803f000000000000003fe35ecb41752157bf0000000003501141000000000000803f000000000000803fe35ecb41f07c1dc00000000011f81041000000000000803f00000000000000004cb9cb41e050d3bf00000000fb381141000000000000803f000000000000003f4cb9cb41c04f57bf00000000e5791141000000000000803f000000000000803f4cb9cb41d82a1dc00000000007ab1341000000000000803f00000000000000005314cc4190fad2bf00000000eba41241000000000000803f000000000000003f5314cc41e23e57bf00000000cf9e1141000000000000803f000000000000803f5314cc413ac01bc00000000055631641000000000000803f00000000000000004470cc41d07ed1bf000000009e111441000000000000803f000000000000003f4470cc415afa56bf00000000e7bf1141000000000000803f000000000000803f4470cc41023219c000000000e4191941000000000000803f000000000000000085cdcc41d0d2cebf00000000b37c1541000000000000803f000000000000003f85cdcc41398356bf0000000082df1141000000000000803f000000000000803f85cdcc41ae7915c00000000096c61b41000000000000803f0000000000000000912ccd41beebcabf00000000cae31641000000000000803f000000000000003f912ccd413fc855bf00000000fe001241000000000000803f000000000000803f912ccd41f69610c000000000b2601e41000000000000803f0000000000000000fc8dcd41c6bec5bf0000000082441841000000000000803f000000000000003ffc8dcd413f9f54bf0000000052281241000000000000803f000000000000803ffc8dcd419d900ac00000000080df2041000000000000803f000000000000000070f2cd411a41bfbf000000007c9c1941000000000000803f000000000000003f70f2cd41f3c152bf0000000078591241000000000000803f000000000000803f70f2cd41167403c000000000ff3a2341000000000000803f0000000000000000af5ace41e567b7bf0000000058e91a41000000000000803f000000000000003faf5ace413bcf4fbf00000000b1971241000000000000803f000000000000803faf5ace41cca7f6bf00000000816c2541000000000000803f000000000000000089c7ce415628aebf00000000b4281c41000000000000803f000000000000003f89c7ce41c1514bbf00000000e7e41241000000000000803f000000000000803f89c7ce415f8ae4bf00000000176f2741000000000000803f0000000000000000dc39cf419b77a3bf0000000031581d41000000000000803f000000000000003fdc39cf41aec944bf000000004b411341000000000000803f000000000000803fdc39cf41f9b9d0bf00000000a03f2941000000000000803f000000000000000093b2cf41e24a97bf000000006f751e41000000000000803f000000000000003f93b2cf4196b73bbf000000003eab1341000000000000803f000000000000803f93b2cf41d25bbbbf0000000098dc2a41000000000000803f00000000000000009a32d041599789bf000000000c7e1f41000000000000803f000000000000003f9a32d041c0a52fbf00000000801f1441000000000000803f000000000000803f9a32d041368da4bf00000000bc452c41000000000000803f0000000000000000e1bad04177a474bf00000000aa6f2041000000000000803f000000000000003fe1bad041832e20bf0000000098991441000000000000803f000000000000803fe1bad041
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -1.428297, y: 0, z: 9.055265}
+    m_Extent: {x: 1.0324535, y: 0, z: 1.71176}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1249292391
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 360
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 93
+    localAABB:
+      m_Center: {x: 3.6061394, y: 0, z: 4.7524605}
+      m_Extent: {x: 1.7428272, y: 0, z: 2.9123828}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000030003000400010002000100040004000500020004000300060006000700040005000400070007000800050007000600090009000a000700080007000a000a000b0008000a0009000c000c000d000a000b000a000d000d000e000b000d000c000f000f0010000d000e000d001000100011000e0010000f00120012001300100011001000130013001400110013001200150015001600130014001300160016001700140016001500180018001900160017001600190019001a001700190018001b001b001c0019001a0019001c001c001d001a001c001b001e001e001f001c001d001c001f001f0020001d001f001e002100210022001f0020001f002200220023002000220021002400240025002200230022002500250026002300250024002700270028002500260025002800280029002600280027002a002a002b002800290028002b002b002c0029002b002a002d002d002e002b002c002b002e002e002f002c002e002d003000300031002e002f002e003100310032002f0031003000330033003400310032003100340034003500320034003300360036003700340035003400370037003800350037003600390039003a003700380037003a003a003b0038003a0039003c003c003d003a003b003a003d003d003e003b003d003c003f003f0040003d003e003d004000400041003e0040003f00420042004300400041004000430043004400410043004200450045004600430044004300460046004700440046004500480048004900460047004600490049004a004700490048004b004b004c0049004a0049004c004c004d004a004c004b004e004e004f004c004d004c004f004f0050004d004f004e005100510052004f0050004f005200520053005000520051005400540055005200530052005500550056005300550054005700570058005500560055005800580059005600580057005a005a005b005800590058005b005b005c005900
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 93
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 2976
+    _typelessdata: 750ca640000000006546f540000000000000803f00000000000000000000000009c98c4000000000497aef40000000000000803f000000000000003f000000003a0b6740000000002daee940000000000000803f000000000000803f000000006c14a84000000000b660eb40000000000000803f00000000000000001e400e3ea8928e4000000000c2c4e640000000000000803f000000000000003f1e400e3ec8216a4000000000ce28e240000000000000803f000000000000803f1e400e3ed597a94000000000c2afe140000000000000803f00000000000000006a998b3ecbe48f4000000000d64fde40000000000000803f000000000000003f6a998b3e82636c4000000000eaefda40000000000000803f000000000000803f6a998b3e2d9aaa4000000000a534d840000000000000803f0000000000000000289ecd3e77c49040000000001e1bd640000000000000803f000000000000003f289ecd3e81dd6d40000000009701d440000000000000803f000000000000803f289ecd3e2c1fab4000000000e0f0ce40000000000000803f00000000000000005caf063fbf369140000000004026ce40000000000000803f000000000000003f5caf063fa49c6e4000000000a05bcd40000000000000803f000000000000803f5caf063fbc2aab400000000034e6c540000000000000803f00000000000000002a85253fa940914000000000d370c640000000000000803f000000000000003f2a85253f2dad6e400000000072fbc640000000000000803f000000000000803f2a85253f24c1aa4000000000b116bd40000000000000803f0000000000000000de66433f48e79040000000007dfabe40000000000000803f000000000000003fde66433fd81a6e400000000049dec040000000000000803f000000000000803fde66433fffe6a940000000008584b440000000000000803f0000000000000000dd69603fa12f904000000000d8c2b740000000000000803f000000000000003fdd69603f86f06c40000000002b01bb40000000000000803f000000000000803fdd69603f55a1a84000000000fc31ac40000000000000803f000000000000000005a27c3fc61e8f400000000089c9b040000000000000803f000000000000003f05a27c3f6e386b40000000001661b540000000000000803f000000000000803f05a27c3f92f5a640000000005421a440000000000000803f0000000000000000ed108c3fbfb98d40000000002c0eaa40000000000000803f000000000000003fed108c3fd9fb68400000000004fbaf40000000000000803f000000000000803fed108c3f84e9a44000000000a8549c40000000000000803f0000000000000000197d993f9a058c40000000005e90a340000000000000803f000000000000003f197d993f604366400000000014ccaa40000000000000803f000000000000803f197d993f5583a24000000000e6cd9440000000000000803f0000000000000000009da63f65078a4000000000c44f9d40000000000000803f000000000000003f009da63feb16634000000000a2d1a540000000000000803f000000000000803f009da63f6dc99f4000000000a48e8d40000000000000803f00000000000000004577b33f2ac4874000000000f94b9740000000000000803f000000000000003f4577b33fce7d5f40000000004e09a140000000000000803f000000000000803f4577b33f6cc29c400000000025988640000000000000803f00000000000000008c11c03ff5408540000000009d849140000000000000803f000000000000003f8c11c03ffc7e5b400000000015719c40000000000000803f000000000000803f8c11c03f10759940000000009bd67f40000000000000803f00000000000000008670cc3fd2828240000000004ef98b40000000000000803f000000000000003f8670cc3f28215740000000004f079840000000000000803f000000000000803f8670cc3f21e895400000000044117340000000000000803f0000000000000000e197d83f9e1d7f4000000000aea98640000000000000803f000000000000003fe197d83ffa6a524000000000baca9340000000000000803f000000000000803fe197d83f5b2292400000000093e06640000000000000803f0000000000000000628ae43fecd37840000000005c958140000000000000803f000000000000003f628ae43f23634d40000000006eba8f40000000000000803f000000000000803f628ae43f662a8e400000000029445b40000000000000803f0000000000000000df49f03fab32724000000000ea777940000000000000803f000000000000003fdf49f03f8a10484000000000d5d58b40000000000000803f000000000000803fdf49f03fc2068a40000000001b3b5040000000000000803f000000000000000047d7fb3ff1436b4000000000343a7040000000000000803f000000000000003f47d7fb3f5e7a424000000000a71c8840000000000000803f000000000000803f47d7fb3fc2bd854000000000fdc34540000000000000803f000000000000000059990340d511644000000000d2706740000000000000803f000000000000003f5999034025a83c4000000000d48e8440000000000000803f000000000000803f59990340895581400000000005dd3b40000000000000803f0000000000000000b42d094071a65c4000000000051b5f40000000000000803f000000000000003fb42d0940d0a1364000000000832c8140000000000000803f000000000000803fb42d094000a87940000000001a843240000000000000803f0000000000000000f8a70e40df0b5540000000000c385740000000000000803f000000000000003ff8a70e40be6f304000000000feeb7b40000000000000803f000000000000803ff8a70e40ae7d704000000000eab62940000000000000803f000000000000000012071440344c4d400000000022c74f40000000000000803f000000000000003f12071440ba1a2a40000000005ad77540000000000000803f000000000000803f12071440123767400000000001732140000000000000803f00000000000000009c491940887145400000000087c74840000000000000803f000000000000003f9c491940feab2340000000000d1c7040000000000000803f000000000000803f9c491940aede5d4000000000d6b51940000000000000803f0000000000000000df6d1e40f8853d40000000007c384240000000000000803f000000000000003fdf6d1e40422d1d400000000022bb6a40000000000000803f000000000000803fdf6d1e40887e544000000000cd7c1240000000000000803f0000000000000000e771234099933540000000003c193c40000000000000803f000000000000003fe7712340aaa8164000000000abb56540000000000000803f000000000000803fe771234038204b400000000053c50b40000000000000803f00000000000000007c53284083a42d400000000008693640000000000000803f000000000000003f7c532840ce28104000000000bd0c6140000000000000803f000000000000803f7c532840cfcc414000000000ce8c0540000000000000803f000000000000000030102d40d1c22540000000001c273140000000000000803f000000000000003f30102d40d3b80940000000006ac15c40000000000000803f000000000000803f30102d40cc8c3840000000006fa1ff3f000000000000803f000000000000000062a5314099f81d4000000000ba522c40000000000000803f000000000000003f62a531406664034000000000bcd45840000000000000803f000000000000803f62a5314004682f4000000000101df53f000000800000803f000000000000000046103640f44f1640000000001ceb2740000000800000803f000000000000003f46103640c76ffa3f00000000b0475540000000800000803f000000000000803f461036408165264000000000a887eb3f000000800000803f0000000000000000e34d3a4001d30e400000000088ef2340000000800000803f000000000000003fe34d3a400381ee3f000000003c1b5240000000800000803f000000000000803fe34d3a40
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 3.6061394, y: 0, z: 4.7524605}
+    m_Extent: {x: 1.7428272, y: 0, z: 2.9123828}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1261773098
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 360
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 93
+    localAABB:
+      m_Center: {x: 0.391029, y: 0, z: 7.457205}
+      m_Extent: {x: 1.0821339, y: 0, z: 1.5440176}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000030003000400010002000100040004000500020004000300060006000700040005000400070007000800050007000600090009000a000700080007000a000a000b0008000a0009000c000c000d000a000b000a000d000d000e000b000d000c000f000f0010000d000e000d001000100011000e0010000f00120012001300100011001000130013001400110013001200150015001600130014001300160016001700140016001500180018001900160017001600190019001a001700190018001b001b001c0019001a0019001c001c001d001a001c001b001e001e001f001c001d001c001f001f0020001d001f001e002100210022001f0020001f002200220023002000220021002400240025002200230022002500250026002300250024002700270028002500260025002800280029002600280027002a002a002b002800290028002b002b002c0029002b002a002d002d002e002b002c002b002e002e002f002c002e002d003000300031002e002f002e003100310032002f0031003000330033003400310032003100340034003500320034003300360036003700340035003400370037003800350037003600390039003a003700380037003a003a003b0038003a0039003c003c003d003a003b003a003d003d003e003b003d003c003f003f0040003d003e003d004000400041003e0040003f00420042004300400041004000430043004400410043004200450045004600430044004300460046004700440046004500480048004900460047004600490049004a004700490048004b004b004c0049004a0049004c004c004d004a004c004b004e004e004f004c004d004c004f004f0050004d004f004e005100510052004f0050004f005200520053005000520051005400540055005200530052005500550056005300550054005700570058005500560055005800580059005600580057005a005a005b005800590058005b005b005c005900
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 93
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 2976
+    _typelessdata: 980382be000000002b24e240000000000000803f000000000000000090c8ba41801ea13e0000000080aecf40000000000000803f000000000000003f90c8ba414c20623f00000000d538bd40000000000000803f000000000000803f90c8ba41d42265be00000000662ae340000000000000803f0000000000000000b034bb41922bc63e000000006b24d240000000000000803f000000000000003fb034bb4147747f3f00000000701ec140000000000000803f000000000000803fb034bb4126004dbe00000000f019e440000000000000803f0000000000000000669cbb416daee63e00000000caaad440000000000000803f000000000000003f669cbb413bf78c3f00000000a43bc540000000000000803f000000000000803f669cbb4104a13abe0000000063f1e440000000000000803f00000000000000002c00bc41e360013f00000000903ed740000000000000803f000000000000003f2c00bc4104b5983f00000000bd8bc940000000000000803f000000000000803f2c00bc414c0c2dbe00000000a1b0e540000000000000803f00000000000000007860bc4130400d3f00000000bedcd940000000000000803f000000000000003f7860bc41bae1a23f00000000db08ce40000000000000803f000000000000803f7860bc41305823be000000009858e640000000000000803f0000000000000000b8bdbc417602173f000000004282dc40000000000000803f000000000000003fb8bdbc417c6dab3f00000000ecabd240000000000000803f000000000000803fb8bdbc4180b31cbe0000000041ebe640000000000000803f00000000000000005918bd4119b51e3f00000000222cdf40000000000000803f000000000000003f5918bd41894bb23f00000000036dd740000000000000803f000000000000803f5918bd41706c18be000000002c6be740000000000000803f0000000000000000b970bd417265243f000000004cd7e140000000000000803f000000000000003fb970bd410073b73f000000006c43dc40000000000000803f000000000000803fb970bd4114f415be0000000058dbe740000000000000803f000000000000000034c7bd41e320283f00000000c280e440000000000000803f000000000000003f34c7bd4166dfba3f000000002c26e140000000000000803f000000000000803f34c7bd41a4de14be00000000c73ee840000000000000803f00000000000000001b1cbe41c6f4293f000000007825e740000000000000803f000000000000003f1b1cbe419a90bc3f00000000290ce640000000000000803f000000000000803f1b1cbe4150e014be000000004498e840000000000000803f0000000000000000b96fbe4179ee293f0000000067c2e940000000000000803f000000000000003fb96fbe41838abc3f000000008aecea40000000000000803f000000000000803fb96fbe41c0c715be0000000037eae840000000000000803f000000000000000051c2be415f1b283f000000008e54ec40000000000000803f000000000000003f51c2be4157d4ba3f00000000e5beef40000000000000803f000000000000803f51c2be41f47717be000000007836e940000000000000803f00000000000000001d14bf41d088243f00000000e1d8ee40000000000000803f000000000000003f1d14bf41ce77b73f000000004a7bf440000000000000803f000000000000803f1d14bf4184e119be000000005a7ee940000000000000803f00000000000000005465bf412c441f3f000000005a4cf140000000000000803f000000000000003f5465bf415c80b23f000000005a1af940000000000000803f000000000000803f5465bf417cfd1cbe00000000b4c2e940000000000000803f000000000000000027b6bf41d05a183f00000000f3abf340000000000000803f000000000000003f27b6bf4180faab3f000000003295fd40000000000000803f000000000000803f27b6bf416cc920be00000000fc03ea40000000000000803f0000000000000000c506c0411dda0f3f00000000a7f4f540000000000000803f000000000000003fc506c0414af3a33f00000000a9f20041000000000000803f000000000000803fc506c041104625be000000006542ea40000000000000803f00000000000000005757c0416ccf053f000000006c23f840000000000000803f000000000000003f5757c0412e789a3f0000000039020341000000000000803f000000000000803f5757c0416a772abe000000000c7eea40000000000000803f00000000000000000aa8c0413d90f43e000000003d35fa40000000000000803f000000000000003f0aa8c0410c978f3f0000000037f60441000000000000803f000000000000803f0aa8c041406730be0000000007b7ea40000000000000803f00000000000000000bf9c0411ea3da3e000000001327fc40000000000000803f000000000000003f0bf9c041775e833f000000008fcb0641000000000000803f000000000000803f0bf9c041be2837be000000007dedea40000000000000803f0000000000000000874ac1413bf2bd3e00000000e6f5fd40000000000000803f000000000000003f874ac1416abc6b3f00000000287f0841000000000000803f000000000000803f874ac1414cdd3ebe00000000a721eb40000000000000803f0000000000000000b19cc14152989e3e00000000b29eff40000000000000803f000000000000003fb19cc141a54f4e3f00000000df0d0a41000000000000803f000000000000803fb19cc141dab847be00000000ba53eb40000000000000803f0000000000000000c1efc1413660793e00000000388f0041000000000000803f000000000000003fc1efc141529e2e3f0000000093740b41000000000000803f000000000000803fc1efc141620652be00000000c683eb40000000000000803f0000000000000000f643c241a4a8303e000000000b390141000000000000803f000000000000003ff643c241ead50c3f0000000033b00c41000000000000803f000000000000803ff643c241a5295ebe000000008ab1eb40000000000000803f00000000000000009299c241d27ec63d000000004fcb0141000000000000803f000000000000003f9299c2413c54d23e00000000d9bd0d41000000000000803f000000000000803f9299c241f39d6cbe0000000036dceb40000000000000803f0000000000000000e5f0c241a0cf8a3c0000000083440241000000000000803f000000000000003fe5f0c241eea8873e00000000eb9a0e41000000000000803f000000000000803fe5f0c24151f47dbe000000002102ec40000000000000803f0000000000000000414ac3416ea489bd0000000020a30241000000000000803f000000000000003f414ac341c69fe83d000000002f450f41000000000000803f000000000000803f414ac341726589be00000000b020ec40000000000000803f000000000000000004a6c341a90f1fbe00000000a6e50241000000000000803f000000000000003f04a6c341b8512dbd00000000f4ba0f41000000000000803f000000000000803f04a6c341a9e295be000000001534ec40000000000000803f00000000000000009004c441e8287dbe000000008f0a0341000000000000803f000000000000003f9004c4417e8c4ebe0000000013fb0f41000000000000803f000000000000803f9004c4416ac0a4be000000006437ec40000000800000803f00000000000000005366c4414074afbe000000005a100341000000800000803f000000000000003f5366c4411628babe0000000002051041000000800000803f000000000000803f5366c4419845b6be000000009124ec40000000800000803f0000000000000000bccbc4417a0ce2be0000000082f50241000000800000803f000000000000003fbccbc441aee906bf00000000bbd80f41000000800000803f000000000000803fbccbc441fdabcabe00000000a7f4eb40000000800000803f00000000000000004335c5411f210bbf0000000084b80241000000800000803f000000000000003f4335c54140ec30bf00000000b4760f41000000800000803f000000000000803f4335c541
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0.391029, y: 0, z: 7.457205}
+    m_Extent: {x: 1.0821339, y: 0, z: 1.5440176}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1388365132
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 360
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 93
+    localAABB:
+      m_Center: {x: -2.4059653, y: 0, z: 0.66727567}
+      m_Extent: {x: 5.0059104, y: 0, z: 2.6156366}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000030003000400010002000100040004000500020004000300060006000700040005000400070007000800050007000600090009000a000700080007000a000a000b0008000a0009000c000c000d000a000b000a000d000d000e000b000d000c000f000f0010000d000e000d001000100011000e0010000f00120012001300100011001000130013001400110013001200150015001600130014001300160016001700140016001500180018001900160017001600190019001a001700190018001b001b001c0019001a0019001c001c001d001a001c001b001e001e001f001c001d001c001f001f0020001d001f001e002100210022001f0020001f002200220023002000220021002400240025002200230022002500250026002300250024002700270028002500260025002800280029002600280027002a002a002b002800290028002b002b002c0029002b002a002d002d002e002b002c002b002e002e002f002c002e002d003000300031002e002f002e003100310032002f0031003000330033003400310032003100340034003500320034003300360036003700340035003400370037003800350037003600390039003a003700380037003a003a003b0038003a0039003c003c003d003a003b003a003d003d003e003b003d003c003f003f0040003d003e003d004000400041003e0040003f00420042004300400041004000430043004400410043004200450045004600430044004300460046004700440046004500480048004900460047004600490049004a004700490048004b004b004c0049004a0049004c004c004d004a004c004b004e004e004f004c004d004c004f004f0050004d004f004e005100510052004f0050004f005200520053005000520051005400540055005200530052005500550056005300550054005700570058005500560055005800580059005600580057005a005a005b005800590058005b005b005c005900
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 93
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 2976
+    _typelessdata: 8165264000000000a887eb3f000000800000803f0000000000000000e34d3a4001d30e400000000088ef2340000000800000803f000000000000003fe34d3a400381ee3f000000003c1b5240000000800000803f000000000000803fe34d3a40f2b31c400000000044fbe13f000000800000803f00000000000000006f093f40075506400000000063c11f40000000800000803f000000000000003f6f093f4037ecdf3f0000000024854e40000000800000803f000000000000803f6f093f403a5a114000000000425dd73f000000800000803f0000000000000000a7e344406e75f73f0000000015cc1a40000000800000803f000000000000003fa7e344406836cc3f0000000089e94940000000800000803f000000000000803fa7e344408e44044000000000f089cb3f000000800000803f00000000000000009ac94b404c50de3f00000000bc1d1540000000800000803f000000000000003f9ac94b407c17b43f0000000080764440000000800000803f000000000000803f9ac94b40edfbea3f00000000e482be3f000000800000803f00000000000000001fa85340e282c13f0000000082c40e40000000800000803f000000000000003f1fa85340d709983f0000000092473e40000000800000803f000000000000803f1fa853402c3bca3f000000003657b03f000000800000803f0000000000000000fd6b5c405455a13f0000000087ce0740000000800000803f000000000000003ffd6b5c40f8de703f0000000073713740000000800000803f000000000000803ffd6b5c406380a63f00000000061ca13f000000800000803f0000000000000000e7016640bf1f7c3f00000000f3490040000000800000803f000000000000003fe7016640b83e2b3f00000000e3053040000000800000803f000000000000803fe7016640c40a803f0000000050e9903f000000800000803f00000000000000008f56704051f52f3f00000000cd89f03f000000800000803f000000000000003f8f56704032aabf3e0000000025152840000000800000803f000000000000803f8f56704067392e3f0000000064b17f3f000000800000803f00000000000000009c567b409c77bd3e00000000179bdf3f000000800000803f000000000000003f9c567b4050e3733d00000000beae1f40000000800000803f000000000000803f9c567b40d4e9af3e000000003f095c3f000000800000803f00000000000000005b7783404439103d0000000003e4cd3f000000800000803f000000000000003f5b77834084db8bbe00000000b3e11640000000800000803f000000000000803f5b778340804a0bbc000000004b10373f000000800000803f0000000000000000c28589400646a1be00000000dd80bb3f000000800000803f000000000000003fc2858940dc181fbf00000000cabc0d40000000800000803f000000000000803fc2858940de40bfbe000000005afd103f000000800000803f0000000000000000d2cc8f4087a72dbf00000000f48da83f000000800000803f000000000000003fd2cc8f409fae7bbf000000009e4e0440000000800000803f000000000000803fd2cc8f40add73fbf000000002a0fd43e000000800000803f0000000000000000e0429640d6bc86bf000000008a27953f000000800000803f000000000000003fe0429640d68dadbf000000004a4bf53f000000800000803f000000000000803fe0429640742291bf000000000acd843e000000800000803f00000000000000003bde9c4082c4b7bf00000000e969813f000000800000803f000000000000003f3bde9c409066debf0000000090a0e13f000000800000803f000000000000803f3bde9c40db2cc3bf00000000308fd23d000000800000803f00000000000000003495a34096a2e9bf00000000b3e25a3f000000800000803f000000000000003f3495a340280c08c000000000c0b9cd3f000000800000803f000000000000803f3495a340b8c3f5bf00000000e0e55fbd000000800000803f00000000000000001a5eaa4074070ec00000000054b4323f000000800000803f000000000000003f1a5eaa400c2d21c00000000083b3b93f000000800000803f000000000000803f1a5eaa40c84f14c000000000844959be000000800000803f0000000000000000402fb140a26027c0000000003b810a3f000000800000803f000000000000003f402fb1407c713ac0000000006caaa53f000000800000803f000000000000803f402fb14076bc2dc00000000030e4bcbe000000800000803f0000000000000000f4feb740bcb840c000000000f803c53e000000800000803f000000000000003ff4feb74002b553c00000000008bb913f000000800000803f000000000000803ff4feb740280447c0000000007e2506bf000000800000803f000000000000000088c3be40aeeb59c000000000b0bc6b3e000000800000803f000000000000003f88c3be4034d36cc000000000d6037c3f000000800000803f000000000000803f88c3be401e0360c0000000008f342dbf000000800000803f00000000000000004c73c5405ad572c000000000e80aa03d000000800000803f000000000000003f4c73c540cbd382c0000000004937553f000000800000803f000000000000803f4c73c540a89578c000000000546753bf000000800000803f00000000000000008e04cc40d6a885c000000000f47690bd000000800000803f000000000000003f8e04cc40d8068fc00000000096492f3f000000800000803f000000000000803f8e04cc40104c88c000000000ed8578bf000000800000803f0000000000000000a06dd240449e91c000000000d4235cbe000000800000803f000000000000003fa06dd24078f09ac00000000003740a3f000000800000803f000000000000803fa06dd24081f393c0000000004a2c8ebf000000800000803f0000000000000000d4a4d840ed389dc000000000aa68b5be000000800000803f000000000000003fd4a4d840597ea6c000000000d6dfcd3e000000800000803f000000000000803fd4a4d840742f9fc000000000e4539fbf000000800000803f000000000000000076a0de40c266a8c000000000d8b0f9be000000800000803f000000000000003f76a0de40109eb1c000000000e0ed893e000000800000803f000000000000803f76a0de405aeea9c000000000259eafbf000000800000803f0000000000000000de56e440bb15b3c000000000a83c1dbf000000800000803f000000000000003fde56e4401c3dbcc000000000e80b133e000000800000803f000000000000803fde56e440c71eb4c000000000adefbebf000000800000803f000000000000000058bee940c833bdc00000000077a83bbf000000800000803f000000000000003f58bee940c948c6c00000000080cdd13c000000800000803f000000000000803f58bee940a1afbdc000000000772dcdbf000000800000803f000000000000000038cdee40e0aec6c00000000046e357bf000000800000803f000000000000003f38cdee401faecfc000000000f05cabbd000000800000803f000000000000803f38cdee403e90c6c0000000001c3ddabf000000800000803f0000000000000000d279f340f474cfc00000000084b471bf000000800000803f000000000000003fd279f340aa59d8c0000000003cbb3bbe000000800000803f000000000000803fd279f340c6b0cec0000000003605e6bf000000800000803f00000000000000007abaf740fb73d7c000000000cf7184bf000000800000803f000000000000003f7abaf7403037e0c000000000a2798bbe000000800000803f000000000000803f7abaf740dd02d6c0000000002c6ef0bf000000800000803f00000000000000008a85fb40e699dec000000000019c8ebf000000800000803f000000000000003f8a85fb40ef30e7c0000000005827b3be000000800000803f000000000000803f8a85fb40367bdcc000000000e463f9bf000000800000803f00000000000000005ad1fe40a6d4e4c0000000008a3c97bf000000800000803f000000000000003f5ad1fe40162eedc000000000be54d4be000000800000803f000000000000803f5ad1fe40
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -2.4059653, y: 0, z: 0.66727567}
+    m_Extent: {x: 5.0059104, y: 0, z: 2.6156366}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1452596140
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 540
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 124
+    localAABB:
+      m_Center: {x: -7.429123, y: 0.095, z: 5.593294}
+      m_Extent: {x: 1.4274957, y: 0.105000004, z: 2.603608}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 124
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 3968
+    _typelessdata: b6b40dc10ad723bceb583f40a1fb7fbf000000008c443d3c00000000eaf82d41b6b40dc1cdcc4c3eeb583f40a1fb7fbf000000008c443d3c0000003feaf82d41c18b0dc1cdcc4c3e06573f40a1fb7f3f000000008c443dbc0000003feaf82d41c18b0dc10ad723bc06573f40a1fb7f3f000000008c443dbc0000803feaf82d415e910dc10ad723bc97565040e1a27fbf0000000010475a3d00000000555d30415e910dc1cdcc4c3e97565040e1a27fbf0000000010475a3d0000003f555d304177680dc1cdcc4c3edc4d5040e1a27f3f0000000010475abd0000003f555d304177680dc10ad723bcdc4d5040e1a27f3f0000000010475abd0000803f555d3041be410dc10ad723bc162c6140e9dd7ebf00000000827bc03d0000000058bc3241be410dc1cdcc4c3e162c6140e9dd7ebf00000000827bc03d0000003f58bc3241f7180dc1cdcc4c3eb01c6140e9dd7e3f00000000827bc0bd0000003f58bc3241f7180dc10ad723bcb01c6140e9dd7e3f00000000827bc0bd0000803f58bc324193c70cc10ad723bca5d371408fb47dbf0000000083cc083e000000001816354193c70cc1cdcc4c3ea5d371408fb47dbf0000000083cc083e0000003f18163541fc9e0cc1cdcc4c3ec2bd71408fb47d3f0000000083cc08be0000003f18163541fc9e0cc10ad723bcc2bd71408fb47d3f0000000083cc08be0000803f18163541a8240cc10ad723bca32381404a2e7cbf000000004238303e00000000a36a3741a8240cc1cdcc4c3ea32381404a2e7cbf000000004238303e0000003fa36a37414ffc0bc1cdcc4c3e8a1581404a2e7c3f00000000423830be0000003fa36a37414ffc0bc10ad723bc8a1581404a2e7c3f00000000423830be0000803fa36a3741c35a0bc10ad723bc4b408940fc517abf000000003c81563e00000000edb93941c35a0bc1cdcc4c3e4b408940fc517abf000000003c81563e0000003fedb93941b5320bc1cdcc4c3e222f8940fc517a3f000000003c8156be0000003fedb93941b5320bc10ad723bc222f8940fc517a3f000000003c8156be0000803fedb93941bd6b0ac10ad723bc8c3c9140d42578bf000000001eac7b3e00000000d9033c41bd6b0ac1cdcc4c3e8c3c9140d42578bf000000001eac7b3e0000003fd9033c4109440ac1cdcc4c3e6a289140d425783f000000001eac7bbe0000003fd9033c4109440ac10ad723bc6a289140d425783f000000001eac7bbe0000803fd9033c41785909c10ad723bcf81499401caf75bf0000000049e18f3e0000000033483e41785909c1cdcc4c3ef81499401caf75bf0000000049e18f3e0000003f33483e41283209c1cdcc4c3ef3fd98401caf753f0000000049e18fbe0000003f33483e41283209c10ad723bcf3fd98401caf753f0000000049e18fbe0000803f33483e41e02508c10ad723bc1dc6a04036f272bf000000009568a13e00000000b7864041e02508c1cdcc4c3e1dc6a04036f272bf000000009568a13e0000003fb786404101ff07c1cdcc4c3e49aca04036f2723f000000009568a1be0000003fb786404101ff07c10ad723bc49aca04036f2723f000000009568a1be0000803fb7864041edd206c10ad723bc634ca84078f26fbf00000000fa73b23e000000000ebf4241edd206c1cdcc4c3e634ca84078f26fbf00000000fa73b23e0000003f0ebf424189ac06c1cdcc4c3ed62fa84078f26f3f00000000fa73b2be0000003f0ebf424189ac06c10ad723bcd62fa84078f26f3f00000000fa73b2be0000803f0ebf4241aa6205c10ad723bc32a4af401eb26cbf00000000c60cc33e00000000d5f04441aa6205c1cdcc4c3e32a4af401eb26cbf00000000c60cc33e0000003fd5f04441cb3c05c1cdcc4c3efc84af401eb26c3f00000000c60cc3be0000003fd5f04441cb3c05c10ad723bcfc84af401eb26c3f00000000c60cc3be0000803fd5f044412ed703c10ad723bcdac9b6403e3269bf000000003e3dd33e00000000991b47412ed703c1cdcc4c3edac9b6403e3269bf000000003e3dd33e0000003f991b4741dfb103c1cdcc4c3e0ea8b6403e32693f000000003e3dd3be0000003f991b4741dfb103c10ad723bc0ea8b6403e32693f000000003e3dd3be0000803f991b4741a03202c10ad723bca2b9bd40ac7265bf00000000ad10e33e00000000dd3e4941a03202c1cdcc4c3ea2b9bd40ac7265bf00000000ad10e33e0000003fdd3e4941ea0d02c1cdcc4c3e4d95bd40ac72653f00000000ad10e3be0000003fdd3e4941ea0d02c10ad723bc4d95bd40ac72653f00000000ad10e3be0000803fdd3e4941377700c10ad723bcca6fc440ee7161bf00000000f092f23e00000000185a4b41377700c1cdcc4c3eca6fc440ee7161bf00000000f092f23e0000003f185a4b41245300c1cdcc4c3efa48c440ee71613f00000000f092f2be0000003f185a4b41245300c10ad723bcfa48c440ee71613f00000000f092f2be0000803f185a4b41764efdc00ad723bc86e8ca40162d5dbf000000004ee8003f00000000ba6c4d41764efdc0cdcc4c3e86e8ca40162d5dbf000000004ee8003f0000003fba6c4d41b007fdc0cdcc4c3e46bfca40162d5d3f000000004ee800bf0000003fba6c4d41b007fdc00ad723bc46bfca40162d5d3f000000004ee800bf0000803fba6c4d411e8af9c00ad723bc0a20d1409d9f58bf00000000606b083f000000002a764f411e8af9c0cdcc4c3e0a20d1409d9f58bf00000000606b083f0000003f2a764f41cc44f9c0cdcc4c3e62f4d0409d9f583f00000000606b08bf0000003f2a764f41cc44f9c00ad723bc62f4d0409d9f583f00000000606b08bf0000803f2a764f414ca6f5c00ad723bc8112d74040c353bf000000005ed90f3f00000000ca7551414ca6f5c0cdcc4c3e8112d74040c353bf000000005ed90f3f0000003fca7551418862f5c0cdcc4c3e78e4d64040c3533f000000005ed90fbf0000003fca7551418862f5c00ad723bc78e4d64040c3533f000000005ed90fbf0000803fca7551411ea8f1c00ad723bc10bcdc40b58f4ebf000000001939173f00000000f96a53411ea8f1c0cdcc4c3e10bcdc40b58f4ebf000000001939173f0000003ff96a53410466f1c0cdcc4c3eac8bdc40b58f4e3f00000000193917bf0000003ff96a53410466f1c00ad723bcac8bdc40b58f4e3f00000000193917bf0000803ff96a5341ec94edc00ad723bce318e24063fa48bf000000006a911e3f0000000012555541ec94edc0cdcc4c3ee318e24063fa48bf000000006a911e3f0000003f125555419c54edc0cdcc4c3e25e6e14063fa483f000000006a911ebf0000003f125555419c54edc00ad723bc25e6e14063fa483f000000006a911ebf0000803f125555415772e9c00ad723bc2125e740f2f542bf000000001ae9253f00000000723357415772e9c0cdcc4c3e2125e740f2f542bf000000001ae9253f0000003f72335741f433e9c0cdcc4c3e09f0e640f2f5423f000000001ae925bf0000003f72335741f433e9c00ad723bc09f0e640f2f5423f000000001ae925bf0000803f723357415046e5c00ad723bcfcdceb40e0713cbf00000000a4462d3f00000000770559415046e5c0cdcc4c3efcdceb40e0713cbf00000000a4462d3f0000003f77055941030ae5c0cdcc4c3e89a5eb40e0713c3f00000000a4462dbf0000003f77055941030ae5c00ad723bc89a5eb40e0713c3f00000000a4462dbf0000803f770559412b17e1c00ad723bcb33cf040c85935bf00000000f6af343f0000000084ca5a412b17e1c0cdcc4c3eb33cf040c85935bf00000000f6af343f0000003f84ca5a4123dde0c0cdcc4c3ee202f040c859353f00000000f6af34bf0000003f84ca5a4123dde0c00ad723bce202f040c859353f00000000f6af34bf0000803f84ca5a41adebdcc00ad723bca640f440c0942dbf00000000f0293c3f0000000004825c41adebdcc0cdcc4c3ea640f440c0942dbf00000000f0293c3f0000003f04825c4122b4dcc0cdcc4c3e6f04f440c0942d3f00000000f0293cbf0000003f04825c4122b4dcc00ad723bc6f04f440c0942d3f00000000f0293cbf0000803f04825c412ccbd8c00ad723bc51e5f740570425bf00000000b9b7433f000000006b2b5e412ccbd8c0cdcc4c3e51e5f740570425bf00000000b9b7433f0000003f6b2b5e415e96d8c0cdcc4c3eb0a6f7405704253f00000000b9b743bf0000003f6b2b5e415e96d8c00ad723bcb0a6f7405704253f00000000b9b743bf0000803f6b2b5e41a6bdd4c00ad723bc8827fb408c831bbf00000000be594b3f0000000041c65f41a6bdd4c0cdcc4c3e8827fb408c831bbf00000000be594b3f0000003f41c65f41e38bd4c0cdcc4c3e75e6fa408c831b3f00000000be594bbf0000003f41c65f41e38bd4c00ad723bc75e6fa408c831b3f00000000be594bbf0000803f41c65f41dccbd0c00ad723bc8604fe40bce510bf00000000fa0b533f000000001e526141dccbd0c0cdcc4c3e8604fe40bce510bf00000000fa0b533f0000003f1e5261417e9dd0c0cdcc4c3efdc0fd40bce5103f00000000fa0b53bf0000003f1e5261417e9dd0c00ad723bcfdc0fd40bce5103f00000000fa0b53bf0000803f1e5261416bffccc00ad723bc1c3d004188f504bf00000000b2c35a3f00000000bace62416bffccc0cdcc4c3e1c3d004188f504bf00000000b2c35a3f0000003fbace6241dfd4ccc0cdcc4c3e1b1a004188f5043f00000000b2c35abf0000003fbace6241dfd4ccc00ad723bc1b1a004188f5043f00000000b2c35abf0000803fbace6241e862c9c00ad723bcc44301414ee8eebe00000000f86b623f00000000ec3b6441e862c9c0cdcc4c3ec44301414ee8eebe00000000f86b623f0000003fec3b6441ae3cc9c0cdcc4c3e8a1f01414ee8ee3e00000000f86b62bf0000003fec3b6441ae3cc9c00ad723bc8a1f01414ee8ee3e00000000f86b62bf0000803fec3b6441cf01c6c00ad723bc741602410833d0be00000000f5e0693f00000000bb996541cf01c6c0cdcc4c3e741602410833d0be00000000f5e0693f0000003fbb99654180e0c5c0cdcc4c3e08f101410833d03e00000000f5e069bf0000003fbb99654180e0c5c00ad723bc08f101410833d03e00000000f5e069bf0000803fbb9965414be8c2c00ad723bc74b60241a42dadbe0000000055e9703f0000000067e866414be8c2c0cdcc4c3e74b60241a42dadbe0000000055e9703f0000003f67e8664196ccc2c0cdcc4c3ee98f0241a42dad3e0000000055e970bf0000003f67e8664196ccc2c00ad723bce98f0241a42dad3e0000000055e970bf0000803f67e86641a622c0c00ad723bc83260341b03885be00000000a12e773f0000000076286841a622c0c0cdcc4c3e83260341b03885be00000000a12e773f0000003f76286841550dc0c0cdcc4c3ef6fe0241b038853e00000000a12e77bf0000003f76286841550dc0c00ad723bcf6fe0241b038853e00000000a12e77bf0000803f76286841
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -7.429123, y: 0.095, z: 5.593294}
+    m_Extent: {x: 1.4274957, y: 0.105000004, z: 2.603608}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1522571220
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 540
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 124
+    localAABB:
+      m_Center: {x: -2.9276567, y: 0.095, z: 4.9479437}
+      m_Extent: {x: 2.6807432, y: 0.105000004, z: 2.118971}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 124
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 3968
+    _typelessdata: 0378b3c00ad723bc76913540d48e18bf00000000d4934d3f0000000026079f410378b3c0cdcc4c3e76913540d48e18bf00000000d4934d3f0000003f26079f413247b3c0cdcc4c3ee40d3540d48e183f00000000d4934dbf0000003f26079f413247b3c00ad723bce40d3540d48e183f00000000d4934dbf0000803f26079f411769afc00ad723bcb09b3b400a1319bf0000000074314d3f000000001cab9f411769afc0cdcc4c3eb09b3b400a1319bf0000000074314d3f0000003f1cab9f411b38afc0cdcc4c3e5d183b400a13193f0000000074314dbf0000003f1cab9f411b38afc00ad723bc5d183b400a13193f0000000074314dbf0000803f1cab9f410be6aac00ad723bcf25a42407e8019bf00000000a0df4c3f000000001e61a0410be6aac0cdcc4c3ef25a42407e8019bf00000000a0df4c3f0000003f1e61a041ecb4aac0cdcc4c3ed4d741407e80193f00000000a0df4cbf0000003f1e61a041ecb4aac00ad723bcd4d741407e80193f00000000a0df4cbf0000803f1e61a041a9f8a5c00ad723bccec0494022df19bf0000000095984c3f00000000c627a141a9f8a5c0cdcc4c3ecec0494022df19bf0000000095984c3f0000003fc627a1416cc7a5c0cdcc4c3edd3d494022df193f0000000095984cbf0000003fc627a1416cc7a5c00ad723bcdd3d494022df193f0000000095984cbf0000803fc627a14178aaa0c00ad723bc4abf514007341abf000000009f584c3f00000000affda14178aaa0c0cdcc4c3e4abf514007341abf000000009f584c3f0000003faffda1411f79a0c0cdcc4c3e823c514007341a3f000000009f584cbf0000003faffda1411f79a0c00ad723bc823c514007341a3f000000009f584cbf0000803faffda141c2049bc00ad723bca9485a4074821abf000000005a1d4c3f0000000073e1a241c2049bc0cdcc4c3ea9485a4074821abf000000005a1d4c3f0000003f73e1a24151d39ac0cdcc4c3e07c6594074821a3f000000005a1d4cbf0000003f73e1a24151d39ac00ad723bc07c6594074821a3f000000005a1d4cbf0000803f73e1a241ce1095c00ad723bc544f6340d7cc1abf00000000f6e44b3f00000000aed1a341ce1095c0cdcc4c3e544f6340d7cc1abf00000000f6e44b3f0000003faed1a34144df94c0cdcc4c3ed6cc6240d7cc1a3f00000000f6e44bbf0000003faed1a34144df94c00ad723bcd6cc6240d7cc1a3f00000000f6e44bbf0000803faed1a341c1d78ec00ad723bcc7c56c40e6141bbf000000002cae4b3f00000000facca441c1d78ec0cdcc4c3ec7c56c40e6141bbf000000002cae4b3f0000003ffacca44121a68ec0cdcc4c3e6c436c40e6141b3f000000002cae4bbf0000003ffacca44121a68ec00ad723bc6c436c40e6141b3f000000002cae4bbf0000803ffacca441c26288c00ad723bc8c9e7640165c1bbf00000000e4774b3f00000000f3d1a541c26288c0cdcc4c3e8c9e7640165c1bbf00000000e4774b3f0000003ff3d1a5410b3188c0cdcc4c3e541c7640165c1b3f00000000e4774bbf0000003ff3d1a5410b3188c00ad723bc541c7640165c1b3f00000000e4774bbf0000803ff3d1a541ebba81c00ad723bc1c6680408fa31bbf000000003f414b3f0000000032dfa641ebba81c0cdcc4c3e1c6680408fa31bbf000000003f414b3f0000003f32dfa6411d8981c0cdcc4c3e112580408fa31b3f000000003f414bbf0000003f32dfa6411d8981c00ad723bc112580408fa31b3f000000003f414bbf0000803f32dfa641aed275c00ad723bcb0a085405aec1bbf000000006c094b3f0000000052f3a741aed275c0cdcc4c3eb0a085405aec1bbf000000006c094b3f0000003f52f3a741e36e75c0cdcc4c3eb75f85405aec1b3f000000006c094bbf0000003f52f3a741e36e75c00ad723bcb75f85405aec1b3f000000006c094bbf0000803f52f3a7413dee67c00ad723bc52f88a4072371cbf00000000aacf4a3f00000000f00ca9413dee67c0cdcc4c3e52f88a4072371cbf00000000aacf4a3f0000003ff00ca941438a67c0cdcc4c3e6cb78a4072371c3f00000000aacf4abf0000003ff00ca941438a67c00ad723bc6cb78a4072371c3f00000000aacf4abf0000803ff00ca941b2da59c00ad723bc4f669040ce851cbf0000000037934a3f00000000a42aaa41b2da59c0cdcc4c3e4f669040ce851cbf0000000037934a3f0000003fa42aaa41857659c0cdcc4c3e7c259040ce851c3f0000000037934abf0000003fa42aaa41857659c00ad723bc7c259040ce851c3f0000000037934abf0000803fa42aaa4136aa4bc00ad723bcf3e395406ad81cbf0000000048534a3f000000000b4bab4136aa4bc0cdcc4c3ef3e395406ad81cbf0000000048534a3f0000003f0b4bab41d5454bc0cdcc4c3e34a395406ad81c3f0000000048534abf0000003f0b4bab41d5454bc00ad723bc34a395406ad81c3f0000000048534abf0000803f0b4bab41066f3dc00ad723bc856a9b4064301dbf00000000f50e4a3f00000000bf6cac41066f3dc0cdcc4c3e856a9b4064301dbf00000000f50e4a3f0000003fbf6cac416c0a3dc0cdcc4c3edc299b4064301d3f00000000f50e4abf0000003fbf6cac416c0a3dc00ad723bcdc299b4064301d3f00000000f50e4abf0000803fbf6cac415c3b2fc00ad723bc51f3a040ea8e1dbf0000000049c5493f000000005b8ead415c3b2fc0cdcc4c3e51f3a040ea8e1dbf0000000049c5493f0000003f5b8ead4186d62ec0cdcc4c3ec0b2a040ea8e1d3f0000000049c549bf0000003f5b8ead4186d62ec00ad723bcc0b2a040ea8e1d3f0000000049c549bf0000803f5b8ead417c2121c00ad723bc9877a6406cf51dbf000000001375493f000000007aaeae417c2121c0cdcc4c3e9877a6406cf51dbf000000001375493f0000003f7aaeae4164bc20c0cdcc4c3e2137a6406cf51d3f00000000137549bf0000003f7aaeae4164bc20c00ad723bc2137a6406cf51d3f00000000137549bf0000803f7aaeae41ba3313c00ad723bc97f0ab408c651ebf00000000f71c493f00000000b8cbaf41ba3313c0cdcc4c3e97f0ab408c651ebf00000000f71c493f0000003fb8cbaf415ace12c0cdcc4c3e3cb0ab408c651e3f00000000f71c49bf0000003fb8cbaf415ace12c00ad723bc3cb0ab408c651e3f00000000f71c49bf0000803fb8cbaf417a8405c00ad723bc8557b1404de11ebf0000000042bb483f00000000aee4b0417a8405c0cdcc4c3e8557b1404de11ebf0000000042bb483f0000003faee4b041cc1e05c0cdcc4c3e4917b1404de11e3f0000000042bb48bf0000003faee4b041cc1e05c00ad723bc4917b1404de11e3f0000000042bb48bf0000803faee4b041764cf0bf0ad723bc8aa5b6402a6b1fbf00000000d64d483f00000000f9f7b141764cf0bfcdcc4c3e8aa5b6402a6b1fbf00000000d64d483f0000003ff9f7b1416880efbfcdcc4c3e7165b6402a6b1f3f00000000d64d48bf0000003ff9f7b1416880efbf0ad723bc7165b6402a6b1f3f00000000d64d48bf0000803ff9f7b1413457d6bf0ad723bcc1d3bb403f0620bf0000000006d2473f000000003404b3413457d6bfcdcc4c3ec1d3bb403f0620bf0000000006d2473f0000003f3404b341608ad5bfcdcc4c3ed093bb403f06203f0000000006d247bf0000003f3404b341608ad5bf0ad723bcd093bb403f06203f0000000006d247bf0000803f3404b341c74ebdbf0ad723bc34dbc0408cb620bf000000005644473f00000000fb07b441c74ebdbfcdcc4c3e34dbc0408cb620bf000000005644473f0000003ffb07b4411081bcbfcdcc4c3e709bc0408cb6203f00000000564447bf0000003ffb07b4411081bcbf0ad723bc709bc0408cb6203f00000000564447bf0000803ffb07b4414a59a5bf0ad723bcc9b4c5404f8121bf0000000023a0463f00000000e801b5414a59a5bfcdcc4c3ec9b4c5404f8121bf0000000023a0463f0000003fe801b541908aa4bfcdcc4c3e3975c5404f81213f0000000023a046bf0000003fe801b541908aa4bf0ad723bc3975c5404f81213f0000000023a046bf0000803fe801b5418a9d8ebf0ad723bc3d59ca408a6d22bf0000000023df453f0000000099f0b5418a9d8ebfcdcc4c3e3d59ca408a6d22bf0000000023df453f0000003f99f0b541a2cd8dbfcdcc4c3eec19ca408a6d223f0000000023df45bf0000003f99f0b541a2cd8dbf0ad723bcec19ca408a6d223f0000000023df45bf0000803f99f0b541c88672bf0ad723bc13c1ce40d18423bf0000000097f8443f00000000a9d2b641c88672bfcdcc4c3e13c1ce40d18423bf0000000097f8443f0000003fa9d2b6412ce470bfcdcc4c3e0c82ce40d184233f0000000097f844bf0000003fa9d2b6412ce470bf0ad723bc0c82ce40d184233f0000000097f844bf0000803fa9d2b641a8e84abf0ad723bc60e4d240c0d424bf00000000cfdf433f00000000b6a6b741a8e84abfcdcc4c3e60e4d240c0d424bf00000000cfdf433f0000003fb6a6b741b14249bfcdcc4c3eb2a5d240c0d4243f00000000cfdf43bf0000003fb6a6b741b14249bf0ad723bcb2a5d240c0d4243f00000000cfdf43bf0000803fb6a6b741b0b826bf0ad723bc9abad640207126bf00000000e081423f000000005d6bb841b0b826bfcdcc4c3e9abad640207126bf00000000e081423f0000003f5d6bb841980e25bfcdcc4c3e5c7cd6402071263f00000000e08142bf0000003f5d6bb841980e25bf0ad723bc5c7cd6402071263f00000000e08142bf0000803f5d6bb841395706bf0ad723bc223ada40117828bf0000000015c1403f000000003e1fb941395706bfcdcc4c3e223ada40117828bf0000000015c1403f0000003f3e1fb941f1a704bfcdcc4c3e73fcd9401178283f0000000015c140bf0000003f3e1fb941f1a704bf0ad723bc73fcd9401178283f0000000015c140bf0000803f3e1fb9412a66d4be0ad723bc5c57dd4092192bbf000000003b6c3e3f00000000f8c0b9412a66d4becdcc4c3e5c57dd4092192bbf000000003b6c3e3f0000003ff8c0b94122fad0becdcc4c3e6d1add4092192b3f000000003b6c3ebf0000003ff8c0b94122fad0be0ad723bc6d1add4092192b3f000000003b6c3ebf0000803ff8c0b94182aca5be0ad723bcc302e04024a72ebf000000005c2b3b3f00000000304fba4182aca5becdcc4c3ec302e04024a72ebf000000005c2b3b3f0000003f304fba41482ea2becdcc4c3edec6df4024a72e3f000000005c2b3bbf0000003f304fba41482ea2be0ad723bcdec6df4024a72e3f000000005c2b3bbf0000803f304fba41980382be0ad723bc2b24e2403ab633bf000000004651363f0000000090c8ba41980382becdcc4c3e2b24e2403ab633bf000000004651363f0000003f90c8ba41f0d67cbecdcc4c3ed4e9e1403ab6333f00000000465136bf0000003f90c8ba41f0d67cbe0ad723bcd4e9e1403ab6333f00000000465136bf0000803f90c8ba41
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -2.9276567, y: 0.095, z: 4.9479437}
+    m_Extent: {x: 2.6807432, y: 0.105000004, z: 2.118971}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1547881846
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 540
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 124
+    localAABB:
+      m_Center: {x: -1.8828241, y: 0.095, z: 3.7281961}
+      m_Extent: {x: 2.7661295, y: 0.105000004, z: 2.192113}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 124
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 3968
+    _typelessdata: 3ac494c00ad723bc84a5c53fd48e18bf00000000d4934d3f0000000026079f413ac494c0cdcc4c3e84a5c53fd48e18bf00000000d4934d3f0000003f26079f41699394c0cdcc4c3e619ec43fd48e183f00000000d4934dbf0000003f26079f41699394c00ad723bc619ec43fd48e183f00000000d4934dbf0000803f26079f41b39a90c00ad723bc2a09d23f0a1319bf0000000074314d3f000000001cab9f41b39a90c0cdcc4c3e2a09d23f0a1319bf0000000074314d3f0000003f1cab9f41b76990c0cdcc4c3e8402d13f0a13193f0000000074314dbf0000003f1cab9f41b76990c00ad723bc8402d13f0a13193f0000000074314dbf0000803f1cab9f41a0018cc00ad723bc8dc9df3f7e8019bf00000000a0df4c3f000000001e61a041a0018cc0cdcc4c3e8dc9df3f7e8019bf00000000a0df4c3f0000003f1e61a04181d08bc0cdcc4c3e50c3de3f7e80193f00000000a0df4cbf0000003f1e61a04181d08bc00ad723bc50c3de3f7e80193f00000000a0df4cbf0000803f1e61a041320187c00ad723bc76ceee3f22df19bf0000000095984c3f00000000c627a141320187c0cdcc4c3e76ceee3f22df19bf0000000095984c3f0000003fc627a141f5cf86c0cdcc4c3e94c8ed3f22df193f0000000095984cbf0000003fc627a141f5cf86c00ad723bc94c8ed3f22df193f0000000095984cbf0000803fc627a141eba181c00ad723bcecfefe3f07341abf000000009f584c3f00000000affda141eba181c0cdcc4c3eecfefe3f07341abf000000009f584c3f0000003faffda141927081c0cdcc4c3e5cf9fd3f07341a3f000000009f584cbf0000003faffda141927081c00ad723bc5cf9fd3f07341a3f000000009f584cbf0000803faffda141dad877c00ad723bcaf20084074821abf000000005a1d4c3f0000000073e1a241dad877c0cdcc4c3eaf20084074821abf000000005a1d4c3f0000003f73e1a241f77577c0cdcc4c3e0d9e074074821a3f000000005a1d4cbf0000003f73e1a241f77577c00ad723bc0d9e074074821a3f000000005a1d4cbf0000803f73e1a241ffd26bc00ad723bc0e3e1140d7cc1abf00000000f6e44b3f00000000aed1a341ffd26bc0cdcc4c3e0e3e1140d7cc1abf00000000f6e44b3f0000003faed1a341ed6f6bc0cdcc4c3e90bb1040d7cc1a3f00000000f6e44bbf0000003faed1a341ed6f6bc00ad723bc90bb1040d7cc1a3f00000000f6e44bbf0000803faed1a341e6435fc00ad723bc8eca1a40e6141bbf000000002cae4b3f00000000facca441e6435fc0cdcc4c3e8eca1a40e6141bbf000000002cae4b3f0000003ffacca441a5e05ec0cdcc4c3e33481a40e6141b3f000000002cae4bbf0000003ffacca441a5e05ec00ad723bc33481a40e6141b3f000000002cae4bbf0000803ffacca441403d52c00ad723bc2cb92440165c1bbf00000000e4774b3f00000000f3d1a541403d52c0cdcc4c3e2cb92440165c1bbf00000000e4774b3f0000003ff3d1a541d2d951c0cdcc4c3ef4362440165c1b3f00000000e4774bbf0000003ff3d1a541d2d951c00ad723bcf4362440165c1b3f00000000e4774bbf0000803ff3d1a541ced044c00ad723bcd6fc2e408fa31bbf000000003f414b3f0000000032dfa641ced044c0cdcc4c3ed6fc2e408fa31bbf000000003f414b3f0000003f32dfa641326d44c0cdcc4c3ec07a2e408fa31b3f000000003f414bbf0000003f32dfa641326d44c00ad723bcc07a2e408fa31b3f000000003f414bbf0000803f32dfa641591037c00ad723bc768839405aec1bbf000000006c094b3f0000000052f3a741591037c0cdcc4c3e768839405aec1bbf000000006c094b3f0000003f52f3a7418eac36c0cdcc4c3e840639405aec1b3f000000006c094bbf0000003f52f3a7418eac36c00ad723bc840639405aec1b3f000000006c094bbf0000803f52f3a741af0d29c00ad723bcfa4e444072371cbf00000000aacf4a3f00000000f00ca941af0d29c0cdcc4c3efa4e444072371cbf00000000aacf4a3f0000003ff00ca941b5a928c0cdcc4c3e2ecd434072371c3f00000000aacf4abf0000003ff00ca941b5a928c00ad723bc2ecd434072371c3f00000000aacf4abf0000803ff00ca94199da1ac00ad723bc48434f40ce851cbf0000000037934a3f00000000a42aaa4199da1ac0cdcc4c3e48434f40ce851cbf0000000037934a3f0000003fa42aaa416c761ac0cdcc4c3ea2c14e40ce851c3f0000000037934abf0000003fa42aaa416c761ac00ad723bca2c14e40ce851c3f0000000037934abf0000803fa42aaa41dd880cc00ad723bc4c585a406ad81cbf0000000048534a3f000000000b4bab41dd880cc0cdcc4c3e4c585a406ad81cbf0000000048534a3f0000003f0b4bab417c240cc0cdcc4c3eced659406ad81c3f0000000048534abf0000003f0b4bab417c240cc00ad723bcced659406ad81c3f0000000048534abf0000803f0b4bab418854fcbf0ad723bcf080654064301dbf00000000f50e4a3f00000000bf6cac418854fcbfcdcc4c3ef080654064301dbf00000000f50e4a3f0000003fbf6cac41548bfbbfcdcc4c3e9eff644064301d3f00000000f50e4abf0000003fbf6cac41548bfbbf0ad723bc9eff644064301d3f00000000f50e4abf0000803fbf6cac411ca1dfbf0ad723bc30b07040ea8e1dbf0000000049c5493f000000005b8ead411ca1dfbfcdcc4c3e30b07040ea8e1dbf0000000049c5493f0000003f5b8ead4170d7debfcdcc4c3e0e2f7040ea8e1d3f0000000049c549bf0000003f5b8ead4170d7debf0ad723bc0e2f7040ea8e1d3f0000000049c549bf0000803f5b8ead41d81ac3bf0ad723bc06d97b406cf51dbf000000001375493f000000007aaeae41d81ac3bfcdcc4c3e06d97b406cf51dbf000000001375493f0000003f7aaeae41a850c2bfcdcc4c3e18587b406cf51d3f00000000137549bf0000003f7aaeae41a850c2bf0ad723bc18587b406cf51d3f00000000137549bf0000803f7aaeae4110e5a6bf0ad723bc3e7783408c651ebf00000000f71c493f00000000b8cbaf4110e5a6bfcdcc4c3e3e7783408c651ebf00000000f71c493f0000003fb8cbaf41511aa6bfcdcc4c3ee33683408c651e3f00000000f71c49bf0000003fb8cbaf41511aa6bf0ad723bce33683408c651e3f00000000f71c49bf0000803fb8cbaf41f3228bbf0ad723bcd5f188404de11ebf0000000042bb483f00000000aee4b041f3228bbfcdcc4c3ed5f188404de11ebf0000000042bb483f0000003faee4b04195578abfcdcc4c3e99b188404de11e3f0000000042bb48bf0000003faee4b04195578abf0ad723bc99b188404de11e3f0000000042bb48bf0000803faee4b041f4ee5fbf0ad723bcdf558e402a6b1fbf00000000d64d483f00000000f9f7b141f4ee5fbfcdcc4c3edf558e402a6b1fbf00000000d64d483f0000003ff9f7b141d7565ebfcdcc4c3ec6158e402a6b1f3f00000000d64d48bf0000003ff9f7b141d7565ebf0ad723bcc6158e402a6b1f3f00000000d64d48bf0000803ff9f7b141c10a2bbf0ad723bc029d93403f0620bf0000000006d2473f000000003404b341c10a2bbfcdcc4c3e029d93403f0620bf0000000006d2473f0000003f3404b341177129bfcdcc4c3e115d93403f06203f0000000006d247bf0000003f3404b341177129bf0ad723bc115d93403f06203f0000000006d247bf0000803f3404b3411ebcefbe0ad723bcf8c098408cb620bf000000005644473f00000000fb07b4411ebcefbecdcc4c3ef8c098408cb620bf000000005644473f0000003ffb07b4414485ecbecdcc4c3e348198408cb6203f00000000564447bf0000003ffb07b4414485ecbe0ad723bc348198408cb6203f00000000564447bf0000803ffb07b44144598dbe0ad723bc99bb9d404f8121bf0000000023a0463f00000000e801b54144598dbecdcc4c3e99bb9d404f8121bf0000000023a0463f0000003fe801b5415c1e8abecdcc4c3e097c9d404f81213f0000000023a046bf0000003fe801b5415c1e8abe0ad723bc097c9d404f81213f0000000023a046bf0000803fe801b54168c6bdbd0ad723bce486a2408a6d22bf0000000023df453f0000000099f0b54168c6bdbdcdcc4c3ee486a2408a6d22bf0000000023df453f0000003f99f0b541e0c7b0bdcdcc4c3e9347a2408a6d223f0000000023df45bf0000003f99f0b541e0c7b0bd0ad723bc9347a2408a6d223f0000000023df45bf0000803f99f0b54110e9a53d0ad723bc201da740d18423bf0000000097f8443f00000000a9d2b64110e9a53dcdcc4c3e201da740d18423bf0000000097f8443f0000003fa9d2b641f0fdb23dcdcc4c3e19dea640d184233f0000000097f844bf0000003fa9d2b641f0fdb23d0ad723bc19dea640d184233f0000000097f844bf0000803fa9d2b64174e0793e0ad723bcee78ab40c0d424bf00000000cfdf433f00000000b6a6b74174e0793ecdcc4c3eee78ab40c0d424bf00000000cfdf433f0000003fb6a6b741283c803ecdcc4c3e403aab40c0d4243f00000000cfdf43bf0000003fb6a6b741283c803e0ad723bc403aab40c0d4243f00000000cfdf43bf0000803fb6a6b7410380ca3e0ad723bc9695af40207126bf00000000e081423f000000005d6bb8410380ca3ecdcc4c3e9695af40207126bf00000000e081423f0000003f5d6bb84131d4cd3ecdcc4c3e5857af402071263f00000000e08142bf0000003f5d6bb84131d4cd3e0ad723bc5857af402071263f00000000e08142bf0000803f5d6bb841f7e4083f0ad723bc6f6fb340117828bf0000000015c1403f000000003e1fb941f7e4083fcdcc4c3e6f6fb340117828bf0000000015c1403f0000003f3e1fb9413f940a3fcdcc4c3ec031b3401178283f0000000015c140bf0000003f3e1fb9413f940a3f0ad723bcc031b3401178283f0000000015c140bf0000803f3e1fb9417145293f0ad723bcc704b74092192bbf000000003b6c3e3f00000000f8c0b9417145293fcdcc4c3ec704b74092192bbf000000003b6c3e3f0000003ff8c0b94175fb2a3fcdcc4c3ed8c7b64092192b3f000000003b6c3ebf0000003ff8c0b94175fb2a3f0ad723bcd8c7b64092192b3f000000003b6c3ebf0000803ff8c0b941ae5a463f0ad723bccc57ba4024a72ebf000000005c2b3b3f00000000304fba41ae5a463fcdcc4c3ecc57ba4024a72ebf000000005c2b3b3f0000003f304fba41cb19483fcdcc4c3ee71bba4024a72e3f000000005c2b3bbf0000003f304fba41cb19483f0ad723bce71bba4024a72e3f000000005c2b3bbf0000803f304fba413c54603f0ad723bc2c73bd403ab633bf000000004651363f0000000090c8ba413c54603fcdcc4c3e2c73bd403ab633bf000000004651363f0000003f90c8ba414c20623fcdcc4c3ed538bd403ab6333f00000000465136bf0000003f90c8ba414c20623f0ad723bcd538bd403ab6333f00000000465136bf0000803f90c8ba41
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -1.8828241, y: 0.095, z: 3.7281961}
+    m_Extent: {x: 2.7661295, y: 0.105000004, z: 2.192113}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1570402823
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 540
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 124
+    localAABB:
+      m_Center: {x: -4.8949666, y: 0.095, z: 8.176058}
+      m_Extent: {x: 1.5281821, y: 0.105000004, z: 1.670877}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 124
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 3968
+    _typelessdata: 6f8acdc00ad723bcec051c41b03885be00000000a12e773f00000000762868416f8acdc0cdcc4c3eec051c41b03885be00000000a12e773f0000003f762868411e75cdc0cdcc4c3e5fde1b41b038853e00000000a12e77bf0000003f762868411e75cdc00ad723bc5fde1b41b038853e00000000a12e77bf0000803f762868419d0ec7c00ad723bc30c61c4104e642be0000000002527b3f00000000715b69419d0ec7c0cdcc4c3e30c61c4104e642be0000000002527b3f0000003f715b694106ffc6c0cdcc4c3efa9d1c4104e6423e0000000002527bbf0000003f715b694106ffc6c00ad723bcfa9d1c4104e6423e0000000002527bbf0000803f715b6941c99bc0c00ad723bc20471d41a8ebf0bd00000000f6387e3f000000001b836a41c99bc0c0cdcc4c3e20471d41a8ebf0bd00000000f6387e3f0000003f1b836a412692c0c0cdcc4c3e731e1d41a8ebf03d00000000f6387ebf0000003f1b836a412692c0c00ad723bc731e1d41a8ebf03d00000000f6387ebf0000803f1b836a416f38bac00ad723bc27891d41f0312fbd0000000007c47f3f00000000afa06b416f38bac0cdcc4c3e27891d41f0312fbd0000000007c47f3f0000003fafa06b41ee34bac0cdcc4c3e3b601d41f0312f3d0000000007c47fbf0000003fafa06b41ee34bac00ad723bc3b601d41f0312f3d0000000007c47fbf0000803fafa06b41acebb3c00ad723bc0b8d1d41c04b093d000000002cdb7f3f0000000051b56c41acebb3c0cdcc4c3e0b8d1d41c04b093d000000002cdb7f3f0000003f51b56c416beeb3c0cdcc4c3e1b641d41c04b09bd000000002cdb7fbf0000003f51b56c416beeb3c00ad723bc1b641d41c04b09bd000000002cdb7fbf0000803f51b56c41e3bcadc00ad723bc01541d418032e23d000000000d6f7e3f0000000018c26d41e3bcadc0cdcc4c3e01541d418032e23d000000000d6f7e3f0000003f18c26d41efc5adc0cdcc4c3e4c2b1d418032e2bd000000000d6f7ebf0000003f18c26d41efc5adc00ad723bc4c2b1d418032e2bd000000000d6f7ebf0000803f18c26d419ab3a7c00ad723bcbadf1c41c0b33f3e0000000056797b3f00000000fdc76e419ab3a7c0cdcc4c3ebadf1c41c0b33f3e0000000056797b3f0000003ffdc76e41f0c2a7c0cdcc4c3e7eb71c41c0b33fbe0000000056797bbf0000003ffdc76e41f0c2a7c00ad723bc7eb71c41c0b33fbe0000000056797bbf0000803ffdc76e4111d7a1c00ad723bc50321c4168ac863e0000000041fc763f00000000e9c76f4111d7a1c0cdcc4c3e50321c4168ac863e0000000041fc763f0000003fe9c76f419deca1c0cdcc4c3ecc0a1c4168ac86be0000000041fc76bf0000003fe9c76f419deca1c00ad723bccc0a1c4168ac86be0000000041fc76bf0000803fe9c76f412a2e9cc00ad723bc414e1b4130a7ac3e000000007301713f00000000a6c270412a2e9cc0cdcc4c3e414e1b4130a7ac3e000000007301713f0000003fa6c27041c9499cc0cdcc4c3eb1271b4130a7acbe00000000730171bf0000003fa6c27041c9499cc00ad723bcb1271b4130a7acbe00000000730171bf0000803fa6c2704125bf96c00ad723bc4b361a413479d13e000000001898693f00000000ebb8714125bf96c0cdcc4c3e4b361a413479d13e000000001898693f0000003febb87141a9e096c0cdcc4c3eeb101a413479d1be00000000189869bf0000003febb87141a9e096c00ad723bceb101a413479d1be00000000189869bf0000803febb871419e8f91c00ad723bc65ed184174def43e00000000efd2603f0000000052ab72419e8f91c0cdcc4c3e65ed184174def43e00000000efd2603f0000003f52ab7241cbb691c0cdcc4c3e6cc9184174def4be00000000efd260bf0000003f52ab7241cbb691c00ad723bc6cc9184174def4be00000000efd260bf0000803f52ab724188a48cc00ad723bc9476174110500b3f0000000031c6563f000000005d9a734188a48cc0cdcc4c3e9476174110500b3f0000000031c6563f0000003f5d9a73411dd18cc0cdcc4c3e3754174110500bbf0000000031c656bf0000003f5d9a73411dd18cc00ad723bc3754174110500bbf0000000031c656bf0000803f5d9a7341310288c00ad723bcd8d41541ea491b3f00000000c7854b3f000000007e867441310288c0cdcc4c3ed8d41541ea491b3f00000000c7854b3f0000003f7e867441e23388c0cdcc4c3e48b41541ea491bbf00000000c7854bbf0000003f7e867441e23388c00ad723bc48b41541ea491bbf00000000c7854bbf0000803f7e86744168ac83c00ad723bc190b14415e4c2a3f00000000d7233f3f000000001270754168ac83c0cdcc4c3e190b14415e4c2a3f00000000d7233f3f0000003f12707541e7e283c0cdcc4c3e84ec13415e4c2abf00000000d7233fbf0000003f12707541e7e283c00ad723bc84ec13415e4c2abf00000000d7233fbf0000803f127075414b4d7fc00ad723bc1f1c1241a64a383f00000000d6af313f00000000645776414b4d7fc0cdcc4c3e1f1c1241a64a383f00000000d6af313f0000003f645776413dc37fc0cdcc4c3eb1ff1141a64a38bf00000000d6af31bf0000003f645776413dc37fc00ad723bcb1ff1141a64a38bf00000000d6af31bf0000803f645776415ce877c00ad723bc8c0a1041d839453f000000001736233f00000000b43c77415ce877c0cdcc4c3e8c0a1041d839453f000000001736233f0000003fb43c7741966678c0cdcc4c3e6ff00f41d83945bf00000000173623bf0000003fb43c7741966678c00ad723bc6ff00f41d83945bf00000000173623bf0000803fb43c7741773071c00ad723bcd2d80d41620f513f00000000dbbf133f000000003c207841773071c0cdcc4c3ed2d80d41620f513f00000000dbbf133f0000003f3c20784144b671c0cdcc4c3e2ec10d41620f51bf00000000dbbf13bf0000003f3c20784144b671c00ad723bc2ec10d41620f51bf00000000dbbf13bf0000803f3c207841592c6bc00ad723bc4c890b416abf5b3f00000000e653033f000000002b027941592c6bc0cdcc4c3e4c890b416abf5b3f00000000e653033f0000003f2b027941fdb86bc0cdcc4c3e49740b416abf5bbf00000000e65303bf0000003f2b027941fdb86bc00ad723bc49740b416abf5bbf00000000e65303bf0000803f2b0279413ee365c00ad723bc391e0941903b653f00000000f2eee33e00000000b5e279413ee365c0cdcc4c3e391e0941903b653f00000000f2eee33e0000003fb5e27941f47566c0cdcc4c3efd0b0941903b65bf00000000f2eee3be0000003fb5e27941f47566c00ad723bcfd0b0941903b65bf00000000f2eee3be0000803fb5e27941195d61c00ad723bcde990641de716d3f00000000bb5fbf3e000000000fc27a41195d61c0cdcc4c3ede990641de716d3f00000000bb5fbf3e0000003f0fc27a4110f561c0cdcc4c3e8f8a0641de716dbf00000000bb5fbfbe0000003f0fc27a4110f561c00ad723bc8f8a0641de716dbf00000000bb5fbfbe0000803f0fc27a41bea25dc00ad723bc98fe03412a4c743f000000005708993e0000000075a07b41bea25dc0cdcc4c3e98fe03412a4c743f000000005708993e0000003f75a07b41183f5ec0cdcc4c3e5af203412a4c74bf00000000570899be0000003f75a07b41183f5ec00ad723bc5af203412a4c74bf00000000570899be0000803f75a07b41d6bd5ac00ad723bcf34e014112b0793f00000000f4fd613e00000000327e7c41d6bd5ac0cdcc4c3ef34e014112b0793f00000000f4fd613e0000003f327e7c41a25d5bc0cdcc4c3ee945014112b079bf00000000f4fd61be0000003f327e7c41a25d5bc00ad723bce945014112b079bf00000000f4fd61be0000803f327e7c41c8b858c00ad723bca41bfd409c7f7d3f0000000076cd0e3e00000000a05b7d41c8b858c0cdcc4c3ea41bfd409c7f7d3f0000000076cd0e3e0000003fa05b7d41055b59c0cdcc4c3e3810fd409c7f7dbf0000000076cd0ebe0000003fa05b7d41055b59c00ad723bc3810fd409c7f7dbf0000000076cd0ebe0000803fa05b7d41649e57c00ad723bc157df740ba9a7f3f00000000d0a3633d000000002e397e41649e57c0cdcc4c3e157df740ba9a7f3f00000000d0a3633d0000003f2e397e41fa4158c0cdcc4c3e8778f740ba9a7fbf00000000d0a363bd0000003f2e397e41fa4158c00ad723bc8778f740ba9a7fbf00000000d0a363bd0000803f2e397e41657957c00ad723bc02caf140c4e17f3f00000000cfd0f8bc0000000063177f41657957c0cdcc4c3e02caf140c4e17f3f00000000cfd0f8bc0000003f63177f41291d58c0cdcc4c3e7fccf140c4e17fbf00000000cfd0f83c0000003f63177f41291d58c00ad723bc7fccf140c4e17fbf00000000cfd0f83c0000803f63177f41bd5358c00ad723bc6a0bec40fe387e3f00000000cceaf0bd00000000e4f67f41bd5358c0cdcc4c3e6a0bec40fe387e3f00000000cceaf0bd0000003fe4f67f4171f658c0cdcc4c3e0d15ec40fe387ebf00000000cceaf03d0000003fe4f67f4171f658c00ad723bc0d15ec40fe387ebf00000000cceaf03d0000803fe4f67f41c8355ac00ad723bc934be640848c7a3f00000000133152be00000000396c8041c8355ac0cdcc4c3e934be640848c7a3f00000000133152be0000003f396c804122d65ac0cdcc4c3e645ce640848c7abf000000001331523e0000003f396c804122d65ac00ad723bc645ce640848c7abf000000001331523e0000803f396c804160255dc00ad723bcd695e040bcd4743f000000004b9595be0000000078de804160255dc0cdcc4c3ed695e040bcd4743f000000004b9595be0000003f78de804111c25dc0cdcc4c3ec5ade040bcd474bf000000004b95953e0000003f78de804111c25dc00ad723bcc5ade040bcd474bf000000004b95953e0000803f78de8041282561c00ad723bc46f6da40101a6d3f000000003511c1be00000000b0528141282561c0cdcc4c3e46f6da40101a6d3f000000003511c1be0000003fb0528141e7bc61c0cdcc4c3e2a15db40101a6dbf000000003511c13e0000003fb0528141e7bc61c00ad723bc2a15db40101a6dbf000000003511c13e0000803fb05281410a3466c00ad723bc2d79d5402c77633f0000000073e8eabe0000000073c981410a3466c0cdcc4c3e2d79d5402c77633f0000000073e8eabe0000003f73c981419ec566c0cdcc4c3ec29ed5402c7763bf0000000073e8ea3e0000003f73c981419ec566c00ad723bcc29ed5402c7763bf0000000073e8ea3e0000803f73c98141264d6cc00ad723bc702ad0407619583f00000000863f09bf000000005e438241264d6cc0cdcc4c3e702ad0407619583f00000000863f09bf0000003f5e43824173d76cc0cdcc4c3e5c56d040761958bf00000000863f093f0000003f5e43824173d76cc00ad723bc5c56d040761958bf00000000863f093f0000803f5e438241
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -4.8949666, y: 0.095, z: 8.176058}
+    m_Extent: {x: 1.5281821, y: 0.105000004, z: 1.670877}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1615408649
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 540
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 124
+    localAABB:
+      m_Center: {x: -0.73838425, y: 0.095, z: 9.124887}
+      m_Extent: {x: 0.112674505, y: 0.105000004, z: 0.17174482}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 124
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 3968
+    _typelessdata: ce7430bf0ad723bc6e4e0f4168a23a3e000000004cb67bbf000000004335c541ce7430bfcdcc4c3e6e4e0f4168a23a3e000000004cb67bbf0000003f4335c54140ec30bfcdcc4c3eb4760f4168a23abe000000004cb67b3f0000003f4335c54140ec30bf0ad723bcb4760f4168a23abe000000004cb67b3f0000803f4335c541580736bf0ad723bc4d420f4190a5a73d000000000f247fbf00000000bc9ec541580736bfcdcc4c3e4d420f4190a5a73d000000000f247fbf0000003fbc9ec541fd3c36bfcdcc4c3e1f6b0f4190a5a7bd000000000f247f3f0000003fbc9ec541fd3c36bf0ad723bc1f6b0f4190a5a7bd000000000f247f3f0000803fbc9ec54111473abf0ad723bc12400f41e001aebc0000000038f17fbf000000003d04c64111473abfcdcc4c3e12400f41e001aebc0000000038f17fbf0000003f3d04c64126393abfcdcc4c3e05690f41e001ae3c0000000038f17f3f0000003f3d04c64126393abf0ad723bc05690f41e001ae3c0000000038f17f3f0000803f3d04c641cb8e3dbf0ad723bcd0430f41a0c8ffbd00000000dbfe7dbf000000008866c641cb8e3dbfcdcc4c3ed0430f41a0c8ffbd00000000dbfe7dbf0000003f8866c641f13c3dbfcdcc4c3e736c0f41a0c8ff3d00000000dbfe7d3f0000003f8866c641f13c3dbf0ad723bc736c0f41a0c8ff3d00000000dbfe7d3f0000803f8866c641f33740bf0ad723bc624b0f41306e68be000000006e5179bf000000004dc6c641f33740bfcdcc4c3e624b0f41306e68be000000006e5179bf0000003f4dc6c64132a33fbfcdcc4c3e46730f41306e683e000000006e51793f0000003f4dc6c64132a33fbf0ad723bc46730f41306e683e000000006e51793f0000803f4dc6c641429042bf0ad723bc2a560f416cb6a6be000000008d0c72bf000000002424c741429042bfcdcc4c3e2a560f416cb6a6be000000008d0c72bf0000003f2424c741ddba41bfcdcc4c3ee57c0f416cb6a63e000000008d0c723f0000003f2424c741ddba41bf0ad723bce57c0f416cb6a63e000000008d0c723f0000803f2424c741c7d144bf0ad723bcb2640f4104a9d6be00000000fb6968bf000000008c80c741c7d144bfcdcc4c3eb2640f4104a9d6be00000000fb6968bf0000003f8c80c74104bf43bfcdcc4c3ee2890f4104a9d63e00000000fb69683f0000003f8c80c74104bf43bf0ad723bce2890f4104a9d63e00000000fb69683f0000803f8c80c741342047bf0ad723bc0b780f41bcbf01bf00000000faae5cbf00000000eedbc741342047bfcdcc4c3e0b780f41bcbf01bf00000000faae5cbf0000003feedbc7410cd445bfcdcc4c3e5a9b0f41bcbf013f00000000faae5c3f0000003feedbc7410cd445bf0ad723bc5a9b0f41bcbf013f00000000faae5c3f0000803feedbc741468949bf0ad723bc5e910f41b07016bf00000000d9214fbf000000009d36c841468949bfcdcc4c3e5e910f41b07016bf00000000d9214fbf0000003f9d36c841260848bfcdcc4c3e82b20f41b070163f00000000d9214f3f0000003f9d36c841260848bf0ad723bc82b20f41b070163f00000000d9214f3f0000803f9d36c841d5084cbf0ad723bc73b10f41775129bf000000003a0240bf00000000d590c841d5084cbfcdcc4c3e73b10f41775129bf000000003a0240bf0000003fd590c84160574abfcdcc4c3e2cd00f417751293f000000003a02403f0000003fd590c84160574abf0ad723bc2cd00f417751293f000000003a02403f0000803fd590c841258e4ebf0ad723bc8ad80f41fb5b3abf0000000059842fbf00000000c2eac841258e4ebfcdcc4c3e8ad80f41fb5b3abf0000000059842fbf0000003fc2eac84111b14cbfcdcc4c3e9ff40f41fb5b3a3f0000000059842f3f0000003fc2eac84111b14cbf0ad723bc9ff40f41fb5b3a3f0000000059842f3f0000803fc2eac8413a0151bf0ad723bc330610412f9349bf00000000ffce1dbf000000008444c9413a0151bfcdcc4c3e330610412f9349bf00000000ffce1dbf0000003f8444c94132fd4ebfcdcc4c3e731f10412f93493f00000000ffce1d3f0000003f8444c94132fd4ebf0ad723bc731f10412f93493f00000000ffce1d3f0000803f8444c941114853bf0ad723bc5d39104180fc56bf0000000035fc0abf000000002d9ec941114853bfcdcc4c3e5d39104180fc56bf0000000035fc0abf0000003f2d9ec941b42151bfcdcc4c3e9a4f104180fc563f0000000035fc0a3f0000003f2d9ec941b42151bf0ad723bc9a4f104180fc563f0000000035fc0a3f0000803f2d9ec941c44a55bf0ad723bc67701041c29a62bf000000009736eebe00000000cbf7c941c44a55bfcdcc4c3e67701041c29a62bf000000009736eebe0000003fcbf7c941a90653bfcdcc4c3e75831041c29a623f000000009736ee3e0000003fcbf7c941a90653bf0ad723bc75831041c29a623f000000009736ee3e0000803fcbf7c941bdf656bf0ad723bc5ba91041246a6cbf00000000b868c4be000000006951ca41bdf656bfcdcc4c3e5ba91041246a6cbf00000000b868c4be0000003f6951ca41859954bfcdcc4c3e11b91041246a6c3f00000000b868c43e0000003f6951ca41859954bf0ad723bc11b91041246a6c3f00000000b868c43e0000803f6951ca41d04058bf0ad723bc1be21041915d74bf00000000fa9898be0000000014abca41d04058bfcdcc4c3e1be21041915d74bf00000000fa9898be0000003f14abca413dcf55bfcdcc4c3e50ee1041915d743f00000000fa98983e0000003f14abca413dcf55bf0ad723bc50ee1041915d743f00000000fa98983e0000803f14abca413d2659bf0ad723bc9f1811416e5d7abf0000000017ab55be00000000de04cb413d2659bfcdcc4c3e9f1811416e5d7abf0000000017ab55be0000003fde04cb414ea556bfcdcc4c3e2b2111416e5d7a3f0000000017ab553e0000003fde04cb414ea556bf0ad723bc2b2111416e5d7a3f0000000017ab553e0000803fde04cb416aac59bf0ad723bc464b1141f0477ebf00000000caefecbd00000000e35ecb416aac59bfcdcc4c3e464b1141f0477ebf00000000caefecbd0000003fe35ecb41752157bfcdcc4c3e03501141f0477e3f00000000caefec3d0000003fe35ecb41752157bf0ad723bc03501141f0477e3f00000000caefec3d0000803fe35ecb41fcde59bf0ad723bc1879114174f37fbf00000000c547a0bc000000004cb9cb41fcde59bfcdcc4c3e1879114174f37fbf00000000c547a0bc0000003f4cb9cb41c04f57bfcdcc4c3ee579114174f37f3f00000000c547a03c0000003f4cb9cb41c04f57bf0ad723bce579114174f37f3f00000000c547a03c0000803f4cb9cb4132cc59bf0ad723bc0ba211412a337fbf00000000ffcba13d000000005314cc4132cc59bfcdcc4c3e0ba211412a337fbf00000000ffcba13d0000003f5314cc41e23e57bfcdcc4c3ecf9e11412a337f3f00000000ffcba1bd0000003f5314cc41e23e57bf0ad723bccf9e11412a337f3f00000000ffcba1bd0000803f5314cc41217f59bf0ad723bc3bc711411ede7bbf00000000ef3e373e000000004470cc41217f59bfcdcc4c3e3bc711411ede7bbf00000000ef3e373e0000003f4470cc415afa56bfcdcc4c3ee7bf11411ede7b3f00000000ef3e37be0000003f4470cc415afa56bf0ad723bce7bf11411ede7b3f00000000ef3e37be0000803f4470cc4196f858bf0ad723bceeea11414cd875bf00000000c4c68e3e0000000085cdcc4196f858bfcdcc4c3eeeea11414cd875bf00000000c4c68e3e0000003f85cdcc41398356bfcdcc4c3e82df11414cd8753f00000000c4c68ebe0000003f85cdcc41398356bf0ad723bc82df11414cd8753f00000000c4c68ebe0000803f85cdcc413f2758bf0ad723bc6f1012414c1c6dbf000000003b06c13e00000000912ccd413f2758bfcdcc4c3e6f1012414c1c6dbf000000003b06c13e0000003f912ccd413fc855bfcdcc4c3efe0012414c1c6d3f000000003b06c1be0000003f912ccd413fc855bf0ad723bcfe0012414c1c6d3f000000003b06c1be0000803f912ccd4133e156bf0ad723bca23b12416fc361bf00000000fd62f13e00000000fc8dcd4133e156bfcdcc4c3ea23b12416fc361bf00000000fd62f13e0000003ffc8dcd413f9f54bfcdcc4c3e522812416fc3613f00000000fd62f1be0000003ffc8dcd413f9f54bf0ad723bc522812416fc3613f00000000fd62f1be0000803ffc8dcd41c5e054bf0ad723bc6b701241cb0954bf000000004e710f3f0000000070f2cd41c5e054bfcdcc4c3e6b701241cb0954bf000000004e710f3f0000003f70f2cd41f3c152bfcdcc4c3e78591241cb09543f000000004e710fbf0000003f70f2cd41f3c152bf0ad723bc78591241cb09543f000000004e710fbf0000803f70f2cd41c2c551bf0ad723bcfcb112418a4c44bf000000003553243f00000000af5ace41c2c551bfcdcc4c3efcb112418a4c44bf000000003553243f0000003faf5ace413bcf4fbfcdcc4c3eb19712418a4c443f00000000355324bf0000003faf5ace413bcf4fbf0ad723bcb19712418a4c443f00000000355324bf0000803faf5ace41031c4dbf0ad723bc2f021341d40133bf000000006902373f0000000089c7ce41031c4dbfcdcc4c3e2f021341d40133bf000000006902373f0000003f89c7ce41c1514bbfcdcc4c3ee7e41241d401333f00000000690237bf0000003f89c7ce41c1514bbf0ad723bce7e41241d401333f00000000690237bf0000803f89c7ce41016546bf0ad723bc2e611341c2ac20bf000000003a4c473f00000000dc39cf41016546bfcdcc4c3e2e611341c2ac20bf000000003a4c473f0000003fdc39cf41aec944bfcdcc4c3e4b411341c2ac203f000000003a4c47bf0000003fdc39cf41aec944bf0ad723bc4b411341c2ac203f000000003a4c47bf0000803fdc39cf41a0223dbf0ad723bc58cd1341eccf0dbf00000000d321553f0000000093b2cf41a0223dbfcdcc4c3e58cd1341eccf0dbf00000000d321553f0000003f93b2cf4196b73bbfcdcc4c3e3eab1341eccf0d3f00000000d32155bf0000003f93b2cf4196b73bbf0ad723bc3eab1341eccf0d3f00000000d32155bf0000803f93b2cf4154e030bf0ad723bc6f431441eac3f5be000000004b94603f000000009a32d04154e030bfcdcc4c3e6f431441eac3f5be000000004b94603f0000003f9a32d041c0a52fbfcdcc4c3e801f1441eac3f53e000000004b9460bf0000003f9a32d041c0a52fbf0ad723bc801f1441eac3f53e000000004b9460bf0000803f9a32d041733921bf0ad723bc01bf14418a8bd0be000000003dcd693f00000000e1bad041733921bfcdcc4c3e01bf14418a8bd0be000000003dcd693f0000003fe1bad041832e20bfcdcc4c3e989914418a8bd03e000000003dcd69bf0000003fe1bad041832e20bf0ad723bc989914418a8bd03e000000003dcd69bf0000803fe1bad041
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -0.73838425, y: 0.095, z: 9.124887}
+    m_Extent: {x: 0.112674505, y: 0.105000004, z: 0.17174482}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1639774144
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 540
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 124
+    localAABB:
+      m_Center: {x: -0.26652777, y: 0.095, z: 7.2257757}
+      m_Extent: {x: 0.13113822, y: 0.105000004, z: 0.16598248}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 124
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 3968
+    _typelessdata: 980382be0ad723bc2b24e2403ab633bf000000004651363f0000000090c8ba41980382becdcc4c3e2b24e2403ab633bf000000004651363f0000003f90c8ba41f0d67cbecdcc4c3ed4e9e1403ab6333f00000000465136bf0000003f90c8ba41f0d67cbe0ad723bcd4e9e1403ab6333f00000000465136bf0000803f90c8ba41d42265be0ad723bc662ae3405c0c41bf00000000ca21283f00000000b034bb41d42265becdcc4c3e662ae3405c0c41bf00000000ca21283f0000003fb034bb41046a5dbecdcc4c3e99f4e2405c0c413f00000000ca2128bf0000003fb034bb41046a5dbe0ad723bc99f4e2405c0c413f00000000ca2128bf0000803fb034bb4126004dbe0ad723bcf019e440eeaa4dbf00000000ad6f183f00000000669cbb4126004dbecdcc4c3ef019e440eeaa4dbf00000000ad6f183f0000003f669cbb411ec644becdcc4c3e28e9e340eeaa4d3f00000000ad6f18bf0000003f669cbb411ec644be0ad723bc28e9e340eeaa4d3f00000000ad6f18bf0000803f669cbb4104a13abe0ad723bc63f1e440fa5359bf00000000514b073f000000002c00bc4104a13abecdcc4c3e63f1e440fa5359bf00000000514b073f0000003f2c00bc4194ef31becdcc4c3e18c6e440fa53593f00000000514b07bf0000003f2c00bc4194ef31be0ad723bc18c6e440fa53593f00000000514b07bf0000803f2c00bc414c0c2dbe0ad723bca1b0e54024cb63bf0000000018a2e93e000000007860bc414c0c2dbecdcc4c3ea1b0e54024cb63bf0000000018a2e93e0000003f7860bc41b4ef23becdcc4c3e3f8be54024cb633f0000000018a2e9be0000003f7860bc41b4ef23be0ad723bc3f8be54024cb633f0000000018a2e9be0000803f7860bc41305823be0ad723bc9858e640bad86cbf00000000f150c23e00000000b8bdbc41305823becdcc4c3e9858e640bad86cbf00000000f150c23e0000003fb8bdbc41e4de19becdcc4c3e8139e640bad86c3f00000000f150c2be0000003fb8bdbc41e4de19be0ad723bc8139e640bad86c3f00000000f150c2be0000803fb8bdbc4180b31cbe0ad723bc41ebe640b64c74bf00000000cc04993e000000005918bd4180b31cbecdcc4c3e41ebe640b64c74bf00000000cc04993e0000003f5918bd41e0ed12becdcc4c3ec6d2e640b64c743f00000000cc0499be0000003f5918bd41e0ed12be0ad723bcc6d2e640b64c743f00000000cc0499be0000803f5918bd41706c18be0ad723bc2c6be740af007abf00000000e2595c3e00000000b970bd41706c18becdcc4c3e2c6be740af007abf00000000e2595c3e0000003fb970bd41686c0ebecdcc4c3e8b59e740af007a3f00000000e2595cbe0000003fb970bd41686c0ebe0ad723bc8b59e740af007a3f00000000e2595cbe0000803fb970bd4114f415be0ad723bc58dbe74011d97dbf00000000857f043e0000000034c7bd4114f415becdcc4c3e58dbe74011d97dbf00000000857f043e0000003f34c7bd41accc0bbecdcc4c3ebfd0e74011d97d3f00000000857f04be0000003f34c7bd41accc0bbe0ad723bcbfd0e74011d97d3f00000000857f04be0000803f34c7bd41a4de14be0ad723bcc73ee84015c57fbf00000000bba52d3d000000001b1cbe41a4de14becdcc4c3ec73ee84015c57fbf00000000bba52d3d0000003f1b1cbe4190a30abecdcc4c3e4e3be84015c57f3f00000000bba52dbd0000003f1b1cbe4190a30abe0ad723bc4e3be84015c57f3f00000000bba52dbd0000803f1b1cbe4150e014be0ad723bc4498e840d1bd7fbf00000000260938bd00000000b96fbe4150e014becdcc4c3e4498e840d1bd7fbf00000000260938bd0000003fb96fbe4184a50abecdcc4c3ef29be840d1bd7f3f000000002609383d0000003fb96fbe4184a50abe0ad723bcf29be840d1bd7f3f000000002609383d0000803fb96fbe41c0c715be0ad723bc37eae84094c47dbf00000000c6ed06be0000000051c2be41c0c715becdcc4c3e37eae84094c47dbf00000000c6ed06be0000003f51c2be412ca10bbecdcc4c3e03f5e84094c47d3f00000000c6ed063e0000003f51c2be412ca10bbe0ad723bc03f5e84094c47d3f00000000c6ed063e0000803f51c2be41f47717be0ad723bc7836e940e3e079bf0000000007985ebe000000001d14bf41f47717becdcc4c3e7836e940e3e079bf0000000007985ebe0000003f1d14bf4130790dbecdcc4c3e4748e940e3e0793f0000000007985e3e0000003f1d14bf4130790dbe0ad723bc4748e940e3e0793f0000000007985e3e0000803f1d14bf4184e119be0ad723bc5a7ee940821e74bf00000000a42a9abe000000005465bf4184e119becdcc4c3e5a7ee940821e74bf00000000a42a9abe0000003f5465bf41bc1d10becdcc4c3e0597e940821e743f00000000a42a9a3e0000003f5465bf41bc1d10be0ad723bc0597e940821e743f00000000a42a9a3e0000803f5465bf417cfd1cbe0ad723bcb4c2e940c88b6cbf0000000070c6c3be0000000027b6bf417cfd1cbecdcc4c3eb4c2e940c88b6cbf0000000070c6c3be0000003f27b6bf41448713becdcc4c3e07e2e940c88b6c3f0000000070c6c33e0000003f27b6bf41448713be0ad723bc07e2e940c88b6c3f0000000070c6c33e0000803f27b6bf416cc920be0ad723bcfc03ea407b3863bf00000000a6daebbe00000000c506c0416cc920becdcc4c3efc03ea407b3863bf00000000a6daebbe0000003fc506c041b0b217becdcc4c3eb829ea407b38633f00000000a6daeb3e0000003fc506c041b0b217be0ad723bcb829ea407b38633f00000000a6daeb3e0000803fc506c041104625be0ad723bc6542ea404e3558bf000000009e1309bf000000005757c041104625becdcc4c3e6542ea404e3558bf000000009e1309bf0000003f5757c04118a01cbecdcc4c3e436eea404e35583f000000009e13093f0000003f5757c04118a01cbe0ad723bc436eea404e35583f000000009e13093f0000803f5757c0416a772abe0ad723bc0c7eea4004944bbf000000003a371bbf000000000aa8c0416a772abecdcc4c3e0c7eea4004944bbf000000003a371bbf0000003f0aa8c041c65222becdcc4c3eb7afea4004944b3f000000003a371b3f0000003f0aa8c041c65222be0ad723bcb7afea4004944b3f000000003a371b3f0000803f0aa8c041406730be0ad723bc07b7ea401c683dbf0000000059392cbf000000000bf9c041406730becdcc4c3e07b7ea401c683dbf0000000059392cbf0000003f0bf9c041b8d328becdcc4c3e24eeea401c683d3f0000000059392c3f0000003f0bf9c041b8d328be0ad723bc24eeea401c683d3f0000000059392c3f0000803f0bf9c041be2837be0ad723bc7dedea4006c82dbf0000000095fa3bbf00000000874ac141be2837becdcc4c3e7dedea4006c82dbf0000000095fa3bbf0000003f874ac1413a3530becdcc4c3ea429eb4006c82d3f0000000095fa3b3f0000003f874ac1413a3530be0ad723bca429eb4006c82d3f0000000095fa3b3f0000803f874ac1414cdd3ebe0ad723bca721eb4092ce1cbf00000000e85a4abf00000000b19cc1414cdd3ebecdcc4c3ea721eb4092ce1cbf00000000e85a4abf0000003fb19cc141989738becdcc4c3e6862eb4092ce1c3f00000000e85a4a3f0000003fb19cc141989738be0ad723bc6862eb4092ce1c3f00000000e85a4a3f0000803fb19cc141dab847be0ad723bcba53eb40489c0abf00000000663a57bf00000000c1efc141dab847becdcc4c3eba53eb40489c0abf00000000663a57bf0000003fc1efc1417c2d42becdcc4c3e9998eb40489c0a3f00000000663a573f0000003fc1efc1417c2d42be0ad723bc9998eb40489c0a3f00000000663a573f0000803fc1efc141620652be0ad723bcc683eb4092b1eebe00000000667a62bf00000000f643c241620652becdcc4c3ec683eb4092b1eebe00000000667a62bf0000003ff643c24146404dbecdcc4c3e3fcceb4092b1ee3e00000000667a623f0000003ff643c24146404dbe0ad723bc3fcceb4092b1ee3e00000000667a623f0000803ff643c241a5295ebe0ad723bc8ab1eb40c666c6be0000000094ff6bbf000000009299c241a5295ebecdcc4c3e8ab1eb40c666c6be0000000094ff6bbf0000003f9299c241d5315abecdcc4c3e0ffdeb40c666c63e0000000094ff6b3f0000003f9299c241d5315abe0ad723bc0ffdeb40c666c63e0000000094ff6b3f0000803f9299c241f39d6cbe0ad723bc36dceb4046c59cbe0000000048b473bf00000000e5f0c241f39d6cbecdcc4c3e36dceb4046c59cbe0000000048b473bf0000003fe5f0c241497b69becdcc4c3e322aec4046c59c3e0000000048b4733f0000003fe5f0c241497b69be0ad723bc322aec4046c59c3e0000000048b4733f0000803fe5f0c24151f47dbe0ad723bc2102ec403c8f64be00000000aa8a79bf00000000414ac34151f47dbecdcc4c3e2102ec403c8f64be00000000aa8a79bf0000003f414ac34134ab7bbecdcc4c3efc51ec403c8f643e00000000aa8a793f0000003f414ac34134ab7bbe0ad723bcfc51ec403c8f643e00000000aa8a793f0000803f414ac341726589be0ad723bcb020ec40d4e00ebe00000000ec7e7dbf0000000004a6c341726589becdcc4c3eb020ec40d4e00ebe00000000ec7e7dbf0000003f04a6c34190ae88becdcc4c3ece71ec40d4e00e3e00000000ec7e7d3f0000003f04a6c34190ae88be0ad723bcce71ec40d4e00e3e00000000ec7e7d3f0000803f04a6c341a9e295be0ad723bc1534ec40802d66bd0000000070987fbf000000009004c441a9e295becdcc4c3e1534ec40802d66bd0000000070987fbf0000003f9004c441019995becdcc4c3ee085ec40802d663d0000000070987f3f0000003f9004c441019995be0ad723bce085ec40802d663d0000000070987f3f0000803f9004c4416ac0a4be0ad723bc6437ec404068d33c000000002dea7fbf000000005366c4416ac0a4becdcc4c3e6437ec404068d33c000000002dea7fbf0000003f5366c4413de2a4becdcc4c3e4989ec404068d3bc000000002dea7f3f0000003f5366c4413de2a4be0ad723bc4989ec404068d3bc000000002dea7f3f0000803f5366c4419845b6be0ad723bc9124ec40a02ed83d00000000dc917ebf00000000bccbc4419845b6becdcc4c3e9124ec40a02ed83d00000000dc917ebf0000003fbccbc441f4cfb6becdcc4c3e0876ec40a02ed8bd00000000dc917e3f0000003fbccbc441f4cfb6be0ad723bc0876ec40a02ed8bd00000000dc917e3f0000803fbccbc441fdabcabe0ad723bca7f4eb4068a23a3e000000004cb67bbf000000004335c541fdabcabecdcc4c3ea7f4eb4068a23a3e000000004cb67bbf0000003f4335c541e19acbbecdcc4c3e3445ec4068a23abe000000004cb67b3f0000003f4335c541e19acbbe0ad723bc3445ec4068a23abe000000004cb67b3f0000803f4335c541
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -0.26652777, y: 0.095, z: 7.2257757}
+    m_Extent: {x: 0.13113822, y: 0.105000004, z: 0.16598248}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1654876770
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 360
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 93
+    localAABB:
+      m_Center: {x: -2.3625474, y: 0, z: 4.3014994}
+      m_Extent: {x: 3.2458525, y: 0, z: 2.765416}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000030003000400010002000100040004000500020004000300060006000700040005000400070007000800050007000600090009000a000700080007000a000a000b0008000a0009000c000c000d000a000b000a000d000d000e000b000d000c000f000f0010000d000e000d001000100011000e0010000f00120012001300100011001000130013001400110013001200150015001600130014001300160016001700140016001500180018001900160017001600190019001a001700190018001b001b001c0019001a0019001c001c001d001a001c001b001e001e001f001c001d001c001f001f0020001d001f001e002100210022001f0020001f002200220023002000220021002400240025002200230022002500250026002300250024002700270028002500260025002800280029002600280027002a002a002b002800290028002b002b002c0029002b002a002d002d002e002b002c002b002e002e002f002c002e002d003000300031002e002f002e003100310032002f0031003000330033003400310032003100340034003500320034003300360036003700340035003400370037003800350037003600390039003a003700380037003a003a003b0038003a0039003c003c003d003a003b003a003d003d003e003b003d003c003f003f0040003d003e003d004000400041003e0040003f00420042004300400041004000430043004400410043004200450045004600430044004300460046004700440046004500480048004900460047004600490049004a004700490048004b004b004c0049004a0049004c004c004d004a004c004b004e004e004f004c004d004c004f004f0050004d004f004e005100510052004f0050004f005200520053005000520051005400540055005200530052005500550056005300550054005700570058005500560055005800580059005600580057005a005a005b005800590058005b005b005c005900
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 93
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 2976
+    _typelessdata: 0378b3c00000000076913540000000000000803f000000000000000026079f41b605a4c00000000053f00b40000000000000803f000000000000003f26079f41699394c000000000619ec43f000000000000803f000000000000803f26079f411769afc000000000b09b3b40000000000000803f00000000000000001cab9f4167e99fc000000000790e1240000000000000803f000000000000003f1cab9f41b76990c0000000008402d13f000000000000803f000000000000803f1cab9f410be6aac000000000f25a4240000000000000803f00000000000000001e61a041465b9bc0000000004dde1840000000000000803f000000000000003f1e61a04181d08bc00000000050c3de3f000000000000803f000000000000803f1e61a041a9f8a5c000000000cec04940000000000000803f0000000000000000c627a1414f6496c0000000008c522040000000000000803f000000000000003fc627a141f5cf86c00000000094c8ed3f000000000000803f000000000000803fc627a14178aaa0c0000000004abf5140000000000000803f0000000000000000affda141850d91c000000000fc5d2840000000000000803f000000000000003faffda141927081c0000000005cf9fd3f000000000000803f000000000000803faffda141c2049bc000000000a9485a40000000000000803f000000000000000073e1a241df5f8bc0000000005bf33040000000000000803f000000000000003f73e1a241f77577c0000000000d9e0740000000000000803f000000000000803f73e1a241ce1095c000000000544f6340000000000000803f0000000000000000aed1a341626485c00000000072053a40000000000000803f000000000000003faed1a341ed6f6bc00000000090bb1040000000000000803f000000000000803faed1a341c1d78ec000000000c7c56c40000000000000803f0000000000000000facca44114487ec000000000fd864340000000000000803f000000000000003ffacca441a5e05ec00000000033481a40000000000000803f000000000000803ffacca441c26288c0000000008c9e7640000000000000803f0000000000000000f3d1a541ab4f71c000000000c06a4d40000000000000803f000000000000003ff3d1a541d2d951c000000000f4362440000000000000803f000000000000803ff3d1a541ebba81c0000000001c668040000000000000803f000000000000000032dfa64184f163c0000000007ca35740000000000000803f000000000000003f32dfa641326d44c000000000c07a2e40000000000000803f000000000000803f32dfa641aed275c000000000b0a08540000000000000803f000000000000000052f3a7419e3f56c000000000f2236240000000000000803f000000000000003f52f3a7418eac36c00000000084063940000000000000803f000000000000803f52f3a7413dee67c00000000052f88a40000000000000803f0000000000000000f00ca941f94b48c000000000e9de6c40000000000000803f000000000000003ff00ca941b5a928c0000000002ecd4340000000000000803f000000000000803ff00ca941b2da59c0000000004f669040000000000000803f0000000000000000a42aaa418f283ac00000000020c77740000000000000803f000000000000003fa42aaa416c761ac000000000a2c14e40000000000000803f000000000000803fa42aaa4136aa4bc000000000f3e39540000000000000803f00000000000000000b4bab4159e72bc000000000ad678140000000000000803f000000000000003f0b4bab417c240cc000000000ced65940000000000000803f000000000000803f0b4bab41066f3dc000000000856a9b40000000000000803f0000000000000000bf6cac41589a1dc0000000002af58640000000000000803f000000000000003fbf6cac41548bfbbf000000009eff6440000000000000803f000000000000803fbf6cac415c3b2fc00000000051f3a040000000000000803f00000000000000005b8ead418a530fc0000000006c858c40000000000000803f000000000000003f5b8ead4170d7debf000000000e2f7040000000000000803f000000000000803f5b8ead417c2121c0000000009877a640000000000000803f00000000000000007aaeae41e82401c000000000d2119240000000000000803f000000000000003f7aaeae41a850c2bf0000000018587b40000000000000803f000000000000803f7aaeae41ba3313c00000000097f0ab40000000000000803f0000000000000000b8cbaf41e240e6bf00000000bd939740000000000000803f000000000000003fb8cbaf41511aa6bf00000000e3368340000000000000803f000000000000803fb8cbaf417a8405c0000000008557b140000000000000803f0000000000000000aee4b04145b0cabf000000008f049d40000000000000803f000000000000003faee4b04195578abf0000000099b18840000000000000803f000000000000803faee4b041764cf0bf000000008aa5b640000000000000803f0000000000000000f9f7b141f1bbafbf00000000a85da240000000000000803f000000000000003ff9f7b141d7565ebf00000000c6158e40000000000000803f000000000000803ff9f7b1413457d6bf00000000c1d3bb40000000000000803f00000000000000003404b341e08795bf000000006998a740000000000000803f000000000000003f3404b341177129bf00000000115d9340000000000000803f000000000000803f3404b341c74ebdbf0000000034dbc040000000000000803f0000000000000000fb07b441187078bf0000000034aeac40000000000000803f000000000000003ffb07b4414485ecbe0000000034819840000000000000803f000000000000803ffb07b4414a59a5bf00000000c9b4c540000000000000803f0000000000000000e801b541e1e047bf000000006998b140000000000000803f000000000000003fe801b5415c1e8abe00000000097c9d40000000000000803f000000000000803fe801b5418a9d8ebf000000003d59ca40000000000000803f000000000000000099f0b54108aa19bf000000006850b640000000000000803f000000000000003f99f0b541e0c7b0bd000000009347a240000000000000803f000000000000803f99f0b541c88672bf0000000013c1ce40000000000000803f0000000000000000a9d2b6410a27dcbe0000000096cfba40000000000000803f000000000000003fa9d2b641f0fdb23d0000000019dea640000000000000803f000000000000803fa9d2b641a8e84abf0000000060e4d240000000000000803f0000000000000000b6a6b74194ca8abe00000000500fbf40000000000000803f000000000000003fb6a6b741283c803e00000000403aab40000000000000803f000000000000803fb6a6b741b0b826bf000000009abad640000000000000803f00000000000000005d6bb8415c3affbd00000000f908c340000000000000803f000000000000003f5d6bb84131d4cd3e000000005857af40000000000000803f000000000000803f5d6bb841395706bf00000000223ada40000000000000803f00000000000000003e1fb941d0a0073c00000000f1b5c640000000000000803f000000000000003f3e1fb9413f940a3f00000000c031b340000000000000803f000000000000803f3e1fb9412a66d4be000000005c57dd40000000000000803f0000000000000000f8c0b941bf90013e000000009a0fca40000000000000803f000000000000003ff8c0b94175fb2a3f00000000d8c7b640000000000000803f000000000000803ff8c0b94182aca5be00000000c302e040000000000000803f0000000000000000304fba4113876a3e00000000550fcd40000000000000803f000000000000003f304fba41cb19483f00000000e71bba40000000000000803f000000000000803f304fba41980382be000000002b24e240000000000000803f000000000000000090c8ba41801ea13e0000000080aecf40000000000000803f000000000000003f90c8ba414c20623f00000000d538bd40000000000000803f000000000000803f90c8ba41
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -2.3625474, y: 0, z: 4.3014994}
+    m_Extent: {x: 3.2458525, y: 0, z: 2.765416}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1658140472
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 540
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 124
+    localAABB:
+      m_Center: {x: 1.4950119, y: 0.095, z: 8.378264}
+      m_Extent: {x: 2.1247947, y: 0.105000004, z: 1.0757525}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 124
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 3968
+    _typelessdata: 733921bf0ad723bc01bf14418a8bd0be000000003dcd693f00000000e1bad041733921bfcdcc4c3e01bf14418a8bd0be000000003dcd693f0000003fe1bad041832e20bfcdcc4c3e989914418a8bd03e000000003dcd69bf0000003fe1bad041832e20bf0ad723bc989914418a8bd03e000000003dcd69bf0000803fe1bad04134e60dbf0ad723bce2391541eaeaabbe000000001723713f00000000314dd14134e60dbfcdcc4c3ee2391541eaeaabbe000000001723713f0000003f314dd141260a0dbfcdcc4c3e4d131541eaeaab3e00000000172371bf0000003f314dd141260a0dbf0ad723bc4d131541eaeaab3e00000000172371bf0000803f314dd141a6c0eabe0ad723bc80b61541c2918bbe000000000e4e763f0000000072ead141a6c0eabecdcc4c3e80b61541c2918bbe000000000e4e763f0000003f72ead1415a5be9becdcc4c3e178f1541c2918b3e000000000e4e76bf0000003f72ead1415a5be9be0ad723bc178f1541c2918b3e000000000e4e76bf0000803f72ead1416ea2b0be0ad723bc132b16411c205dbe00000000bef5793f000000002492d2416ea2b0becdcc4c3e132b16411c205dbe00000000bef5793f0000003f2492d2416387afbecdcc4c3e150316411c205d3e00000000bef579bf0000003f2492d2416387afbe0ad723bc150316411c205d3e00000000bef579bf0000803f2492d2418d4a5dbe0ad723bce2901641343a28be0000000090857c3f00000000a843d3418d4a5dbecdcc4c3ee2901641343a28be0000000090857c3f0000003fa843d341e49b5bbecdcc4c3e7a681641343a283e0000000090857cbf0000003fa843d341e49b5bbe0ad723bc7a681641343a283e0000000090857cbf0000803fa843d341417c97bd0ad723bc0de316419854eebd00000000bb427e3f000000004afed341417c97bdcdcc4c3e0de316419854eebd00000000bb427e3f0000003f4afed341211a95bdcdcc4c3e5eba16419854ee3d00000000bb427ebf0000003f4afed341211a95bd0ad723bc5eba16419854ee3d00000000bb427ebf0000803f4afed3414ed0a23d0ad723bc001e1741b8d291bd00000000aa597f3f000000004cc1d4414ed0a23dcdcc4c3e001e1741b8d291bd00000000aa597f3f0000003f4cc1d4419d45a43dcdcc4c3e25f51641b8d2913d00000000aa597fbf0000003f4cc1d4419d45a43d0ad723bc25f51641b8d2913d00000000aa597fbf0000803f4cc1d441c956783e0ad723bcef3e1741a005e5bc0000000064e67f3f00000000e78bd541c956783ecdcc4c3eef3e1741a005e5bc0000000064e67f3f0000003fe78bd54113a0783ecdcc4c3efd151741a005e53c0000000064e67fbf0000003fe78bd54113a0783e0ad723bcfd151741a005e53c0000000064e67fbf0000803fe78bd541c0add33e0ad723bca743174180f4653c000000008df97f3f00000000535dd641c0add33ecdcc4c3ea743174180f4653c000000008df97f3f0000003f535dd6415a9bd33ecdcc4c3eb21a174180f465bc000000008df97fbf0000003f535dd6415a9bd33e0ad723bcb21a174180f465bc000000008df97fbf0000803f535dd641ab36173f0ad723bc582a174100a7623d00000000979b7f3f00000000c934d741ab36173fcdcc4c3e582a174100a7623d00000000979b7f3f0000003fc934d7416712173fcdcc4c3e7301174100a762bd00000000979b7fbf0000003fc934d7416712173f0ad723bc7301174100a762bd00000000979b7fbf0000803fc934d741bdd2453f0ad723bc85f116418076c53d00000000abce7e3f000000008411d841bdd2453fcdcc4c3e85f116418076c53d00000000abce7e3f0000003f8411d8418d93453fcdcc4c3ec1c816418076c5bd00000000abce7ebf0000003f8411d8418d93453f0ad723bcc1c816418076c5bd00000000abce7ebf0000803f8411d841574c753f0ad723bcf797164128fe0c3e00000000d08f7d3f00000000c6f2d841574c753fcdcc4c3ef797164128fe0c3e00000000d08f7d3f0000003fc6f2d8411bf2743fcdcc4c3e656f164128fe0cbe00000000d08f7dbf0000003fc6f2d8411bf2743f0ad723bc656f164128fe0cbe00000000d08f7dbf0000803fc6f2d841d2a3923f0ad723bca71c164198ce373e0000000093d77b3f00000000dad7d941d2a3923fcdcc4c3ea71c164198ce373e0000000093d77b3f0000003fdad7d9410169923fcdcc4c3e5bf4154198ce37be0000000093d77bbf0000003fdad7d9410169923f0ad723bc5bf4154198ce37be0000000093d77bbf0000803fdad7d941b3b5aa3f0ad723bcc77e1541507b633e000000006d9a793f0000000014c0da41b3b5aa3fcdcc4c3ec77e1541507b633e000000006d9a793f0000003f14c0da41e86caa3fcdcc4c3ed7561541507b63be000000006d9a79bf0000003f14c0da41e86caa3f0ad723bcd7561541507b63be000000006d9a79bf0000803f14c0da4174b0c23f0ad723bcbebd14414423883e00000000ddc8763f00000000d8aadb4174b0c23fcdcc4c3ebebd14414423883e00000000ddc8763f0000003fd8aadb415359c23fcdcc4c3e42961441442388be00000000ddc876bf0000003fd8aadb415359c23f0ad723bc42961441442388be00000000ddc876bf0000803fd8aadb41236ada3f0ad723bc23d9134164329f3e000000008c4f733f000000009997dc41236ada3fcdcc4c3e23d9134164329f3e000000008c4f733f0000003f9997dc414004da3fcdcc4c3e35b2134164329fbe000000008c4f73bf0000003f9997dc414004da3f0ad723bc35b2134164329fbe000000008c4f73bf0000803f9997dc4159baf13f0ad723bcbbd012414cfdb63e0000000069176f3f00000000dd85dd4159baf13fcdcc4c3ebbd012414cfdb63e0000000069176f3f0000003fdd85dd413c45f13fcdcc4c3e7aaa12414cfdb6be0000000069176fbf0000003fdd85dd413c45f13f0ad723bc7aaa12414cfdb6be0000000069176fbf0000803fdd85dd414d3d04400ad723bc76a41141cc8ccf3e00000000e3056a3f000000004275de414d3d0440cdcc4c3e76a41141cc8ccf3e00000000e3056a3f0000003f4275de41e3fa0340cdcc4c3e057f1141cc8ccfbe00000000e3056abf0000003f4275de41e3fa03400ad723bc057f1141cc8ccfbe00000000e3056abf0000803f4275de416e430f400ad723bc7154104188dde83e0000000071fd633f000000007e65df416e430f40cdcc4c3e7154104188dde83e0000000071fd633f0000003f7e65df41e9f80e40cdcc4c3ef72f104188dde8be0000000071fd63bf0000003f7e65df41e9f80e400ad723bcf72f104188dde8be0000000071fd63bf0000803f7e65df41fede19400ad723bcdce00e41bc6e013f0000000086de5c3f000000006856e041fede1940cdcc4c3edce00e41bc6e013f0000000086de5c3f0000003f6856e041278c1940cdcc4c3e85bd0e41bc6e01bf0000000086de5cbf0000003f6856e041278c19400ad723bc85bd0e41bc6e01bf0000000086de5cbf0000803f6856e041370124400ad723bcef490d415cb40e3f000000002489543f00000000f847e14137012440cdcc4c3eef490d415cb40e3f000000002489543f0000003ff847e141e2a52340cdcc4c3eee270d415cb40ebf00000000248954bf0000003ff847e141e2a523400ad723bcee270d415cb40ebf00000000248954bf0000803ff847e141699d2d400ad723bccb8f0b414c231c3f000000002ddf4a3f000000004a3ae241699d2d40cdcc4c3ecb8f0b414c231c3f000000002ddf4a3f0000003f4a3ae2417b392d40cdcc4c3e556f0b414c231cbf000000002ddf4abf0000003f4a3ae2417b392d400ad723bc556f0b414c231cbf000000002ddf4abf0000803f4a3ae24124a936400ad723bc4eb20941e293293f0000000096c73f3f00000000aa2de34124a93640cdcc4c3e4eb20941e293293f0000000096c73f3f0000003faa2de3419c3c3640cdcc4c3e9e930941e29329bf0000000096c73fbf0000003faa2de3419c3c36400ad723bc9e930941e29329bf0000000096c73fbf0000803faa2de341421c3f400ad723bce5b007410ed3363f000000003332333f000000008c22e441421c3f40cdcc4c3ee5b007410ed3363f000000003332333f0000003f8c22e44140a73e40cdcc4c3e399407410ed336bf00000000333233bf0000003f8c22e44140a73e400ad723bc399407410ed336bf00000000333233bf0000803f8c22e44199f046400ad723bc5a8a0541daa3433f00000000e51b253f000000009a19e54199f04640cdcc4c3e5a8a0541daa3433f00000000e51b253f0000003f9a19e54163734640cdcc4c3eef6f0541daa343bf00000000e51b25bf0000003f9a19e541637346400ad723bcef6f0541daa343bf00000000e51b25bf0000803f9a19e54160214e400ad723bc953c03415ec24f3f00000000b592153f00000000ab13e64160214e40cdcc4c3e953c03415ec24f3f00000000b592153f0000003fab13e641699c4d40cdcc4c3ea62403415ec24fbf00000000b59215bf0000003fab13e641699c4d400ad723bca62403415ec24fbf00000000b59215bf0000803fab13e6412aaa54400ad723bc86c40041e4e85a3f0000000044b8043f00000000ce11e7412aaa5440cdcc4c3e86c40041e4e85a3f0000000044b8043f0000003fce11e741101e5440cdcc4c3e4aaf0041e4e85abf0000000044b804bf0000003fce11e741101e54400ad723bc4aaf0041e4e85abf0000000044b804bf0000803fce11e741a9855a400ad723bc383cfc4036d6643f00000000de84e53e000000003f15e841a9855a40cdcc4c3e383cfc4036d6643f00000000de84e53e0000003f3f15e84134f35940cdcc4c3e7f17fc4036d664bf00000000de84e5be0000003f3f15e84134f359400ad723bc7f17fc4036d664bf00000000de84e5be0000803f3f15e84148ac5f400ad723bcbc88f6405e546d3f00000000cbf1bf3e00000000691fe94148ac5f40cdcc4c3ebc88f6405e546d3f00000000cbf1bf3e0000003f691fe94164145f40cdcc4c3e066af6405e546dbf00000000cbf1bfbe0000003f691fe94164145f400ad723bc066af6405e546dbf00000000cbf1bfbe0000803f691fe9410c1364400ad723bc6763f040663e743f000000002060993e00000000dd31ea410c136440cdcc4c3e6763f040663e743f000000002060993e0000003fdd31ea41bc766340cdcc4c3edd4af040663e74bf00000000206099be0000003fdd31ea41bc7663400ad723bcdd4af040663e74bf00000000206099be0000803fdd31ea41eaaa67400ad723bc80c0e940c683793f000000006907653e000000004c4eeb41eaaa6740cdcc4c3e80c0e940c683793f000000006907653e0000003f4c4eeb413a0b6740cdcc4c3e2daee940c68379bf00000000690765be0000003f4c4eeb413a0b67400ad723bc2daee940c68379bf00000000690765be0000803f4c4eeb41
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 1.4950119, y: 0.095, z: 8.378264}
+    m_Extent: {x: 2.1247947, y: 0.105000004, z: 1.0757525}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1680872731
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 540
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 124
+    localAABB:
+      m_Center: {x: 0.391029, y: 0.095, z: 7.457205}
+      m_Extent: {x: 1.0821339, y: 0.105000004, z: 1.5440176}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 124
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 3968
+    _typelessdata: 3c54603f0ad723bc2c73bd403ab633bf000000004651363f0000000090c8ba413c54603fcdcc4c3e2c73bd403ab633bf000000004651363f0000003f90c8ba414c20623fcdcc4c3ed538bd403ab6333f00000000465136bf0000003f90c8ba414c20623f0ad723bcd538bd403ab6333f00000000465136bf0000803f90c8ba4113867d3f0ad723bc3d54c1405c0c41bf00000000ca21283f00000000b034bb4113867d3fcdcc4c3e3d54c1405c0c41bf00000000ca21283f0000003fb034bb4147747f3fcdcc4c3e701ec1405c0c413f00000000ca2128bf0000003fb034bb4147747f3f0ad723bc701ec1405c0c413f00000000ca2128bf0000803fb034bb41faef8b3f0ad723bc6c6cc540eeaa4dbf00000000ad6f183f00000000669cbb41faef8b3fcdcc4c3e6c6cc540eeaa4dbf00000000ad6f183f0000003f669cbb413bf78c3fcdcc4c3ea43bc540eeaa4d3f00000000ad6f18bf0000003f669cbb413bf78c3f0ad723bca43bc540eeaa4d3f00000000ad6f18bf0000803f669cbb41d69e973f0ad723bc08b7c940fa5359bf00000000514b073f000000002c00bc41d69e973fcdcc4c3e08b7c940fa5359bf00000000514b073f0000003f2c00bc4104b5983fcdcc4c3ebd8bc940fa53593f00000000514b07bf0000003f2c00bc4104b5983f0ad723bcbd8bc940fa53593f00000000514b07bf0000803f2c00bc4126bea13f0ad723bc3d2ece4024cb63bf0000000018a2e93e000000007860bc4126bea13fcdcc4c3e3d2ece4024cb63bf0000000018a2e93e0000003f7860bc41bae1a23fcdcc4c3edb08ce4024cb633f0000000018a2e9be0000003f7860bc41bae1a23f0ad723bcdb08ce4024cb633f0000000018a2e9be0000803f7860bc41523eaa3f0ad723bc03cbd240bad86cbf00000000f150c23e00000000b8bdbc41523eaa3fcdcc4c3e03cbd240bad86cbf00000000f150c23e0000003fb8bdbc417c6dab3fcdcc4c3eecabd240bad86c3f00000000f150c2be0000003fb8bdbc417c6dab3f0ad723bcecabd240bad86c3f00000000f150c2be0000803fb8bdbc41d512b13f0ad723bc7e85d740b64c74bf00000000cc04993e000000005918bd41d512b13fcdcc4c3e7e85d740b64c74bf00000000cc04993e0000003f5918bd41894bb23fcdcc4c3e036dd740b64c743f00000000cc0499be0000003f5918bd41894bb23f0ad723bc036dd740b64c743f00000000cc0499be0000803f5918bd41ff32b63f0ad723bc0d55dc40af007abf00000000e2595c3e00000000b970bd41ff32b63fcdcc4c3e0d55dc40af007abf00000000e2595c3e0000003fb970bd410073b73fcdcc4c3e6c43dc40af007a3f00000000e2595cbe0000003fb970bd410073b73f0ad723bc6c43dc40af007a3f00000000e2595cbe0000803fb970bd41789ab93f0ad723bcc530e14011d97dbf00000000857f043e0000000034c7bd41789ab93fcdcc4c3ec530e14011d97dbf00000000857f043e0000003f34c7bd4166dfba3fcdcc4c3e2c26e14011d97d3f00000000857f04be0000003f34c7bd4166dfba3f0ad723bc2c26e14011d97d3f00000000857f04be0000803f34c7bd413849bb3f0ad723bca20fe64015c57fbf00000000bba52d3d000000001b1cbe413849bb3fcdcc4c3ea20fe64015c57fbf00000000bba52d3d0000003f1b1cbe419a90bc3fcdcc4c3e290ce64015c57f3f00000000bba52dbd0000003f1b1cbe419a90bc3f0ad723bc290ce64015c57f3f00000000bba52dbd0000803f1b1cbe412a43bb3f0ad723bcdce8ea40d1bd7fbf00000000260938bd00000000b96fbe412a43bb3fcdcc4c3edce8ea40d1bd7fbf00000000260938bd0000003fb96fbe41838abc3fcdcc4c3e8aecea40d1bd7f3f000000002609383d0000003fb96fbe41838abc3f0ad723bc8aecea40d1bd7f3f000000002609383d0000803fb96fbe41848fb93f0ad723bc19b4ef4094c47dbf00000000c6ed06be0000000051c2be41848fb93fcdcc4c3e19b4ef4094c47dbf00000000c6ed06be0000003f51c2be4157d4ba3fcdcc4c3ee5beef4094c47d3f00000000c6ed063e0000003f51c2be4157d4ba3f0ad723bce5beef4094c47d3f00000000c6ed063e0000803f51c2be41f637b63f0ad723bc7b69f440e3e079bf0000000007985ebe000000001d14bf41f637b63fcdcc4c3e7b69f440e3e079bf0000000007985ebe0000003f1d14bf41ce77b73fcdcc4c3e4a7bf440e3e0793f0000000007985e3e0000003f1d14bf41ce77b73f0ad723bc4a7bf440e3e0793f0000000007985e3e0000803f1d14bf41e447b13f0ad723bcaf01f940821e74bf00000000a42a9abe000000005465bf41e447b13fcdcc4c3eaf01f940821e74bf00000000a42a9abe0000003f5465bf415c80b23fcdcc4c3e5a1af940821e743f00000000a42a9a3e0000003f5465bf415c80b23f0ad723bc5a1af940821e743f00000000a42a9a3e0000803f5465bf41b8cbaa3f0ad723bcdf75fd40c88b6cbf0000000070c6c3be0000000027b6bf41b8cbaa3fcdcc4c3edf75fd40c88b6cbf0000000070c6c3be0000003f27b6bf4180faab3fcdcc4c3e3295fd40c88b6c3f0000000070c6c33e0000003f27b6bf4180faab3f0ad723bc3295fd40c88b6c3f0000000070c6c33e0000803f27b6bf4173d0a23f0ad723bccbdf00417b3863bf00000000a6daebbe00000000c506c04173d0a23fcdcc4c3ecbdf00417b3863bf00000000a6daebbe0000003fc506c0414af3a33fcdcc4c3ea9f200417b38633f00000000a6daeb3e0000003fc506c0414af3a33f0ad723bca9f200417b38633f00000000a6daeb3e0000803fc506c0416f63993f0ad723bc4bec02414e3558bf000000009e1309bf000000005757c0416f63993fcdcc4c3e4bec02414e3558bf000000009e1309bf0000003f5757c0412e789a3fcdcc4c3e390203414e35583f000000009e13093f0000003f5757c0412e789a3f0ad723bc390203414e35583f000000009e13093f0000803f5757c04177928e3f0ad723bc61dd044104944bbf000000003a371bbf000000000aa8c04177928e3fcdcc4c3e61dd044104944bbf000000003a371bbf0000003f0aa8c0410c978f3fcdcc4c3e37f6044104944b3f000000003a371b3f0000003f0aa8c0410c978f3f0ad723bc37f6044104944b3f000000003a371b3f0000803f0aa8c041066c823f0ad723bc01b006411c683dbf0000000059392cbf000000000bf9c041066c823fcdcc4c3e01b006411c683dbf0000000059392cbf0000003f0bf9c041775e833fcdcc4c3e8fcb06411c683d3f0000000059392c3f0000003f0bf9c041775e833f0ad723bc8fcb06411c683d3f0000000059392c3f0000803f0bf9c0418aff693f0ad723bc1461084106c82dbf0000000095fa3bbf00000000874ac1418aff693fcdcc4c3e1461084106c82dbf0000000095fa3bbf0000003f874ac1416abc6b3fcdcc4c3e287f084106c82d3f0000000095fa3b3f0000003f874ac1416abc6b3f0ad723bc287f084106c82d3f0000000095fa3b3f0000803f874ac14138be4c3f0ad723bc7eed094192ce1cbf00000000e85a4abf00000000b19cc14138be4c3fcdcc4c3e7eed094192ce1cbf00000000e85a4abf0000003fb19cc141a54f4e3fcdcc4c3edf0d0a4192ce1c3f00000000e85a4a3f0000003fb19cc141a54f4e3f0ad723bcdf0d0a4192ce1c3f00000000e85a4a3f0000803fb19cc1417a3b2d3f0ad723bc24520b41489c0abf00000000663a57bf00000000c1efc1417a3b2d3fcdcc4c3e24520b41489c0abf00000000663a57bf0000003fc1efc141529e2e3fcdcc4c3e93740b41489c0a3f00000000663a573f0000003fc1efc141529e2e3f0ad723bc93740b41489c0a3f00000000663a573f0000803fc1efc14164a40b3f0ad723bcf68b0c4192b1eebe00000000667a62bf00000000f643c24164a40b3fcdcc4c3ef68b0c4192b1eebe00000000667a62bf0000003ff643c241ead50c3fcdcc4c3e33b00c4192b1ee3e00000000667a623f0000003ff643c241ead50c3f0ad723bc33b00c4192b1ee3e00000000667a623f0000803ff643c2415458d03e0ad723bc16980d41c666c6be0000000094ff6bbf000000009299c2415458d03ecdcc4c3e16980d41c666c6be0000000094ff6bbf0000003f9299c2413c54d23ecdcc4c3ed9bd0d41c666c63e0000000094ff6b3f0000003f9299c2413c54d23e0ad723bcd9bd0d41c666c63e0000000094ff6b3f0000803f9299c2419817863e0ad723bced730e4146c59cbe0000000048b473bf00000000e5f0c2419817863ecdcc4c3eed730e4146c59cbe0000000048b473bf0000003fe5f0c241eea8873ecdcc4c3eeb9a0e4146c59c3e0000000048b4733f0000003fe5f0c241eea8873e0ad723bceb9a0e4146c59c3e0000000048b4733f0000803fe5f0c2418c0de43d0ad723bc421d0f413c8f64be00000000aa8a79bf00000000414ac3418c0de43dcdcc4c3e421d0f413c8f64be00000000aa8a79bf0000003f414ac341c69fe83dcdcc4c3e2f450f413c8f643e00000000aa8a793f0000003f414ac341c69fe83d0ad723bc2f450f413c8f643e00000000aa8a793f0000803f414ac341ca0833bd0ad723bc65920f41d4e00ebe00000000ec7e7dbf0000000004a6c341ca0833bdcdcc4c3e65920f41d4e00ebe00000000ec7e7dbf0000003f04a6c341b8512dbdcdcc4c3ef4ba0f41d4e00e3e00000000ec7e7d3f0000003f04a6c341b8512dbd0ad723bcf4ba0f41d4e00e3e00000000ec7e7d3f0000803f04a6c341ce1f4fbe0ad723bc2ed20f41802d66bd0000000070987fbf000000009004c441ce1f4fbecdcc4c3e2ed20f41802d66bd0000000070987fbf0000003f9004c4417e8c4ebecdcc4c3e13fb0f41802d663d0000000070987f3f0000003f9004c4417e8c4ebe0ad723bc13fb0f41802d663d0000000070987f3f0000803f9004c4414306babe0ad723bc0fdc0f414068d33c000000002dea7fbf000000005366c4414306babecdcc4c3e0fdc0f414068d33c000000002dea7fbf0000003f5366c4411628babecdcc4c3e020510414068d3bc000000002dea7f3f0000003f5366c4411628babe0ad723bc020510414068d3bc000000002dea7f3f0000803f5366c44180a406bf0ad723bc00b00f41a02ed83d00000000dc917ebf00000000bccbc44180a406bfcdcc4c3e00b00f41a02ed83d00000000dc917ebf0000003fbccbc441aee906bfcdcc4c3ebbd80f41a02ed8bd00000000dc917e3f0000003fbccbc441aee906bf0ad723bcbbd80f41a02ed8bd00000000dc917e3f0000803fbccbc441ce7430bf0ad723bc6e4e0f4168a23a3e000000004cb67bbf000000004335c541ce7430bfcdcc4c3e6e4e0f4168a23a3e000000004cb67bbf0000003f4335c54140ec30bfcdcc4c3eb4760f4168a23abe000000004cb67b3f0000003f4335c54140ec30bf0ad723bcb4760f4168a23abe000000004cb67b3f0000803f4335c541
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0.391029, y: 0.095, z: 7.457205}
+    m_Extent: {x: 1.0821339, y: 0.105000004, z: 1.5440176}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &1759975340
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 540
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 124
+    localAABB:
+      m_Center: {x: -2.1466584, y: 0.095, z: -0.049688578}
+      m_Extent: {x: 4.7466035, y: 0.105000004, z: 1.8986723}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 124
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 3968
+    _typelessdata: 816526400ad723bca887eb3ffccfe83e00000000e60064bf00000000e34d3a4081652640cdcc4c3ea887eb3ffccfe83e00000000e60064bf0000003fe34d3a40011b2640cdcc4c3e80abec3ffccfe8be00000000e600643f0000003fe34d3a40011b26400ad723bc80abec3ffccfe8be00000000e600643f0000803fe34d3a40f2b31c400ad723bc44fbe13f2cf2dc3e00000000c5ef66bf000000006f093f40f2b31c40cdcc4c3e44fbe13f2cf2dc3e00000000c5ef66bf0000003f6f093f403f6d1c40cdcc4c3ede22e33f2cf2dcbe00000000c5ef663f0000003f6f093f403f6d1c400ad723bcde22e33f2cf2dcbe00000000c5ef663f0000803f6f093f403a5a11400ad723bc425dd73fb88fd53e00000000bbaa68bf00000000a7e344403a5a1140cdcc4c3e425dd73fb88fd53e00000000bbaa68bf0000003fa7e34440e3151140cdcc4c3e1287d83fb88fd5be00000000bbaa683f0000003fa7e34440e31511400ad723bc1287d83fb88fd5be00000000bbaa683f0000803fa7e344408e4404400ad723bcf089cb3fdc80d03e00000000a1cf69bf000000009ac94b408e440440cdcc4c3ef089cb3fdc80d03e00000000a1cf69bf0000003f9ac94b40d6010440cdcc4c3e38b5cc3fdc80d0be00000000a1cf693f0000003f9ac94b40d60104400ad723bc38b5cc3fdc80d0be00000000a1cf693f0000803f9ac94b40edfbea3f0ad723bce482be3fd8cdcc3e0000000083a06abf000000001fa85340edfbea3fcdcc4c3ee482be3fd8cdcc3e0000000083a06abf0000003f1fa85340da78ea3fcdcc4c3e36afbf3fd8cdccbe0000000083a06a3f0000003f1fa85340da78ea3f0ad723bc36afbf3fd8cdccbe0000000083a06a3f0000803f1fa853402c3bca3f0ad723bc3657b03ff0f6c93e00000000d63d6bbf00000000fd6b5c402c3bca3fcdcc4c3e3657b03ff0f6c93e00000000d63d6bbf0000003ffd6b5c40eab9c93fcdcc4c3e5284b13ff0f6c9be00000000d63d6b3f0000003ffd6b5c40eab9c93f0ad723bc5284b13ff0f6c9be00000000d63d6b3f0000803ffd6b5c406380a63f0ad723bc061ca13f88b3c73e000000005fb96bbf00000000e70166406380a63fcdcc4c3e061ca13f88b3c73e000000005fb96bbf0000003fe70166409400a63fcdcc4c3ec049a23f88b3c7be000000005fb96b3f0000003fe70166409400a63f0ad723bcc049a23f88b3c7be000000005fb96b3f0000803fe7016640c40a803f0ad723bc50e9903f74d7c53e00000000a71d6cbf000000008f567040c40a803fcdcc4c3e50e9903f74d7c53e00000000a71d6cbf0000003f8f5670404c187f3fcdcc4c3e8a17923f74d7c5be00000000a71d6c3f0000003f8f5670404c187f3f0ad723bc8a17923f74d7c5be00000000a71d6c3f0000803f8f56704067392e3f0ad723bc64b17f3fec45c43e000000005e716cbf000000009c567b4067392e3fcdcc4c3e64b17f3fec45c43e000000005e716cbf0000003f9c567b402c3e2d3fcdcc4c3e5807813fec45c4be000000005e716c3f0000003f9c567b402c3e2d3f0ad723bc5807813fec45c4be000000005e716c3f0000803f9c567b40d4e9af3e0ad723bc3f095c3f98ebc23e00000000f6b86cbf000000005b778340d4e9af3ecdcc4c3e3f095c3f98ebc23e00000000f6b86cbf0000003f5b778340d6f6ad3ecdcc4c3e41675e3f98ebc2be00000000f6b86c3f0000003f5b778340d6f6ad3e0ad723bc41675e3f98ebc2be00000000f6b86c3f0000803f5b778340804a0bbc0ad723bc4b10373fb0bac13e0000000080f76cbf00000000c2858940804a0bbccdcc4c3e4b10373fb0bac13e0000000080f76cbf0000003fc2858940c04849bccdcc4c3eed6e393fb0bac1be0000000080f76c3f0000003fc2858940c04849bc0ad723bced6e393fb0bac1be0000000080f76c3f0000803fc2858940de40bfbe0ad723bc5afd103f38a9c03e00000000342f6dbf00000000d2cc8f40de40bfbecdcc4c3e5afd103f38a9c03e00000000342f6dbf0000003fd2cc8f40142ec1becdcc4c3e8b5c133f38a9c0be00000000342f6d3f0000003fd2cc8f40142ec1be0ad723bc8b5c133f38a9c0be00000000342f6d3f0000803fd2cc8f40add73fbf0ad723bc2a0fd43e98afbf3e00000000c0616dbf00000000e0429640add73fbfcdcc4c3e2a0fd43e98afbf3e00000000c0616dbf0000003fe042964008cd40bfcdcc4c3e8eced83e98afbfbe00000000c0616d3f0000003fe042964008cd40bf0ad723bc8eced83e98afbfbe00000000c0616d3f0000803fe0429640742291bf0ad723bc0acd843ec4c7be3e000000006c906dbf000000003bde9c40742291bfcdcc4c3e0acd843ec4c7be3e000000006c906dbf0000003f3bde9c408e9c91bfcdcc4c3e5e8d893ec4c7bebe000000006c906d3f0000003f3bde9c408e9c91bf0ad723bc5e8d893ec4c7bebe000000006c906d3f0000803f3bde9c40db2cc3bf0ad723bc308fd23de4ecbd3e0000000040bc6dbf000000003495a340db2cc3bfcdcc4c3e308fd23de4ecbd3e0000000040bc6dbf0000003f3495a34068a6c3bfcdcc4c3e0094e53de4ecbdbe0000000040bc6d3f0000003f3495a34068a6c3bf0ad723bc0094e53de4ecbdbe0000000040bc6d3f0000803f3495a340b8c3f5bf0ad723bce0e55fbdd01abd3e0000000018e66dbf000000001a5eaa40b8c3f5bfcdcc4c3ee0e55fbdd01abd3e0000000018e66dbf0000003f1a5eaa40be3cf6bfcdcc4c3e90d539bdd01abdbe0000000018e66d3f0000003f1a5eaa40be3cf6bf0ad723bc90d539bdd01abdbe0000000018e66d3f0000803f1a5eaa40c84f14c00ad723bc844959beec4dbc3e00000000ba0e6ebf00000000402fb140c84f14c0cdcc4c3e844959beec4dbc3e00000000ba0e6ebf0000003f402fb1400a8c14c0cdcc4c3ed0c34fbeec4dbcbe00000000ba0e6e3f0000003f402fb1400a8c14c00ad723bcd0c34fbeec4dbcbe00000000ba0e6e3f0000803f402fb14076bc2dc00ad723bc30e4bcbeb882bb3e00000000d0366ebf00000000f4feb74076bc2dc0cdcc4c3e30e4bcbeb882bb3e00000000d0366ebf0000003ff4feb74076f82dc0cdcc4c3e8820b8beb882bbbe00000000d0366e3f0000003ff4feb74076f82dc00ad723bc8820b8beb882bbbe00000000d0366e3f0000803ff4feb740280447c00ad723bc7e2506bfc0b5ba3e000000000b5f6ebf0000000088c3be40280447c0cdcc4c3e7e2506bfc0b5ba3e000000000b5f6ebf0000003f88c3be40e83f47c0cdcc4c3e43c303bfc0b5babe000000000b5f6e3f0000003f88c3be40e83f47c00ad723bc43c303bfc0b5babe000000000b5f6e3f0000803f88c3be401e0360c00ad723bc8f342dbf84e3b93e000000001a886ebf000000004c73c5401e0360c0cdcc4c3e8f342dbf84e3b93e000000001a886ebf0000003f4c73c5409a3e60c0cdcc4c3eebd12abf84e3b9be000000001a886e3f0000003f4c73c5409a3e60c00ad723bcebd12abf84e3b9be000000001a886e3f0000803f4c73c540a89578c00ad723bc546753bf1008b93e00000000bdb26ebf000000008e04cc40a89578c0cdcc4c3e546753bf1008b93e00000000bdb26ebf0000003f8e04cc40ded078c0cdcc4c3e420451bf1008b9be00000000bdb26e3f0000003f8e04cc40ded078c00ad723bc420451bf1008b9be00000000bdb26e3f0000803f8e04cc40104c88c00ad723bced8578bfe81eb83e00000000d0df6ebf00000000a06dd240104c88c0cdcc4c3eed8578bfe81eb83e00000000d0df6ebf0000003fa06dd240856988c0cdcc4c3e682276bfe81eb8be00000000d0df6e3f0000003fa06dd240856988c00ad723bc682276bfe81eb8be00000000d0df6e3f0000803fa06dd24081f393c00ad723bc4a2c8ebf6c22b73e000000004f106fbf00000000d4a4d84081f393c0cdcc4c3e4a2c8ebf6c22b73e000000004f106fbf0000003fd4a4d840ce1094c0cdcc4c3e4afa8cbf6c22b7be000000004f106f3f0000003fd4a4d840ce1094c00ad723bc4afa8cbf6c22b7be000000004f106f3f0000803fd4a4d840742f9fc00ad723bce4539fbf8c0bb63e0000000088456fbf0000000076a0de40742f9fc0cdcc4c3ee4539fbf8c0bb63e0000000088456fbf0000003f76a0de40954c9fc0cdcc4c3ea0219ebf8c0bb6be0000000088456f3f0000003f76a0de40954c9fc00ad723bca0219ebf8c0bb6be0000000088456f3f0000803f76a0de405aeea9c00ad723bc259eafbf00d1b43e0000000020816fbf00000000de56e4405aeea9c0cdcc4c3e259eafbf00d1b43e0000000020816fbf0000003fde56e440480baac0cdcc4c3e946baebf00d1b4be0000000020816f3f0000003fde56e440480baac00ad723bc946baebf00d1b4be0000000020816f3f0000803fde56e440c71eb4c00ad723bcadefbebf0066b33e0000000057c56fbf0000000058bee940c71eb4c0cdcc4c3eadefbebf0066b33e0000000057c56fbf0000003f58bee9407b3bb4c0cdcc4c3ec5bcbdbf0066b3be0000000057c56f3f0000003f58bee9407b3bb4c00ad723bcc5bcbdbf0066b3be0000000057c56f3f0000803f58bee940a1afbdc00ad723bc772dcdbf34b8b13e000000004e1570bf0000000038cdee40a1afbdc0cdcc4c3e772dcdbf34b8b13e000000004e1570bf0000003f38cdee4011ccbdc0cdcc4c3e28facbbf34b8b1be000000004e15703f0000003f38cdee4011ccbdc00ad723bc28facbbf34b8b1be000000004e15703f0000803f38cdee403e90c6c00ad723bc1c3ddabf10acaf3e00000000aa7570bf00000000d279f3403e90c6c0cdcc4c3e1c3ddabf10acaf3e00000000aa7570bf0000003fd279f3405aacc6c0cdcc4c3e5309d9bf10acafbe00000000aa75703f0000003fd279f3405aacc6c00ad723bc5309d9bf10acafbe00000000aa75703f0000803fd279f340c6b0cec00ad723bc3605e6bf4416ad3e0000000088ed70bf000000007abaf740c6b0cec0cdcc4c3e3605e6bf4416ad3e0000000088ed70bf0000003f7abaf74078cccec0cdcc4c3ed2d0e4bf4416adbe0000000088ed703f0000003f7abaf74078cccec00ad723bcd2d0e4bf4416adbe0000000088ed703f0000803f7abaf740dd02d6c00ad723bc2c6ef0bfbcada93e00000000838871bf000000008a85fb40dd02d6c0cdcc4c3e2c6ef0bfbcada93e00000000838871bf0000003f8a85fb40031ed6c0cdcc4c3e0239efbfbcada9be000000008388713f0000003f8a85fb40031ed6c00ad723bc0239efbfbcada9be000000008388713f0000803f8a85fb40367bdcc00ad723bce463f9bff4eca43e00000000d95a72bf000000005ad1fe40367bdcc0cdcc4c3ee463f9bff4eca43e00000000d95a72bf0000003f5ad1fe409a95dcc0cdcc4c3eae2df8bff4eca4be00000000d95a723f0000003f5ad1fe409a95dcc00ad723bcae2df8bff4eca4be00000000d95a723f0000803f5ad1fe40
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -2.1466584, y: 0.095, z: -0.049688578}
+    m_Extent: {x: 4.7466035, y: 0.105000004, z: 1.8986723}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!43 &2083558346
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 540
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 124
+    localAABB:
+      m_Center: {x: -4.830466, y: 0.095, z: 4.7727394}
+      m_Extent: {x: 1.138257, y: 0.105000004, z: 1.7378027}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 01000000040004000500010002000100050005000600020003000200060006000700030005000400080008000900050006000500090009000a000600070006000a000a000b000700090008000c000c000d0009000a0009000d000d000e000a000b000a000e000e000f000b000d000c001000100011000d000e000d001100110012000e000f000e001200120013000f0011001000140014001500110012001100150015001600120013001200160016001700130015001400180018001900150016001500190019001a001600170016001a001a001b001700190018001c001c001d0019001a0019001d001d001e001a001b001a001e001e001f001b001d001c002000200021001d001e001d002100210022001e001f001e002200220023001f0021002000240024002500210022002100250025002600220023002200260026002700230025002400280028002900250026002500290029002a002600270026002a002a002b002700290028002c002c002d0029002a0029002d002d002e002a002b002a002e002e002f002b002d002c003000300031002d002e002d003100310032002e002f002e003200320033002f0031003000340034003500310032003100350035003600320033003200360036003700330035003400380038003900350036003500390039003a003600370036003a003a003b003700390038003c003c003d0039003a0039003d003d003e003a003b003a003e003e003f003b003d003c004000400041003d003e003d004100410042003e003f003e004200420043003f0041004000440044004500410042004100450045004600420043004200460046004700430045004400480048004900450046004500490049004a004600470046004a004a004b004700490048004c004c004d0049004a0049004d004d004e004a004b004a004e004e004f004b004d004c005000500051004d004e004d005100510052004e004f004e005200520053004f0051005000540054005500510052005100550055005600520053005200560056005700530055005400580058005900550056005500590059005a005600570056005a005a005b005700590058005c005c005d0059005a0059005d005d005e005a005b005a005e005e005f005b005d005c006000600061005d005e005d006100610062005e005f005e006200620063005f0061006000640064006500610062006100650065006600620063006200660066006700630065006400680068006900650066006500690069006a006600670066006a006a006b006700690068006c006c006d0069006a0069006d006d006e006a006b006a006e006e006f006b006d006c007000700071006d006e006d007100710072006e006f006e007200720073006f0071007000740074007500710072007100750075007600720073007200760076007700730075007400780078007900750076007500790079007a007600770076007a007a007b007700
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 124
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 24
+      format: 0
+      dimension: 2
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 3968
+    _typelessdata: 264d6cc00ad723bc702ad0407619583f00000000863f09bf000000005e438241264d6cc0cdcc4c3e702ad0407619583f00000000863f09bf0000003f5e43824173d76cc0cdcc4c3e5c56d040761958bf00000000863f093f0000003f5e43824173d76cc00ad723bc5c56d040761958bf00000000863f093f0000803f5e438241c98a70c00ad723bcd7d4cc4058f1573f00000000997e09bf00000000dec08241c98a70c0cdcc4c3ed7d4cc4058f1573f00000000997e09bf0000003fdec08241fd1471c0cdcc4c3ed700cd4058f157bf00000000997e093f0000003fdec08241fd1471c00ad723bcd700cd4058f157bf00000000997e093f0000803fdec0824155e674c00ad723bce469c940bccb573f000000009bb909bf00000000af41834155e674c0cdcc4c3ee469c940bccb573f000000009bb909bf0000003faf418341717075c0cdcc4c3ef695c940bccb57bf000000009bb9093f0000003faf418341717075c00ad723bcf695c940bccb57bf000000009bb9093f0000803faf418341b05d79c00ad723bc25ebc5404ca8573f000000000cf109bf0000000093c58341b05d79c0cdcc4c3e25ebc5404ca8573f000000000cf109bf0000003f93c58341b5e779c0cdcc4c3e4917c6404ca857bf000000000cf1093f0000003f93c58341b5e779c00ad723bc4917c6404ca857bf000000000cf1093f0000803f93c58341ddee7dc00ad723bc305ac240ac86573f0000000091250abf000000004c4c8441ddee7dc0cdcc4c3e305ac240ac86573f0000000091250abf0000003f4c4c8441cd787ec0cdcc4c3e6686c240ac8657bf0000000091250a3f0000003f4c4c8441cd787ec00ad723bc6686c240ac8657bf0000000091250a3f0000803f4c4c8441e04b81c00ad723bc97b8be40a666573f000000007d570abf000000009bd58441e04b81c0cdcc4c3e97b8be40a666573f000000007d570abf0000003f9bd58441cd9081c0cdcc4c3edce4be40a66657bf000000007d570a3f0000003f9bd58441cd9081c00ad723bcdce4be40a66657bf000000007d570a3f0000803f9bd5844129ab83c00ad723bcf307bb40e647573f000000004f870abf000000004361854129ab83c0cdcc4c3ef307bb40e647573f000000004f870abf0000003f436185410cf083c0cdcc4c3e4734bb40e64757bf000000004f870a3f0000003f436185410cf083c00ad723bc4734bb40e64757bf000000004f870a3f0000803f436185413b1486c00ad723bcdb49b7404c2a573f0000000044b50abf0000000006ef85413b1486c0cdcc4c3edb49b7404c2a573f0000000044b50abf0000003f06ef8541155986c0cdcc4c3e3e76b7404c2a57bf0000000044b50a3f0000003f06ef8541155986c00ad723bc3e76b7404c2a57bf0000000044b50a3f0000803f06ef8541168688c00ad723bcea7fb340900d573f00000000cee10abf00000000a47e8641168688c0cdcc4c3eea7fb340900d573f00000000cee10abf0000003fa47e8641e7ca88c0cdcc4c3e5cacb340900d57bf00000000cee10a3f0000003fa47e8641e7ca88c00ad723bc5cacb340900d57bf00000000cee10a3f0000803fa47e8641a4ff8ac00ad723bcb8abaf4092f1563f00000000200d0bbf00000000e10f8741a4ff8ac0cdcc4c3eb8abaf4092f1563f00000000200d0bbf0000003fe10f87416c448bc0cdcc4c3e37d8af4092f156bf00000000200d0b3f0000003fe10f87416c448bc00ad723bc37d8af4092f156bf00000000200d0b3f0000803fe10f8741e37f8dc00ad723bcddceab4026d6563f000000007a370bbf000000007fa28741e37f8dc0cdcc4c3eddceab4026d6563f000000007a370bbf0000003f7fa28741a2c48dc0cdcc4c3e69fbab4026d656bf000000007a370b3f0000003f7fa28741a2c48dc00ad723bc69fbab4026d656bf000000007a370b3f0000803f7fa28741c80590c00ad723bcfaeaa74026bb563f000000001e610bbf000000003e368841c80590c0cdcc4c3efaeaa74026bb563f000000001e610bbf0000003f3e3688417f4a90c0cdcc4c3e9417a84026bb56bf000000001e610b3f0000003f3e3688417f4a90c00ad723bc9417a84026bb56bf000000001e610b3f0000803f3e368841459092c00ad723bca601a4406ca0563f000000003e8a0bbf00000000e1ca8841459092c0cdcc4c3ea601a4406ca0563f000000003e8a0bbf0000003fe1ca8841f3d492c0cdcc4c3e4e2ea4406ca056bf000000003e8a0b3f0000003fe1ca8841f3d492c00ad723bc4e2ea4406ca056bf000000003e8a0b3f0000803fe1ca88414e1e95c00ad723bc7d14a040d885563f0000000016b30bbf000000002a6089414e1e95c0cdcc4c3e7d14a040d885563f0000000016b30bbf0000003f2a608941f46295c0cdcc4c3e3141a040d88556bf0000000016b30b3f0000003f2a608941f46295c00ad723bc3141a040d88556bf0000000016b30b3f0000803f2a608941dbae97c00ad723bc1a259c404a6b563f00000000d4db0bbf00000000dbf58941dbae97c0cdcc4c3e1a259c404a6b563f00000000d4db0bbf0000003fdbf5894178f397c0cdcc4c3edb519c404a6b56bf00000000d4db0b3f0000003fdbf5894178f397c00ad723bcdb519c404a6b56bf00000000d4db0b3f0000803fdbf58941df409ac00ad723bc1e359840a650563f00000000a4040cbf00000000b58b8a41df409ac0cdcc4c3e1e359840a650563f00000000a4040cbf0000003fb58b8a4174859ac0cdcc4c3eec619840a65056bf00000000a4040c3f0000003fb58b8a4174859ac00ad723bcec619840a65056bf00000000a4040c3f0000803fb58b8a4150d39cc00ad723bc1e469440c235563f00000000c72d0cbf000000007b218b4150d39cc0cdcc4c3e1e469440c235563f00000000c72d0cbf0000003f7b218b41dc179dc0cdcc4c3ef9729440c23556bf00000000c72d0c3f0000003f7b218b41dc179dc00ad723bcf9729440c23556bf00000000c72d0c3f0000803f7b218b4120659fc00ad723bcba5990407e1a563f0000000069570cbf00000000eeb68b4120659fc0cdcc4c3eba5990407e1a563f0000000069570cbf0000003feeb68b41a3a99fc0cdcc4c3ea28690407e1a56bf0000000069570c3f0000003feeb68b41a3a99fc00ad723bca28690407e1a56bf0000000069570c3f0000803feeb68b414af5a1c00ad723bc8b718c40b0fe553f00000000c4810cbf00000000d04b8c414af5a1c0cdcc4c3e8b718c40b0fe553f00000000c4810cbf0000003fd04b8c41c439a2c0cdcc4c3e819e8c40b0fe55bf00000000c4810c3f0000003fd04b8c41c439a2c00ad723bc819e8c40b0fe55bf00000000c4810c3f0000803fd04b8c41bb82a4c00ad723bc2d8f88403ee2553f000000000dad0cbf00000000e4df8c41bb82a4c0cdcc4c3e2d8f88403ee2553f000000000dad0cbf0000003fe4df8c412cc7a4c0cdcc4c3e31bc88403ee255bf000000000dad0c3f0000003fe4df8c412cc7a4c00ad723bc31bc88403ee255bf000000000dad0c3f0000803fe4df8c416e0ca7c00ad723bc3cb4844000c5553f000000007bd90cbf00000000eb728d416e0ca7c0cdcc4c3e3cb4844000c5553f000000007bd90cbf0000003feb728d41d650a7c0cdcc4c3e4ee1844000c555bf000000007bd90c3f0000003feb728d41d650a7c00ad723bc4ee1844000c555bf000000007bd90c3f0000803feb728d415991a9c00ad723bc54e28040c8a6553f000000004e070dbf00000000a6048e415991a9c0cdcc4c3e54e28040c8a6553f000000004e070dbf0000003fa6048e41b8d5a9c0cdcc4c3e750f8140c8a655bf000000004e070d3f0000003fa6048e41b8d5a9c00ad723bc750f8140c8a655bf000000004e070d3f0000803fa6048e417010acc00ad723bc17367a406087553f00000000d6360dbf00000000d8948e417010acc0cdcc4c3e17367a406087553f00000000d6360dbf0000003fd8948e41c554acc0cdcc4c3e77907a40608755bf00000000d6360d3f0000003fd8948e41c554acc00ad723bc77907a40608755bf00000000d6360d3f0000803fd8948e41ab88aec00ad723bcf7bf72409866553f000000005f680dbf0000000044238f41ab88aec0cdcc4c3ef7bf72409866553f000000005f680dbf0000003f44238f41f5ccaec0cdcc4c3e771a7340986655bf000000005f680d3f0000003f44238f41f5ccaec00ad723bc771a7340986655bf000000005f680d3f0000803f44238f4100f9b0c00ad723bc83656b403644553f000000002f9c0dbf00000000a9af8f4100f9b0c0cdcc4c3e83656b403644553f000000002f9c0dbf0000003fa9af8f413f3db1c0cdcc4c3e24c06b40364455bf000000002f9c0d3f0000003fa9af8f413f3db1c00ad723bc24c06b40364455bf000000002f9c0d3f0000803fa9af8f416960b3c00ad723bcdc296440fc1f553f00000000b4d20dbf00000000cc3990416960b3c0cdcc4c3edc296440fc1f553f00000000b4d20dbf0000003fcc3990419ca4b3c0cdcc4c3ea1846440fc1f55bf00000000b4d20d3f0000003fcc3990419ca4b3c00ad723bca1846440fc1f55bf00000000b4d20d3f0000803fcc399041debdb5c00ad723bc35105d408ef9543f00000000600c0ebf000000006cc19041debdb5c0cdcc4c3e35105d408ef9543f00000000600c0ebf0000003f6cc190410502b6c0cdcc4c3e1e6b5d408ef954bf00000000600c0e3f0000003f6cc190410502b6c00ad723bc1e6b5d408ef954bf00000000600c0e3f0000803f6cc190415a10b8c00ad723bcb51b5640a0d0543f00000000ab490ebf000000004d4691415a10b8c0cdcc4c3eb51b5640a0d0543f00000000ab490ebf0000003f4d4691417454b8c0cdcc4c3ec6765640a0d054bf00000000ab490e3f0000003f4d4691417454b8c00ad723bcc6765640a0d054bf00000000ab490e3f0000803f4d469141d956bac00ad723bc804f4f40caa4543f00000000288b0ebf0000000030c89141d956bac0cdcc4c3e804f4f40caa4543f00000000288b0ebf0000003f30c89141e59abac0cdcc4c3ebbaa4f40caa454bf00000000288b0e3f0000003f30c89141e59abac00ad723bcbbaa4f40caa454bf00000000288b0e3f0000803f30c891415990bcc00ad723bcb1ae48408075543f0000000099d10ebf00000000d84692415990bcc0cdcc4c3eb1ae48408075543f0000000099d10ebf0000003fd846924156d4bcc0cdcc4c3e180a4940807554bf0000000099d10e3f0000003fd846924156d4bcc00ad723bc180a4940807554bf0000000099d10e3f0000803fd8469241dbbbbec00ad723bc663c42403642543f00000000c91d0fbf0000000005c29241dbbbbec0cdcc4c3e663c42403642543f00000000c91d0fbf0000003f05c29241c7ffbec0cdcc4c3efe974240364254bf00000000c91d0f3f0000003f05c29241c7ffbec00ad723bcfe974240364254bf00000000c91d0f3f0000803f05c29241
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -4.830466, y: 0.095, z: 4.7727394}
+    m_Extent: {x: 1.138257, y: 0.105000004, z: 1.7378027}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    offset: 0
+    size: 0
+    path: 
+--- !u!108 &2138677392 stripped
+Light:
+  m_CorrespondingSourceObject: {fileID: 8662640338840425039, guid: c53bf4124de6242c988d867025a62152,
+    type: 3}
+  m_PrefabInstance: {fileID: 8662640338125730527}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1702683004382276263
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1702683005025460132, guid: 60c63d1905f7546e0bfda04fa769570c,
+        type: 3}
+      propertyPath: m_Name
+      value: Post-process Volume
+      objectReference: {fileID: 0}
+    - target: {fileID: 1702683005025460129, guid: 60c63d1905f7546e0bfda04fa769570c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1702683005025460129, guid: 60c63d1905f7546e0bfda04fa769570c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1702683005025460129, guid: 60c63d1905f7546e0bfda04fa769570c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1702683005025460129, guid: 60c63d1905f7546e0bfda04fa769570c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1702683005025460129, guid: 60c63d1905f7546e0bfda04fa769570c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1702683005025460129, guid: 60c63d1905f7546e0bfda04fa769570c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1702683005025460129, guid: 60c63d1905f7546e0bfda04fa769570c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1702683005025460129, guid: 60c63d1905f7546e0bfda04fa769570c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1702683005025460129, guid: 60c63d1905f7546e0bfda04fa769570c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1702683005025460129, guid: 60c63d1905f7546e0bfda04fa769570c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1702683005025460129, guid: 60c63d1905f7546e0bfda04fa769570c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 60c63d1905f7546e0bfda04fa769570c, type: 3}
+--- !u!1001 &3317651709798981238
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7708220628765859792, guid: a15547f4c5a2f4366b4a48fa06b04603,
+        type: 3}
+      propertyPath: m_Name
+      value: StationaryCamera
+      objectReference: {fileID: 0}
+    - target: {fileID: 6400925206651555409, guid: a15547f4c5a2f4366b4a48fa06b04603,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 6400925206651555409, guid: a15547f4c5a2f4366b4a48fa06b04603,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 9.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 6400925206651555409, guid: a15547f4c5a2f4366b4a48fa06b04603,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 6400925206651555409, guid: a15547f4c5a2f4366b4a48fa06b04603,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.6956676
+      objectReference: {fileID: 0}
+    - target: {fileID: 6400925206651555409, guid: a15547f4c5a2f4366b4a48fa06b04603,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.12667513
+      objectReference: {fileID: 0}
+    - target: {fileID: 6400925206651555409, guid: a15547f4c5a2f4366b4a48fa06b04603,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.12667513
+      objectReference: {fileID: 0}
+    - target: {fileID: 6400925206651555409, guid: a15547f4c5a2f4366b4a48fa06b04603,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.6956676
+      objectReference: {fileID: 0}
+    - target: {fileID: 6400925206651555409, guid: a15547f4c5a2f4366b4a48fa06b04603,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6400925206651555409, guid: a15547f4c5a2f4366b4a48fa06b04603,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 6400925206651555409, guid: a15547f4c5a2f4366b4a48fa06b04603,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -20.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 6400925206651555409, guid: a15547f4c5a2f4366b4a48fa06b04603,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a15547f4c5a2f4366b4a48fa06b04603, type: 3}
+--- !u!1001 &3891773255740532986
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3891773256012222687, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Name
+      value: Track
+      objectReference: {fileID: 0}
+    - target: {fileID: 3891773256012222674, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3891773256012222674, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3891773256012222674, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3891773256012222674, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3891773256012222674, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3891773256012222674, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3891773256012222674, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3891773256012222674, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3891773256012222674, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3891773256012222674, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3891773256012222674, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5843558909617171145, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1249292391}
+    - target: {fileID: 8200926219049428831, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1249292391}
+    - target: {fileID: 725300005981539451, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1388365132}
+    - target: {fileID: 610383685248088616, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1388365132}
+    - target: {fileID: 6193557901001714321, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 676533774}
+    - target: {fileID: 823564075855506725, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 676533774}
+    - target: {fileID: 6774420398290340508, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 720844179}
+    - target: {fileID: 1113406785571508307, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 720844179}
+    - target: {fileID: 138150599418625156, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 535687184}
+    - target: {fileID: 8365841128604327101, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 535687184}
+    - target: {fileID: 7613343717269818041, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 255452631}
+    - target: {fileID: 7861871626331956209, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 255452631}
+    - target: {fileID: 1159999155559391349, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 311070365}
+    - target: {fileID: 2172131141616597307, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 311070365}
+    - target: {fileID: 1147668725647646011, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1654876770}
+    - target: {fileID: 2234488884942058068, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1654876770}
+    - target: {fileID: 3974249534275778220, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1261773098}
+    - target: {fileID: 2541754902153153784, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1261773098}
+    - target: {fileID: 1341076736484038722, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1242041360}
+    - target: {fileID: 2155047867887703775, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1242041360}
+    - target: {fileID: 8078728387451789292, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 149870122}
+    - target: {fileID: 6875260830253278821, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 149870122}
+    - target: {fileID: 8203529996925538436, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1155560283}
+    - target: {fileID: 330889365549815489, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1155560283}
+    - target: {fileID: 8839251501743093904, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1759975340}
+    - target: {fileID: 1592775525040503603, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1759975340}
+    - target: {fileID: 3281957005113958647, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 594260057}
+    - target: {fileID: 9080884017815331388, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 594260057}
+    - target: {fileID: 5440205151572703805, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 17559291}
+    - target: {fileID: 2553001960905029883, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 17559291}
+    - target: {fileID: 6553811902379151256, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1570402823}
+    - target: {fileID: 1911763694175934258, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1570402823}
+    - target: {fileID: 1147760582386782182, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 2083558346}
+    - target: {fileID: 9198476181273896357, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 2083558346}
+    - target: {fileID: 1351314602894731400, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 540795372}
+    - target: {fileID: 8355555683000472178, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 540795372}
+    - target: {fileID: 6929161371589231190, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1522571220}
+    - target: {fileID: 8023511557899472743, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1522571220}
+    - target: {fileID: 4495932151924466462, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1639774144}
+    - target: {fileID: 5712102614165309066, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1639774144}
+    - target: {fileID: 1317884817459096138, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 661021024}
+    - target: {fileID: 3024566098995238421, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 661021024}
+    - target: {fileID: 3053068777966074930, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1068218713}
+    - target: {fileID: 1806660049038662567, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1068218713}
+    - target: {fileID: 7269681337161398658, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 7534102}
+    - target: {fileID: 3785824200617683739, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 7534102}
+    - target: {fileID: 6891851964805091255, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1062378135}
+    - target: {fileID: 7644139431957401998, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1062378135}
+    - target: {fileID: 2490257402231668751, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 686140020}
+    - target: {fileID: 2630971147054972944, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 686140020}
+    - target: {fileID: 5506511592745782056, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1452596140}
+    - target: {fileID: 2282447443778240258, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1452596140}
+    - target: {fileID: 101338460777817926, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 114129735}
+    - target: {fileID: 6050064279556275401, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 114129735}
+    - target: {fileID: 2308146560734473321, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 14025792}
+    - target: {fileID: 4888247883264171811, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 14025792}
+    - target: {fileID: 6885944863847263525, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 736362454}
+    - target: {fileID: 5326509325709955112, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 736362454}
+    - target: {fileID: 8712080940064437814, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1547881846}
+    - target: {fileID: 6694546459689352699, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1547881846}
+    - target: {fileID: 7018011985409435099, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1680872731}
+    - target: {fileID: 5639671121212161015, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1680872731}
+    - target: {fileID: 1620374192948491248, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1615408649}
+    - target: {fileID: 8999466145481894111, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1615408649}
+    - target: {fileID: 3147445758788518281, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1658140472}
+    - target: {fileID: 3765886412487075526, guid: f36c1aa58d49149e8be80c3a982875a5,
+        type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 1658140472}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f36c1aa58d49149e8be80c3a982875a5, type: 3}
+--- !u!1001 &4759284450060073953
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4759284448989664001, guid: bc5ee6cf73cd948b383ef9224f240b33,
+        type: 3}
+      propertyPath: m_Name
+      value: Car
+      objectReference: {fileID: 0}
+    - target: {fileID: 4759284448989664000, guid: bc5ee6cf73cd948b383ef9224f240b33,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 4759284448989664000, guid: bc5ee6cf73cd948b383ef9224f240b33,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4759284448989664000, guid: bc5ee6cf73cd948b383ef9224f240b33,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4759284448989664000, guid: bc5ee6cf73cd948b383ef9224f240b33,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4759284448989664000, guid: bc5ee6cf73cd948b383ef9224f240b33,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.82514745
+      objectReference: {fileID: 0}
+    - target: {fileID: 4759284448989664000, guid: bc5ee6cf73cd948b383ef9224f240b33,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4759284448989664000, guid: bc5ee6cf73cd948b383ef9224f240b33,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.56491745
+      objectReference: {fileID: 0}
+    - target: {fileID: 4759284448989664000, guid: bc5ee6cf73cd948b383ef9224f240b33,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4759284448989664000, guid: bc5ee6cf73cd948b383ef9224f240b33,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4759284448989664000, guid: bc5ee6cf73cd948b383ef9224f240b33,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -111.20701
+      objectReference: {fileID: 0}
+    - target: {fileID: 4759284448989664000, guid: bc5ee6cf73cd948b383ef9224f240b33,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bc5ee6cf73cd948b383ef9224f240b33, type: 3}
+--- !u!1001 &8269822857138705050
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8269822857894421960, guid: e6d0e87570f414d69bcf566b79758956,
+        type: 3}
+      propertyPath: m_Name
+      value: EventSystem
+      objectReference: {fileID: 0}
+    - target: {fileID: 8269822857894421967, guid: e6d0e87570f414d69bcf566b79758956,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8269822857894421967, guid: e6d0e87570f414d69bcf566b79758956,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8269822857894421967, guid: e6d0e87570f414d69bcf566b79758956,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8269822857894421967, guid: e6d0e87570f414d69bcf566b79758956,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8269822857894421967, guid: e6d0e87570f414d69bcf566b79758956,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8269822857894421967, guid: e6d0e87570f414d69bcf566b79758956,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8269822857894421967, guid: e6d0e87570f414d69bcf566b79758956,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8269822857894421967, guid: e6d0e87570f414d69bcf566b79758956,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 8269822857894421967, guid: e6d0e87570f414d69bcf566b79758956,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8269822857894421967, guid: e6d0e87570f414d69bcf566b79758956,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8269822857894421967, guid: e6d0e87570f414d69bcf566b79758956,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e6d0e87570f414d69bcf566b79758956, type: 3}
+--- !u!1001 &8662640338125730527
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8662640338840425040, guid: c53bf4124de6242c988d867025a62152,
+        type: 3}
+      propertyPath: m_Name
+      value: Directional Light
+      objectReference: {fileID: 0}
+    - target: {fileID: 8662640338840425038, guid: c53bf4124de6242c988d867025a62152,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.24
+      objectReference: {fileID: 0}
+    - target: {fileID: 8662640338840425038, guid: c53bf4124de6242c988d867025a62152,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8662640338840425038, guid: c53bf4124de6242c988d867025a62152,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 8662640338840425038, guid: c53bf4124de6242c988d867025a62152,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7388608
+      objectReference: {fileID: 0}
+    - target: {fileID: 8662640338840425038, guid: c53bf4124de6242c988d867025a62152,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.5997209
+      objectReference: {fileID: 0}
+    - target: {fileID: 8662640338840425038, guid: c53bf4124de6242c988d867025a62152,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.2709314
+      objectReference: {fileID: 0}
+    - target: {fileID: 8662640338840425038, guid: c53bf4124de6242c988d867025a62152,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.14496852
+      objectReference: {fileID: 0}
+    - target: {fileID: 8662640338840425038, guid: c53bf4124de6242c988d867025a62152,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8662640338840425038, guid: c53bf4124de6242c988d867025a62152,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 32.629
+      objectReference: {fileID: 0}
+    - target: {fileID: 8662640338840425038, guid: c53bf4124de6242c988d867025a62152,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 195.59999
+      objectReference: {fileID: 0}
+    - target: {fileID: 8662640338840425038, guid: c53bf4124de6242c988d867025a62152,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 106.461006
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c53bf4124de6242c988d867025a62152, type: 3}


### PR DESCRIPTION
Changing every GameObject in to a prefab helps keep changes manageable by git. Change to a single does not cause huge changes in the scene, but only changes the prefab file instead.

Top-down camera is set as default camera and can be used instead of the car-following camera.