### PR TITLE
Minor optimizations

### DIFF
--- a/Assets/Scripts/SpectatorSocket.cs
+++ b/Assets/Scripts/SpectatorSocket.cs
@@ -48,8 +48,8 @@ public class SpectatorSocket : MonoBehaviour
                 if (raceParams.raceLogFile != null) {
                     Debug.Log("Writing race log to " + raceParams.raceLogFile);
                     var stream = new BinaryWriter(File.Open(raceParams.raceLogFile, FileMode.Create));
-                
-                    Spectate(b => {stream.Write(b); stream.Flush(); }, () => stream.Close(), new CarInfo[] { });
+
+                    Spectate(b => { stream.Write(b); }, () => stream.Close(), new CarInfo[] { });
                 }
                 EventBus.Subscribe<CarAdded>(this, e => {
                     CarInfo car = ((CarAdded)e).car;


### PR DESCRIPTION
- Compute return to track position for crashed car from its current and next track segment.
- Skip explicit flush of spectator socket. Seems to fix a blocking issue during reading, but I did not do a deeper investigation why it works.