### PR TITLE
Parametrize amount of track segments

### DIFF
--- a/Assets/Scripts/RaceController.cs
+++ b/Assets/Scripts/RaceController.cs
@@ -15,8 +15,25 @@ public class RaceController : MonoBehaviour
     private RaceParameters raceParameters;
     private State state;
 
+    public int GetNumSegments() {
+        return raceParameters.numSegments;
+    }
+
     public IEnumerable<CarInfo> GetCars() {
         return cars.Values.Select(car => car.CarInfo);
+    }
+
+    public int GetTrackSegment(string car) {
+        return cars[car].trackSegment;
+    }
+
+    public float TrackDistanceAtSegment(int segment) {
+        float spacing = track.Length / (float)raceParameters.numSegments;
+        return (segment * spacing) % track.Length;
+    }
+
+    public int NextSegment(int segment) {
+        return (segment + 1) % raceParameters.numSegments;
     }
 
     private void OnEnable()
@@ -98,16 +115,10 @@ public class RaceController : MonoBehaviour
         state.CarHitTrigger(car, 0);
     }
 
-    public void TrackSegmentTrigger1(GameObject car)
+    public void TrackSegmentTrigger(GameObject car, int segment)
     {
-        state.CarHitTrigger(car, 1);
+        state.CarHitTrigger(car, segment);
     }
-
-    public void TrackSegmentTrigger2(GameObject car)
-    {
-        state.CarHitTrigger(car, 2);
-    }
-
 
     public class Playback: State
     {
@@ -365,10 +376,13 @@ public class RaceController : MonoBehaviour
             Subscribe<CarConnected>(e => {
                 try {
                     var car = c.addCarOnTrack(e);
+
                     var controllers = FindObjectsOfType<CarController>();
                     float totalLength = c.track.Length;
-                    float spacing = totalLength / (float)10; // always 10 segments                                        
-                    var curveSample = c.track.GetSampleAtDistance(c.track.Length - (i * spacing));
+                    float spacing = c.raceParameters.numSegmentsBetweenCars * totalLength / (float)c.raceParameters.numSegments;
+
+                    var curveSample = c.track.GetSampleAtDistance(
+                            c.track.Length - ((i * spacing) % c.track.Length));
                     car.transform.position = curveSample.location + 0.1f * Vector3.up;
                     car.transform.rotation = curveSample.Rotation;
                     car.GetComponent<Rigidbody>().velocity = Vector3.zero;
@@ -419,7 +433,7 @@ public class RaceController : MonoBehaviour
         override public void CarHitTrigger(GameObject car, int segment)
         {
             var totalTime = GameEvent.TimeDiff(System.DateTime.Now, sessionStartTime);
-            bool updateStandings = c.cars[car.name].TrackSegmentStarted(segment, totalTime);
+            bool updateStandings = c.cars[car.name].TrackSegmentStarted(segment, totalTime, c.raceParameters.numSegments);
             if (updateStandings)
             {
                 EventBus.Publish(CurrentStandings());
@@ -619,15 +633,16 @@ public class RaceController : MonoBehaviour
             EventBus.Publish(new CarFinished(CarInfo));
         }
 
-        internal bool TrackSegmentStarted(int segment, float totalTime)
+        internal bool TrackSegmentStarted(int segment, float totalTime, int numSegments)
         {
-            if (segment == (this.trackSegment + 1) % 3) {
-                this.trackSegment = segment;
+            int currentSegment = this.trackSegment;
+            this.trackSegment = segment;
+            if (segment == (currentSegment + 1) % numSegments) {
                 if (segment == 0)
-                {                    
+                {
                     NewLapTime(totalTime);
-                    return true;
                 }
+                return true;
             }
             return false;
         }

--- a/Assets/Scripts/RaceParameters.cs
+++ b/Assets/Scripts/RaceParameters.cs
@@ -6,6 +6,8 @@ using System.IO;
 public class RaceParameters : GameEvent
 {
     public int lapCount = 5;
+    public int numSegments = 3;
+    public int numSegmentsBetweenCars = 1;
     public int autoStartQualifyingSeconds = 30;
     public int qualifyingDurationSeconds = 30;
     public int autoStartRaceSeconds = 10;

--- a/Assets/Scripts/TrackController.cs
+++ b/Assets/Scripts/TrackController.cs
@@ -14,8 +14,7 @@ public class TrackController : MonoBehaviour
 
     private Transform finishLine;
     private Transform finishLineTrigger;
-    private Transform firstTrigger;
-    private Transform secondTrigger;
+    private Transform[] lineTriggers;
 
 #if UNITY_EDITOR
     [Header("EDITOR ONLY")]
@@ -128,10 +127,17 @@ public class TrackController : MonoBehaviour
 
     void UpdateTriggers()
     {
+        int numSegments = RaceParameters.readRaceParameters().numSegments;
+        Array.Resize(ref lineTriggers, numSegments);
         var raceController = FindObjectOfType<RaceController>();
         UpdateTrigger(ref finishLineTrigger, 0, raceController.FinishLineTrigger);
-        UpdateTrigger(ref firstTrigger, 0.33f, raceController.TrackSegmentTrigger1);
-        UpdateTrigger(ref secondTrigger, 0.67f, raceController.TrackSegmentTrigger2);
+        for (int i = 0; i < numSegments; ++i) {
+            int segment = i;
+            UpdateTrigger(
+                    ref lineTriggers[i],
+                    (i+1)/(float)(numSegments+1),
+                    car => raceController.TrackSegmentTrigger(car, segment));
+        }
     }
 
     private void UpdateTrigger(ref Transform trigger, float distance, TriggerEventSourceEventHandler eventHandler)


### PR DESCRIPTION
Set amount of track triggers (excluding finish line) and space between spawned cars in the config file.

E.g. finish line + 10 triggers and 2 segments between each spawned car:
```
{
    "lapCount": 5,
    "numSegments": 10,
    "numSegmentsBetweenCars": 2,
    "mode": "development",
    "visibility": "public"
}
```