### PR TITLE
Set python path environment variable

### DIFF
--- a/Assets/Scripts/PreBuildProcessing.cs
+++ b/Assets/Scripts/PreBuildProcessing.cs
@@ -1,0 +1,16 @@
+﻿#if UNITY_EDITOR
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEngine;
+
+public class PreBuildProcessing : IPreprocessBuildWithReport
+{
+    public int callbackOrder => 1;
+    public void OnPreprocessBuild(BuildReport report)
+    {
+        Debug.Log("Setting Python path...");
+        System.Environment.SetEnvironmentVariable("EMSDK_PYTHON", "/usr/local/bin/python");
+    }
+}
+#endif

--- a/Assets/Scripts/PreBuildProcessing.cs.meta
+++ b/Assets/Scripts/PreBuildProcessing.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9618a8947f1e144a0b6ec07ce02f3ed2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
On MacOS Monterey, (M1 Max Macbook Pro) Python is no longer found by default. Seems that we need to provide an environment variable to make this work. Works on my machine!